### PR TITLE
Added statsd logging to template preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ define run_docker_container
 		-e CI_NAME=${CI_NAME} \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \
+		-e STATSD_ENABLED= \
 		${DOCKER_IMAGE_NAME} \
 		${2}
 endef

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,12 +38,12 @@ def load_config(application):
             if service['name'] == 'hosted-graphite'
         )
 
-        application.config['STATSD_ENABLED'] = 1
-        application.config['STATSD_HOST'] = "localhost"
-        application.config['STATSD_PORT'] = 1000
+        application.config['STATSD_ENABLED'] = True
+        application.config['STATSD_HOST'] = "statsd.hostedgraphite.com"
+        application.config['STATSD_PORT'] = 8125
         application.config['STATSD_PREFIX'] = hosted_graphite_config['credentials']['statsd_prefix']
     else:
-        application.config['STATSD_ENABLED'] = None
+        application.config['STATSD_ENABLED'] = False
 
 
 def create_app():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ import json
 
 from flask import Flask
 from flask_httpauth import HTTPTokenAuth
+from notifications_utils.clients.statsd.statsd_client import StatsdClient
 
 from app import version  # noqa
 
@@ -30,6 +31,20 @@ def load_config(application):
     application.config['API_KEY'] = template_preview_config['credentials']['api_key']
     application.config['LOGO_FILENAMES'] = LOGO_FILENAMES
 
+    if os.environ['STATSD_ENABLED'] == "1":
+
+        hosted_graphite_config = next(
+            service for service in vcap_services['user-provided']
+            if service['name'] == 'hosted-graphite'
+        )
+
+        application.config['STATSD_ENABLED'] = 1
+        application.config['STATSD_HOST'] = "localhost"
+        application.config['STATSD_PORT'] = 1000
+        application.config['STATSD_PREFIX'] = hosted_graphite_config['credentials']['statsd_prefix']
+    else:
+        application.config['STATSD_ENABLED'] = None
+
 
 def create_app():
     application = Flask(
@@ -44,6 +59,9 @@ def create_app():
     from app.status import status_blueprint
     application.register_blueprint(status_blueprint)
     application.register_blueprint(preview_blueprint)
+
+    application.statsd_client = StatsdClient()
+    application.statsd_client.init_app(application)
 
     @auth.verify_token
     def verify_token(token):

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -4,10 +4,12 @@ command: ./scripts/run_app.sh $PORT
 services:
   - notify-aws
   - notify-template-preview
+  - hosted-graphite
 instances: 1
 memory: 2G
 env:
   NOTIFY_APP_NAME: notify-template-preview
+  STATSD_ENABLED: 1
 
 applications:
   - name: notify-template-preview

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ PyYAML==3.12
 # weasyprint 0.41 has errors where png previews of PDFs randomly do not render all images
 WeasyPrint==0.40  # pyup: != 0.41
 
-git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
+git+https://github.com/alphagov/notifications-utils.git@23.3.7#egg=notifications-utils==23.3.7
 
 # PaaS requirements
 gunicorn==19.7.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,18 @@ def app():
                 "syslog_drain_url": "",
                 "tags": [],
                 "volume_mounts": []
+            },
+            {
+                "credentials": {
+                    "aws_access_key_id": "access_key",
+                    "aws_secret_access_key": "secret_key",
+                    "sqs_queue_prefix": "preview"
+                },
+                "label": "user-provided",
+                "name": "notify-aws",
+                "syslog_drain_url": "",
+                "tags": [],
+                "volume_mounts": []
             }
         ]
     })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,9 @@ from app import create_app
 
 @pytest.fixture(scope='session')
 def app():
