### PR TITLE
Install and use correct fonts for letter previews

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN \
 		libcairo2-dev \
 		libmagickwand-dev \
 		ghostscript \
-		imagemagick
+		imagemagick \
+		gsfonts
 
 RUN \
 	echo "Clean up" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ html5lib==1.0b10
 wand==0.4.4
 jsonschema==2.6.0
 
-git+https://github.com/alphagov/notifications-utils.git@15.1.2#egg=notifications-utils==15.1.2
+git+https://github.com/alphagov/notifications-utils.git@15.2.3#egg=notifications-utils==15.2.3
 
 # PaaS requirements
 gunicorn


### PR DESCRIPTION
Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/151

***

See here for why we use this font: https://github.com/alphagov/notifications-utils/pull/107

***

Before | After 
---|---
![image](https://cloud.githubusercontent.com/assets/355079/25242384/49412adc-25f1-11e7-8f3c-4e6828096a3e.png) | ![image](https://cloud.githubusercontent.com/assets/355079/25242368/3f02062c-25f1-11e7-8a4b-2508f0f369cc.png)
