### PR TITLE
It is suspected that the template preview app performance is slow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ define run_docker_container
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \
 		-e TEMPLATE_PREVIEW_API_KEY=${TEMPLATE_PREVIEW_API_KEY} \
+		-e STATSD_ENABLED= \
+		-e STATSD_PREFIX="dev" \
+		-e NOTIFY_ENVIRONMENT="{CF_SPACE}" \
 		${DOCKER_IMAGE_NAME} \
 		${2}
 endef

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,9 @@
+import logging
 import os
 
 from flask import Flask
 from flask_httpauth import HTTPTokenAuth
+from notifications_utils.clients.statsd.statsd_client import StatsdClient
 
 from app import version  # noqa
 from app.transformation import Logo
@@ -47,6 +49,16 @@ LOGOS = {
 def load_config(application):
     application.config['API_KEY'] = os.environ['TEMPLATE_PREVIEW_API_KEY']
     application.config['LOGOS'] = LOGOS
+    application.config['NOTIFY_ENVIRONMENT'] = os.environ['NOTIFY_ENVIRONMENT']
+    application.config['NOTIFY_APP_NAME'] = 'template-preview'
+
+    if os.environ['STATSD_ENABLED'] == "1":
+        application.config['STATSD_ENABLED'] = True
+        application.config['STATSD_HOST'] = "statsd.hostedgraphite.com"
+        application.config['STATSD_PORT'] = 8125
+        application.config['STATSD_PREFIX'] = os.environ['STATSD_PREFIX']
+    else:
+        application.config['STATSD_ENABLED'] = False
 
 
 def create_app():
@@ -62,6 +74,13 @@ def create_app():
     from app.status import status_blueprint
     application.register_blueprint(status_blueprint)
     application.register_blueprint(preview_blueprint)
+
+    console = logging.StreamHandler()
+    application.logger.addHandler(console)
+    application.logger.setLevel(logging.INFO)
+
+    application.statsd_client = StatsdClient()
+    application.statsd_client.init_app(application)
 
     @auth.verify_token
     def verify_token(token):

--- a/app/preview.py
+++ b/app/preview.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 from flask import Blueprint, request, send_file, abort, current_app, jsonify
 from flask_weasyprint import HTML
+from notifications_utils.statsd_decorators import statsd
 from wand.image import Image
 from notifications_utils.template import (
     LetterPreviewTemplate,
@@ -15,6 +16,7 @@ from app.transformation import PDFData, color_mapping
 preview_blueprint = Blueprint('preview_blueprint', __name__)
 
 
+@statsd(namespace="template_preview")
 def png_from_pdf(data, page_number):
     output = BytesIO()
     with Image(blob=data, resolution=150) as pdf:
@@ -36,6 +38,7 @@ def png_from_pdf(data, page_number):
     }
 
 
+@statsd(namespace="template_preview")
 def get_logo(dvla_org_id):
     try:
         return current_app.config['LOGOS'][dvla_org_id]
@@ -43,11 +46,13 @@ def get_logo(dvla_org_id):
         abort(400)
 
 
+@statsd(namespace="template_preview")
 def get_page_count(pdf_data):
     with Image(blob=pdf_data) as image:
         return len(image.sequence)
 
 
+@statsd(namespace="template_preview")
 @preview_blueprint.route("/preview.json", methods=['POST'])
 @auth.login_required
 def page_count():
@@ -60,6 +65,7 @@ def page_count():
     )
 
 
+@statsd(namespace="template_preview")
 @preview_blueprint.route("/preview.<filetype>", methods=['POST'])
 @auth.login_required
 def view_letter_template(filetype):
@@ -109,6 +115,7 @@ def view_letter_template(filetype):
         raise e
 
 
+@statsd(namespace="template_preview")
 @preview_blueprint.route("/print.pdf", methods=['POST'])
 @auth.login_required
 def print_letter_template():

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -4,12 +4,14 @@ command: ./scripts/run_app.sh $PORT
 instances: 1
 memory: 2G
 env:
-  NOTIFY_APP_NAME: notify-template-preview
+  NOTIFY_APP_NAME: rc-notify-template-preview
+  STATSD_ENABLED: 1
 
   # Credentials variables
   AWS_ACCESS_KEY_ID: null
   AWS_SECRET_ACCESS_KEY: null
   TEMPLATE_PREVIEW_API_KEY: null
+  STATSD_PREFIX: null
 
 applications:
   - name: notify-template-preview

--- a/manifest-preview.yml
+++ b/manifest-preview.yml
@@ -4,3 +4,7 @@ inherit: manifest-base.yml
 
 routes:
   - route: preview-notify-template-preview.cloudapps.digital
+
+env:
+  NOTIFY_ENVIRONMENT: preview
+

--- a/manifest-production.yml
+++ b/manifest-production.yml
@@ -4,3 +4,6 @@ inherit: manifest-base.yml
 
 routes:
   - route: production-notify-template-preview.cloudapps.digital
+
+env:
+  NOTIFY_ENVIRONMENT: production

--- a/manifest-sandbox.yml
+++ b/manifest-sandbox.yml
@@ -4,3 +4,6 @@ inherit: manifest-base.yml
 
 routes:
   - route: sandbox-notify-template-preview.cloudapps.digital
+
+env:
+  NOTIFY_ENVIRONMENT: sandbox

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -3,4 +3,7 @@
 inherit: manifest-base.yml
 
 routes:
-  - route: staging-notify-template-preview.cloudapps.digital
+  - route: rc-notify-template-preview.cloudapps.digital
+
+env:
+  NOTIFY_ENVIRONMENT: staging

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==3.12
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
+git+https://github.com/alphagov/notifications-utils.git@23.3.7#egg=notifications-utils==23.3.7
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
Added statsd to template preview so that the performance of the
methods can be monitored overtime and so that future updates
can be proved to have a positive impact.

- Added statsd decorator to all preview.py methods
- Added configuration for statsd in init
- Added environment variable to make file to not turn on statds
locally
- Added a variable to the manifest file so that statsd is turned on
when deployed
- Added the statsd prefix for all environments