### PR TITLE
Add mapping for RGB to CMYK white

### DIFF
--- a/app/colors.yaml
+++ b/app/colors.yaml
@@ -1,4 +1,5 @@
 [ 0,   0,   0   ] : [ 0,   0,   0,   100 ]  # Black
+[ 255, 255, 255 ] : [ 0,   0,   0,   0   ]  # White
 [ 10,   10,   10] : [ 0,   0,   0,   100 ]  # Very dark grey (squash to black)
 [ 255, 179, 69  ] : [ 0,   20,  100, 0   ]  # Placeholder (yellow)
 [ 0,   111, 183 ] : [ 88,  50,  0,   0   ]  # Single identity (blue)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==3.12
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@23.1.0#egg=notifications-utils==23.1.0
+git+https://github.com/alphagov/notifications-utils.git@23.4.2#egg=notifications-utils==23.4.2
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
## What -

In order for DVLA to process letter PDFs correctly they need to have a `NOTIFY:` tag in the top left corner. 

This PR maps white RGB to white CMYK correctly and uses the latest utils which contains the tag.

- also upgrade to latest utils to show notify tag and page counters for CMYK PDFs

## Reference 

https://www.pivotaltracker.com/story/show/153990244