### PR TITLE
Make it clear that you need Imagemagick version 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ If you haven't installed the app yet follow these steps -
 
 ```shell
 # binary dependencies
-brew install imagemagick ghostscript cairo pango
+brew install imagemagick@6 ghostscript cairo pango
+brew link --force imagemagick@6
 
 mkvirtualenv -p /usr/local/bin/python3 notifications-template-preview
 pip install -r requirements.txt


### PR DESCRIPTION
Libraries that we’re using have not been updated to work with Imagemagick version 7. So the steps to get this app running locally need to be:
- install version 6
- force version 6 to be the one that gets used (which Homebrew doesn’t do by default)