### PR TITLE
rename SECRET_KEY to API_KEY to keep it in line with vcap_services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ DOCKER_IMAGE_TAG = ${CF_SPACE}
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 DOCKER_TTY ?= $(if ${JENKINS_HOME},,t)
 
-VCAP_SERVICES ?= '{"user-provided":[{"credentials":{"secret_key":"my-secret-key"},"label":"user-provided","name":"notify-template-preview","syslog_drain_url":"","tags":[],"volume_mounts":[]}]}'
+VCAP_SERVICES ?= '{"user-provided":[{"credentials":{"api_host": "some_domain","api_key":"my-secret-key"},"label":"user-provided","name":"notify-template-preview","syslog_drain_url":"","tags":[],"volume_mounts":[]}]}'
 
 PORT ?= 6013
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,13 +10,12 @@ from app import version
 
 def load_config(application):
     vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-
     template_preview_config = next(
         service for service in vcap_services['user-provided']
         if service['name'] == 'notify-template-preview'
     )
 
-    application.config['SECRET_KEY'] = template_preview_config['credentials']['secret_key']
+    application.config['API_KEY'] = template_preview_config['credentials']['api_key']
 
 
 def create_app():
@@ -35,7 +34,7 @@ def create_app():
 
     @auth.verify_token
     def verify_token(token):
-        return token == application.config['SECRET_KEY']
+        return token == application.config['API_KEY']
 
     return application
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,8 @@ def app():
         "user-provided": [
             {
                 "credentials": {
-                    "secret_key": "my-secret-key"
+                    "api_host": "some domain",
+                    "api_key": "my-secret-key"
                 },
                 "label": "user-provided",
                 "name": "notify-template-preview",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,13 +15,14 @@ def revert_config(app):
 
 
 def test_config_is_loaded(app, revert_config):
-    assert app.config['SECRET_KEY'] == 'my-secret-key'
+    assert app.config['API_KEY'] == 'my-secret-key'
 
     os.environ['VCAP_SERVICES'] = json.dumps({
         "user-provided": [
             {
                 "credentials": {
-                    "secret_key": "foo"
+                    "api_host": "some domain",
+                    "api_key": "some secret key"
                 },
                 "label": "user-provided",
                 "name": "notify-template-preview",
@@ -34,4 +35,4 @@ def test_config_is_loaded(app, revert_config):
 
     load_config(app)
 
-    assert app.config['SECRET_KEY'] == 'foo'
+    assert app.config['API_KEY'] == 'some secret key'


### PR DESCRIPTION
the `notify-template-preview` cloudfoundry service has two values - `api_key` and `api_host`.

make sure we're reading from the right thing