+
+    os.environ['STATSD_ENABLED'] = "0"
+
     os.environ['VCAP_SERVICES'] = json.dumps({
         "user-provided": [
             {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,7 +29,20 @@ def test_config_is_loaded(app, revert_config):
                 "syslog_drain_url": "",
                 "tags": [],
                 "volume_mounts": []
+            },
+            {
+                "credentials": {
+                    "aws_access_key_id": "access_key",
+                    "aws_secret_access_key": "secret_key",
+                    "sqs_queue_prefix": "preview"
+                },
+                "label": "user-provided",
+                "name": "notify-aws",
+                "syslog_drain_url": "",
+                "tags": [],
+                "volume_mounts": []
             }
+
         ]
     })
 
@@ -65,6 +78,18 @@ def test_statds_enabled(app, revert_config):
                 "syslog_drain_url": "",
                 "tags": [],
                 "volume_mounts": []
+            },
+            {
+                "credentials": {
+                    "aws_access_key_id": "access_key",
+                    "aws_secret_access_key": "secret_key",
+                    "sqs_queue_prefix": "preview"
+                },
+                "label": "user-provided",
+                "name": "notify-aws",
+                "syslog_drain_url": "",
+                "tags": [],
+                "volume_mounts": []
             }
         ]
     })
@@ -74,4 +99,5 @@ def test_statds_enabled(app, revert_config):
     assert app.config.get('STATSD_ENABLED')
     assert app.config.get('STATSD_HOST') == "statsd.hostedgraphite.com"
     assert app.config.get('STATSD_PORT') == 8125
-    assert app.config.get('STATSD_PREFIX') == "this_is_a_test_prefix"
+    assert app.config.get('NOTIFY_ENVIRONMENT') == "preview"
+    assert app.config.get('NOTIFY_APP_NAME') == "template-preview"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -36,3 +36,42 @@ def test_config_is_loaded(app, revert_config):
     load_config(app)
 
     assert app.config['API_KEY'] == 'some secret key'
+
+
+def test_statds_enabled(app, revert_config):
+
+    os.environ['STATSD_ENABLED'] = "1"
+
+    os.environ['VCAP_SERVICES'] = json.dumps({
+        "user-provided": [
+            {
+                "credentials": {
+                    "api_host": "some domain",
+                    "api_key": "some secret key"
+                },
+                "label": "user-provided",
+                "name": "notify-template-preview",
+                "syslog_drain_url": "",
+                "tags": [],
+                "volume_mounts": []
+            },
+            {
+                "credentials": {
+                    "statsd_prefix": "this_is_a_test_prefix"
+                },
+                "instance_name": "hosted-graphite",
+                "label": "user-provided",
+                "name": "hosted-graphite",
+                "syslog_drain_url": "",
+                "tags": [],
+                "volume_mounts": []
+            }
+        ]
+    })
+
+    load_config(app)
+
+    assert app.config.get('STATSD_ENABLED') == 1
+    assert app.config.get('STATSD_HOST') == "localhost"
+    assert app.config.get('STATSD_PORT') == 1000
+    assert app.config.get('STATSD_PREFIX') == "this_is_a_test_prefix"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,7 +71,7 @@ def test_statds_enabled(app, revert_config):
 
     load_config(app)
 
-    assert app.config.get('STATSD_ENABLED') == 1
-    assert app.config.get('STATSD_HOST') == "localhost"
-    assert app.config.get('STATSD_PORT') == 1000
+    assert app.config.get('STATSD_ENABLED')
+    assert app.config.get('STATSD_HOST') == "statsd.hostedgraphite.com"
+    assert app.config.get('STATSD_PORT') == 8125
     assert app.config.get('STATSD_PREFIX') == "this_is_a_test_prefix"


### PR DESCRIPTION
It is suspected that the template preview app performance is slow.
Added statsd to template preview so that the performance of the
methods can be monitored overtime and so that future updates
can be proved to have a positive impact.

- Added statsd decorator to all preview.py methods
- Added configuration for statsd in init
- Added test to ensure that statsd config is being imported
- Added environment variable to make file to not turn on statds locally
- Added a variable to the manifest file so that statsd is turned on when deployed