### PR TITLE
Update ghostscript to produce 1.6 PDFs rather than 1.5

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -14,6 +14,7 @@ def convert_pdf_to_cmyk(input_data):
             'gs',
             '-o',
             '-',
+            '-dCompatibilityLevel=1.6',
             '-sDEVICE=pdfwrite',
             '-sColorConversionStrategy=CMYK',
             '-sSourceObjectICC=app/ghostscript/control.txt',

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ PyYAML==3.12
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@23.4.2#egg=notifications-utils==23.4.2
+git+https://github.com/alphagov/notifications-utils.git@23.4.3#egg=notifications-utils==23.4.3
+
 
 # PaaS requirements
 gunicorn==19.7.1


### PR DESCRIPTION
## What 

DVLA require PDF versions 1.6, this PR will update the version to 1.6 from 1.5 and also use utils 23.4.3 to remove the colon from the notify-tag.