### PR TITLE
Reconfig template-preview to use new environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ pip install -r requirements.txt
 make _generate-version-file
 ```
 
-You will also need to set VCAP_SERVICES (extracted from Makefile) -
+You will also need to export an environmental variable -
 
 ```shell
-export VCAP_SERVICES='{"user-provided":[{"credentials":{"api_host": "some_domain","api_key":"my-secret-key"},"label":"user-provided","name":"notify-template-preview","syslog_drain_url":"","tags":[],"volume_mounts":[]}]}'
+export TEMPLATE_PREVIEW_API_KEY="my-secret-key"
 ```
 
 Then call the run app script -

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,13 +21,8 @@ LOGO_FILENAMES = {
 
 
 def load_config(application):
-    vcap_services = json.loads(os.environ['VCAP_SERVICES'])
-    template_preview_config = next(
-        service for service in vcap_services['user-provided']
-        if service['name'] == 'notify-template-preview'
-    )
+    application.config['API_KEY'] = os.environ['TEMPLATE_PREVIEW_API_KEY']
 
-    application.config['API_KEY'] = template_preview_config['credentials']['api_key']
     application.config['LOGO_FILENAMES'] = LOGO_FILENAMES
 
 

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -2,12 +2,16 @@
 
 command: ./scripts/run_app.sh $PORT
 services:
-  - notify-aws
-  - notify-template-preview
 instances: 1
 memory: 2G
 env:
   NOTIFY_APP_NAME: notify-template-preview
+
+  # Credentials variables
+  AWS_ACCESS_KEY_ID: null
+  AWS_SECRET_ACCESS_KEY: null
+  TEMPLATE_PREVIEW_API_HOST: null
+  TEMPLATE_PREVIEW_API_KEY: null
 
 applications:
   - name: notify-template-preview

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+
+import json
+import yaml
+
+
+def merge_dicts(a, b):
+    if not (isinstance(a, dict) and isinstance(b, dict)):
+        raise ValueError("Error merging variables: '{}' and '{}'".format(
+            type(a).__name__, type(b).__name__
+        ))
+
+    result = a.copy()
+    for key, val in b.items():
+        if isinstance(result.get(key), dict):
+            result[key] = merge_dicts(a[key], b[key])
+        else:
+            result[key] = val
+    return result
+
+
+def load_manifest(manifest_file):
+    with open(manifest_file) as f:
+        manifest = yaml.load(f)
+
+    if 'inherit' in manifest:
+        inherit_file = os.path.join(os.path.dirname(manifest_file), manifest.pop('inherit'))
+        manifest = merge_dicts(load_manifest(inherit_file), manifest)
+
+    return manifest
+
+
+def load_variables(vars_files):
+    variables = {}
+    for vars_file in vars_files:
+        with open(vars_file) as f:
+            variables = merge_dicts(variables, yaml.load(f))
+
+    return {
+        k.upper(): json.dumps(v) if isinstance(v, (dict, list)) else v
+        for k, v in variables.items()
+    }
+
+
+def paas_manifest(manifest_file, *vars_files):
+
+    manifest = load_manifest(manifest_file)
+    variables = load_variables(vars_files)
+
+    for key in manifest.get('env', {}):
+        if key in variables:
+            manifest['env'][key] = variables[key]
+
+    return yaml.dump(manifest, default_flow_style=False, allow_unicode=True)
+
+
+if __name__ == "__main__":
+    print('---')
+    print(paas_manifest(*sys.argv[1:]))

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -18,9 +18,6 @@ function check_params {
 function configure_aws_logs {
   aws configure set plugins.cwlogs cwlogs
 
-  export AWS_ACCESS_KEY_ID=$(echo ${VCAP_SERVICES} | jq -r '.["user-provided"][]|select(.name=="notify-aws")|.credentials.aws_access_key_id')
-  export AWS_SECRET_ACCESS_KEY=$(echo ${VCAP_SERVICES} | jq -r '.["user-provided"][]|select(.name=="notify-aws")|.credentials.aws_secret_access_key')
-
   cat > /app/awslogs/awslogs.conf << EOF
 [general]
 state_file = /app/awslogs/awslogs-state

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,21 +8,7 @@ from app import create_app
 
 @pytest.fixture(scope='session')
 def app():
-    os.environ['VCAP_SERVICES'] = json.dumps({
-        "user-provided": [
-            {
-                "credentials": {
-                    "api_host": "some domain",
-                    "api_key": "my-secret-key"
-                },
-                "label": "user-provided",
-                "name": "notify-template-preview",
-                "syslog_drain_url": "",
-                "tags": [],
-                "volume_mounts": []
-            }
-        ]
-    })
+    os.environ['TEMPLATE_PREVIEW_API_KEY'] = "my-secret-key"
     yield create_app()
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,27 +12,3 @@ def revert_config(app):
     old_config = copy.deepcopy(app.config)
     yield
     app.config = old_config
-
-
-def test_config_is_loaded(app, revert_config):
-    assert app.config['API_KEY'] == 'my-secret-key'
-
-    os.environ['VCAP_SERVICES'] = json.dumps({
-        "user-provided": [
-            {
-                "credentials": {
-                    "api_host": "some domain",
-                    "api_key": "some secret key"
-                },
-                "label": "user-provided",
-                "name": "notify-template-preview",
-                "syslog_drain_url": "",
-                "tags": [],
-                "volume_mounts": []
-            }
-        ]
-    })
-
-    load_config(app)
-
-    assert app.config['API_KEY'] == 'some secret key'


### PR DESCRIPTION
This is part of the story of https://www.pivotaltracker.com/story/show/154053579

Please refer to https://github.com/alphagov/notifications-api/pull/1543 for a detailed description of this story. 

**In this PR**
- Reads the environment variable API_KEY directly from env rather than VCAP_SERVICES.  
- Adds a new make generate-manifest target which is called by deployment steps. This calls the generate-manifest.py to populate the environmental variables when deploying the app. 
- generate-manifest.py parse manifest yaml files, and populate the variables that are already defined in env but have been set to NULL. 