### PR TITLE
Fixed `print.pdf` endpoint

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -135,12 +135,11 @@ def print_letter_template():
             for line in pdf_data.read():
                 pdf_data.write(color_mapping(line))
 
-        with BytesIO(pdf_data.result) as attachment:
-            return send_file(
-                attachment,
-                as_attachment=True,
-                attachment_filename='print.pdf'
-            )
+        return send_file(
+            BytesIO(pdf_data.result),
+            as_attachment=True,
+            attachment_filename='print.pdf'
+        )
 
     except Exception as e:
         current_app.logger.error(str(e))

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -201,6 +201,7 @@ def test_print_letter_returns_200(print_letter_template):
 
     assert resp.status_code == 200
     assert resp.headers['Content-Type'] == 'application/pdf'
+    assert len(resp.get_data()) > 0
 
 
 @pytest.mark.parametrize('dvla_org_id, expected_filename', [


### PR DESCRIPTION
## What

`print.pdf` doesn't work when trying to contain the `send_file` within the with statement as `send_file` closes it for you.

- https://github.com/pallets/flask/issues/2468#issuecomment-331321836