### PR TITLE
Update utils to 20.0.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN \
 		Flask-HTTPAuth==3.2.2 \
 		html5lib==1.0b10 \
 		wand==0.4.4 \
-		git+https://github.com/alphagov/notifications-utils.git@17.8.1#egg=notifications-utils==17.8.1 \
+		git+https://github.com/alphagov/notifications-utils.git@20.0.0#egg=notifications-utils==20.0.0 \
 		gunicorn \
 		"awscli>=1.11,<1.12" \
 		"awscli-cwlogs>=1.4,<1.5" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ html5lib==1.0b10
 wand==0.4.4
 jsonschema==2.6.0
 
-git+https://github.com/alphagov/notifications-utils.git@17.8.1#egg=notifications-utils==17.8.1
+git+https://github.com/alphagov/notifications-utils.git@20.0.0#egg=notifications-utils==20.0.0
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
Brings in 3 breaking changes:
- two of which are to do with logging (but don’t affect this app)
- one of which is to do with email output

Stuff we care about is:
- [x] https://github.com/alphagov/notifications-utils/pull/212

Full changes:
- https://github.com/alphagov/notifications-utils/compare/17.8.1...20.0.0