### PR TITLE
Add -q to only output pdf data and not standard output

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -12,6 +12,7 @@ def convert_pdf_to_cmyk(input_data):
     stdout, _ = subprocess.Popen(
         [
             'gs',
+            '-q',
             '-o',
             '-',
             '-dCompatibilityLevel=1.7',

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -1,0 +1,11 @@
+from flask_weasyprint import HTML
+
+from app.transformation import convert_pdf_to_cmyk
+
+
+def test_convert_to_cmyk_pdf_first_line_in_header_correct(client):
+    html = HTML(string=str('<html></html>'))
+    pdf = html.write_pdf()
+
+    data = convert_pdf_to_cmyk(pdf)
+    assert data[:9] == b'%PDF-1.7\n'


### PR DESCRIPTION
## What

DVLA were not able to process the PDFs because they did not appear to be valid pdfs. 
It seems that the standard output of the ghostscript was being added to the pdf data stream, adding  `-q` should fix this and make the pdf valid.