### PR TITLE
Block weasyprint 0.42

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ numpy==1.13.3
 PyYAML==3.12
 
 # weasyprint 0.41 has errors where png previews of PDFs randomly do not render all images
-WeasyPrint==0.40  # pyup: != 0.41
+# weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
+WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
 git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
 


### PR DESCRIPTION
WeasyPrint 0.42 gets stuck in an infinite loop, or memory leak, or
something - with our current setup at least. Seen in tests on jenkins
and when running locally - stacktrace is different each time, so it's
not an individual downstream dependency that's causing the issue, I
suspect.