### PR TITLE
Small deploy fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ cf-login: ## Log in to Cloud Foundry
 .PHONY: cf-deploy
 cf-deploy: ## Deploys the app to Cloud Foundry
 	$(if ${CF_SPACE},,$(error Must specify CF_SPACE))
+	cf target -s ${CF_SPACE}
 	@cf app --guid notify-template-preview || exit 1
 	cf rename notify-template-preview notify-template-preview-rollback
 	cf push notify-template-preview -f manifest-${CF_SPACE}.yml --docker-image ${DOCKER_IMAGE_NAME}
@@ -150,6 +151,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release
+	cf target -s ${CF_SPACE}
 	@cf app --guid notify-template-preview-rollback || exit 1
 	@[ $$(cf curl /v2/apps/`cf app --guid notify-template-preview-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because notify-template-preview-rollback is not in a started state" && exit 1)
 	cf delete -f notify-template-preview || true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN \
 
 RUN \
 	echo "Install binary app dependencies" \
+	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libpango1.0-dev \
 		libcairo2-dev \


### PR DESCRIPTION

a problem was observed where update didn't run because the Install Base Packages command was cached, and the Install binary app dependencies command didn't update

but because it's still installing based off the old indexes, it was attempting to grab an old dependency that no longer exists on debian package manager, and only crashing if you had previous cached docker layers