### PR TITLE
Build libcairo by hand

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,11 +25,21 @@ RUN \
 	&& apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		libpango1.0-dev \
-		libcairo2-dev \
 		libmagickwand-dev \
 		ghostscript \
 		imagemagick \
 		gsfonts
+
+RUN \
+	echo "Install newer version of Cairo" \
+	&& curl -O https://www.cairographics.org/releases/cairo-1.14.8.tar.xz \
+	&& tar xf cairo-1.14.8.tar.xz \
+	&& cd cairo-1.14.8 \
+	&& ./configure \
+	&& make \
+	&& make install \
+	&& cd .. \
+	&& rm -r cairo-1.14.8 cairo-1.14.8.tar.xz
 
 RUN \
 	echo "Clean up" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,16 +30,21 @@ RUN \
 		imagemagick \
 		gsfonts
 
+WORKDIR /tmp/
+
 RUN \
-	echo "Install newer version of Cairo" \
-	&& curl -O https://www.cairographics.org/releases/cairo-1.14.8.tar.xz \
-	&& tar xf cairo-1.14.8.tar.xz \
-	&& cd cairo-1.14.8 \
+	echo "Downloading newer version of Cairo" \
+	&& curl https://www.cairographics.org/releases/cairo-1.14.8.tar.xz | tar xvfJ - -C .
+
+WORKDIR /tmp/cairo-1.14.8/
+
+RUN \
+  echo "Installing newer version of Cairo" \
 	&& ./configure \
 	&& make \
-	&& make install \
-	&& cd .. \
-	&& rm -r cairo-1.14.8 cairo-1.14.8.tar.xz
+	&& make install
+
+WORKDIR /
 
 RUN \
 	echo "Clean up" \


### PR DESCRIPTION
The version of libcairo that comes with Debian stable is quite old. It gives some warnings about ‘known rendering problems’, which might be why logos in our image previews look a bit crusty.

This commit adds step to the `Dockerfile` to build a newer version of Cairo from source, rather than use Apt.

N.B. I have not yet found a way to check if our Python apps are using this version, or still using the old one. So, while this does run, consider it a WIP. It doesn’t seem to have changed anything yet.