### PR TITLE
Allow PNGs to be generated for any page of a letter

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -85,6 +85,9 @@ def view_letter_template(filetype):
     if filetype not in ('pdf', 'png'):
         abort(404)
 
+    if filetype == 'pdf' and request.args.get('page') is not None:
+        abort(400)
+
     json = request.get_json()
     validate_preview_request(json)
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 import jsonschema
-from flask import Blueprint, request, send_file, abort, current_app
+from flask import Blueprint, request, send_file, abort, current_app, jsonify
 from flask_weasyprint import HTML, render_pdf
 from wand.image import Image
 from notifications_utils.template import LetterPreviewTemplate
@@ -52,6 +52,13 @@ def png_from_pdf(pdf_endpoint):
         'filename_or_fp': output,
         'mimetype': 'image/png',
     }
+
+
+@preview_blueprint.route("/preview.json", methods=['POST'])
+@auth.login_required
+def page_count():
+    image = Image(blob=view_letter_template(filetype='pdf').get_data())
+    return jsonify({'count': len(image.sequence)})
 
 
 @preview_blueprint.route("/preview.<filetype>", methods=['POST'])

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -50,6 +50,40 @@ def test_return_headers_match_filetype(view_letter_template, filetype, mimetype)
     assert resp.headers['Content-Type'] == mimetype
 
 
+@pytest.mark.parametrize('sentence_count, page_number, expected_response_code', [
+    (10, 1, 200),
+    (10, 2, 400),
+    (50, 2, 200),
+    (50, 3, 400),
+])
+def test_get_image_by_page(
+    client,
+    auth_header,
+    sentence_count,
+    page_number,
+    expected_response_code
+):
+    response = client.post(
+        url_for('preview_blueprint.view_letter_template', filetype='png', page=page_number),
+        data=json.dumps({
+            'letter_contact_block': '123',
+            'template': {
+                'subject': 'letter subject',
+                'content': (
+                    'All work and no play makes Jack a dull boy. ' * sentence_count
+                ),
+            },
+            'values': {},
+            'dvla_org_id': '001',
+        }),
+        headers={
+            'Content-type': 'application/json',
+            **auth_header
+        }
+    )
+    assert response.status_code == expected_response_code
+
+
 def test_letter_template_constructed_properly(preview_post_body, view_letter_template):
     with patch('app.preview.LetterPreviewTemplate', __str__=Mock(return_value='foo')) as mock_template:
         resp = view_letter_template()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -50,21 +50,23 @@ def test_return_headers_match_filetype(view_letter_template, filetype, mimetype)
     assert resp.headers['Content-Type'] == mimetype
 
 
-@pytest.mark.parametrize('sentence_count, page_number, expected_response_code', [
-    (10, 1, 200),
-    (10, 2, 400),
-    (50, 2, 200),
-    (50, 3, 400),
+@pytest.mark.parametrize('filetype, sentence_count, page_number, expected_response_code', [
+    ('png', 10, 1, 200),
+    ('pdf', 10, 1, 400),
+    ('png', 10, 2, 400),
+    ('png', 50, 2, 200),
+    ('png', 50, 3, 400),
 ])
 def test_get_image_by_page(
     client,
     auth_header,
+    filetype,
     sentence_count,
     page_number,
     expected_response_code
 ):
     response = client.post(
-        url_for('preview_blueprint.view_letter_template', filetype='png', page=page_number),
+        url_for('preview_blueprint.view_letter_template', filetype=filetype, page=page_number),
         data=json.dumps({
             'letter_contact_block': '123',
             'template': {

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -98,3 +98,35 @@ def test_blank_fields_okay(view_letter_template, preview_post_body, blank_item):
 
     assert resp.status_code == 200
     assert mock_template.called is True
+
+
+@pytest.mark.parametrize('sentence_count, expected_pages', [
+    (10, 1),
+    (50, 2),
+])
+def test_page_count(
+    client,
+    auth_header,
+    sentence_count,
+    expected_pages
+):
+    response = client.post(
+        url_for('preview_blueprint.page_count'),
+        data=json.dumps({
+            'letter_contact_block': '123',
+            'template': {
+                'subject': 'letter subject',
+                'content': (
+                    'All work and no play makes Jack a dull boy. ' * sentence_count
+                ),
+            },
+            'values': {},
+            'dvla_org_id': '001',
+        }),
+        headers={
+            'Content-type': 'application/json',
+            **auth_header
+        }
+    )
+    assert response.status_code == 200
+    assert json.loads(response.get_data(as_text=True)) == {'count': expected_pages}


### PR DESCRIPTION
Adds two things:
- an endpoint for the frontend to get the count of pages in a letter
- a query parameter that the frontend can use to specify a page number, when it’s asking for a `preview.png`

Hacking the admin app, it gives us something like this:

***

<img width="659" alt="screen shot 2017-04-19 at 13 09 07" src="https://cloud.githubusercontent.com/assets/355079/25180207/03686aee-2505-11e7-8a12-9d0395351328.png">

***

The idea being that we can show people every page of a letter in the admin app, without having to open the PDF.