### PR TITLE
Small fixes

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -48,8 +48,8 @@ def get_logo_filename(dvla_org_id):
 @preview_blueprint.route("/preview.json", methods=['POST'])
 @auth.login_required
 def page_count():
-    image = Image(blob=view_letter_template(filetype='pdf').get_data())
-    return jsonify({'count': len(image.sequence)})
+    with Image(blob=view_letter_template(filetype='pdf').get_data()) as image:
+        return jsonify({'count': len(image.sequence)})
 
 
 @preview_blueprint.route("/preview.<filetype>", methods=['POST'])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,12 +50,12 @@ RUN \
 RUN \
 	echo "Installing python dependencies" \
 	&& pip install \
-		Flask==0.12.1 \
+		Flask==0.12.2 \
 		Flask-WeasyPrint==0.5 \
-		Flask-HTTPAuth==3.2.2 \
+		Flask-HTTPAuth==3.2.3 \
 		html5lib==1.0b10 \
 		wand==0.4.4 \
-		git+https://github.com/alphagov/notifications-utils.git@23.0.0#egg=notifications-utils==23.0.0 \
+		git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0 \
 		gunicorn \
 		"awscli>=1.11,<1.12" \
 		"awscli-cwlogs>=1.4,<1.5" \


### PR DESCRIPTION
* Images should be used with a `with` context manager.
* the dockerfile should be kept up-to-date with requirements. It won't cause the wrong requirements to be installed, but it will make the install/deploy process longer each time.