### PR TITLE
Bump utils to 20.0.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ RUN \
 		Flask-HTTPAuth==3.2.2 \
 		html5lib==1.0b10 \
 		wand==0.4.4 \
-		git+https://github.com/alphagov/notifications-utils.git@20.0.1#egg=notifications-utils==20.0.1 \
+		git+https://github.com/alphagov/notifications-utils.git@20.0.2#egg=notifications-utils==20.0.2 \
 		gunicorn \
 		"awscli>=1.11,<1.12" \
 		"awscli-cwlogs>=1.4,<1.5" \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ html5lib==1.0b10
 wand==0.4.4
 jsonschema==2.6.0
 
-git+https://github.com/alphagov/notifications-utils.git@20.0.1#egg=notifications-utils==20.0.1
+git+https://github.com/alphagov/notifications-utils.git@20.0.2#egg=notifications-utils==20.0.2
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
Brings in:
- [x] https://github.com/alphagov/notifications-utils/pull/216