### PR TITLE
Updated the Ghostscript command line parameters to improve the Performance of CMYK Conversion

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -18,6 +18,10 @@ def convert_pdf_to_cmyk(input_data):
             '-sDEVICE=pdfwrite',
             '-sColorConversionStrategy=CMYK',
             '-sSourceObjectICC=app/ghostscript/control.txt',
+            '-dBandBufferSpace=100000000'
+            '-dBufferSpace=100000000',
+            '-dMaxPatternBitmap=1000000',
+            '-c 100000000 setvmthreshold -f',
             '-'
         ],
         stdin=subprocess.PIPE,


### PR DESCRIPTION
In testing this have improved the performance by approximately 200ms.

See https://www.ghostscript.com/doc/current/Use.htm#Improving_performance
This is the guide I used for the settings updates.
Under no load (i.e. no traffic) the app uses approx 400MB of RAM as
gunicorn can start 10 processes there could be 10 concurrent gs processes.

-dBandBufferSpace=1000000
The size of the band buffer in the rasterizing pass, in bytes. 0 means
use the same buffer size as for the interpretation pass.
-dBufferSpace=1000000
(4MB Default) Buffer space for band lists, if the bitmap is too big to
fit in memory.
-dMaxPatternBitmap=1000000
use clist based patterns for pattern tiles larger than 100MB
-c 100000000 setvmthreshold -f
Allocated 100MB of memory per gs process x 10 processes - 1GB the app
has a 2GB. Interprets following non-switch arguments as file names to be executed using the normal run command. Since this is the default behavior, -f is useful only for terminating the list of tokens for the -c switch.

More info http://noodle.med.yale.edu/latex/gs/Language.htm

A band is part of the document to raster at a time otherwise it takes
the page.

Under load i.e. a Gatling test with 1 user
83.3    0   430.1MB     1.8MB
Increasing the dBufferSpace and dBandBufferSpace ten fold made no
difference to performance or resource usage.

Running the test with concurrent users i.e. requests only effects the
CPU memory and disk usage seem to remain consistent.