### PR TITLE
Add page count to header for print.pdf endpoint

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -45,11 +45,21 @@ def get_logo_filename(dvla_org_id):
         abort(400)
 
 
+def get_page_count(pdf_data):
+    with Image(blob=pdf_data) as image:
+        return len(image.sequence)
+
+
 @preview_blueprint.route("/preview.json", methods=['POST'])
 @auth.login_required
 def page_count():
-    with Image(blob=view_letter_template(filetype='pdf').get_data()) as image:
-        return jsonify({'count': len(image.sequence)})
+    return jsonify(
+        {
+            'count': get_page_count(
+                view_letter_template(filetype='pdf').get_data()
+            )
+        }
+    )
 
 
 @preview_blueprint.route("/preview.<filetype>", methods=['POST'])
@@ -141,8 +151,7 @@ def print_letter_template():
             attachment_filename='print.pdf'
         )
 
-        with Image(blob=pdf_data.result) as image:
-            response.headers['X-pdf-page-count'] = len(image.sequence)
+        response.headers['X-pdf-page-count'] = get_page_count(pdf_data.result)
         return response
 
     except Exception as e:

--- a/app/preview.py
+++ b/app/preview.py
@@ -135,11 +135,15 @@ def print_letter_template():
             for line in pdf_data.read():
                 pdf_data.write(color_mapping(line))
 
-        return send_file(
+        response = send_file(
             BytesIO(pdf_data.result),
             as_attachment=True,
             attachment_filename='print.pdf'
         )
+
+        with Image(blob=pdf_data.result) as image:
+            response.headers['X-pdf-page-count'] = len(image.sequence)
+        return response
 
     except Exception as e:
         current_app.logger.error(str(e))

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -201,6 +201,7 @@ def test_print_letter_returns_200(print_letter_template):
 
     assert resp.status_code == 200
     assert resp.headers['Content-Type'] == 'application/pdf'
+    assert resp.headers['X-pdf-page-count'] == '1'
     assert len(resp.get_data()) > 0
 
 


### PR DESCRIPTION
## What

In order to calculate letter billing we need a page count from the pdf.

## How to review

Using curl we should be able to see the headers generated when calling the print.pdf endpoint

```
curl -v -O \
  -H "Authorization: Token my-secret-key" \
  -H "Content-type: application/json" \
  -d '{
    "template":{
      "subject": "foo",
      "content": "test"
    },
    "values": null,
    "letter_contact_block": "name,\naddress_line_1,\naddress_line_2",
    "dvla_org_id": "001"
  }' \
  http://localhost:6013/print.pdf
```

## Reference

Part of step 5/5 - https://www.pivotaltracker.com/story/show/151511579