### PR TITLE
Add flake8 and flake8-print linting to project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# W503: line break before binary operator
+exclude = venv*,__pycache__
+ignore = W503
+max-complexity = 8
+max-line-length = 120

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -53,7 +53,7 @@ class ColorMapping():
 
     def output_log(self):
         for old, new in self.replaced_colors.items():
-            print('Replaced {} with {}'.format(old, new), file=sys.stderr)
+            print('Replaced {} with {}'.format(old, new), file=sys.stderr)  # noqa
 
     def get_closest_cmyk_color(self, rgb_tuple):
         closenesses = [

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
-pycodestyle==2.3.1
+flake8==3.5.0
+flake8-print==3.0.1
 pytest==3.3.2
 freezegun==0.3.9

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -25,7 +25,7 @@ function display_result {
 if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
-pycodestyle
+flake8 --enable=T .
 display_result $? 1 "Code style check"
 
 PYTHONPATH=. py.test -vv


### PR DESCRIPTION
The GDS Way™[1] recommends using Flake8 to lint Python projects.

This commit takes the Flake8 config from Digital Marketplace API[2] and removes the bits we don’t need.

It changes the `max_complexity` setting to 8, which matches the setting we have in utils.

It also includes the `flake8-print` plugin which should stop us having to manually catch `print()` statements when reviewing pull requests. This plugin requires the `--enable=T` flag to be set until this bug is fixed: https://github.com/JBKahn/flake8-print/issues/27

Flake8 didn’t find any new violations in this repo, but there is one required print statement which I’ve flagged as `# noqa` to prevent it from causing the tests to fail.

1. https://gds-way.cloudapps.digital/manuals/programming-languages/python/linting.html#how-to-use-flake8
2. https://github.com/alphagov/digitalmarketplace-api/blob/d5ab8afef4a0472f9d266d94ab4ffe1333a9aaad/.flake8