### PR TITLE
Bump utils to 17.7.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN \
 		Flask-HTTPAuth==3.2.2 \
 		html5lib==1.0b10 \
 		wand==0.4.4 \
-		git+https://github.com/alphagov/notifications-utils.git@17.5.4#egg=notifications-utils==17.5.4 \
+		git+https://github.com/alphagov/notifications-utils.git@17.7.0#egg=notifications-utils==17.7.0 \
 		gunicorn \
 		"awscli>=1.11,<1.12" \
 		"awscli-cwlogs>=1.4,<1.5" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ html5lib==1.0b10
 wand==0.4.4
 jsonschema==2.6.0
 
-git+https://github.com/alphagov/notifications-utils.git@17.5.7#egg=notifications-utils==17.5.7
+git+https://github.com/alphagov/notifications-utils.git@17.7.0#egg=notifications-utils==17.7.0
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
Changes: https://github.com/alphagov/notifications-utils/compare/17.5.7...17.7.0