### PR TITLE
bump workers from 5 to 10

### DIFF
--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-gunicorn -w 5 -b 0.0.0.0:$1 wsgi
+gunicorn -w 10 -b 0.0.0.0:$1 wsgi


### PR DESCRIPTION
when we render png previews of a document, we make a request to the
template preview app for every page of the letter - lets make sure
we have enough workers to handle all of these requests concurrently