### PR TITLE
allow blank letter contact blocks

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -17,7 +17,7 @@ def validate_preview_request(json):
         "description": "schema for parameters allowed when generating a template preview",
         "type": "object",
         "properties": {
-            "letter_contact_block": {"type": "string"},
+            "letter_contact_block": {"type": ["string", "null"]},
             "values": {"type": ["object", "null"]},
             "template": {
                 "type": "object",

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -75,3 +75,14 @@ def test_missing_field_400s(view_letter_template, preview_post_body, missing_ite
     resp = view_letter_template(data=preview_post_body)
 
     assert resp.status_code == 400
+
+
+@pytest.mark.parametrize('blank_item', ['letter_contact_block', 'values'])
+def test_blank_fields_okay(view_letter_template, preview_post_body, blank_item):
+    preview_post_body[blank_item] = None
+
+    with patch('app.preview.LetterPreviewTemplate', __str__=Mock(return_value='foo')) as mock_template:
+        resp = view_letter_template(data=preview_post_body)
+
+    assert resp.status_code == 200
+    assert mock_template.called is True


### PR DESCRIPTION
they actually always worked with utils.LetterPreviewTemplate, but we were blocking them at a jsonschema level

![image](https://cloud.githubusercontent.com/assets/5020841/25143488/8dc89216-2462-11e7-8968-4725fd9b9c60.png)
