### PR TITLE
Upgrade memory to fix issue with previewing letters

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -5,7 +5,7 @@ services:
   - notify-aws
   - notify-template-preview
 instances: 1
-memory: 512M
+memory: 2G
 env:
   NOTIFY_APP_NAME: notify-template-preview
 


### PR DESCRIPTION
This upgrades the memory on the image so that memory doesn't run low and cause the letter previews to fail. 
