### PR TITLE
Fixed Failing tests after a rebase with master

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -9,7 +9,7 @@ class Logo():
 
 
 def convert_pdf_to_cmyk(input_data):
-    stdout, _ = subprocess.Popen(
+    gs_process = subprocess.Popen(
         [
             'gs',
             '-q',
@@ -19,7 +19,7 @@ def convert_pdf_to_cmyk(input_data):
             '-sDEVICE=pdfwrite',
             '-sColorConversionStrategy=CMYK',
             '-sSourceObjectICC=app/ghostscript/control.txt',
-            '-dBandBufferSpace=100000000'
+            '-dBandBufferSpace=100000000',
             '-dBufferSpace=100000000',
             '-dMaxPatternBitmap=1000000',
             '-c 100000000 setvmthreshold -f',
@@ -28,5 +28,9 @@ def convert_pdf_to_cmyk(input_data):
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    ).communicate(input=input_data)
+    )
+    stdout, stderr = gs_process.communicate(input=input_data)
+    if gs_process.returncode != 0:
+        raise Exception('ghostscript process failed with return code: {}\nstdout: {}\nstderr:{}'
+                        .format(gs_process.returncode, stdout, stderr))
     return stdout

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -1,3 +1,4 @@
+import pytest
 from flask_weasyprint import HTML
 
 from app.transformation import convert_pdf_to_cmyk
@@ -9,3 +10,15 @@ def test_convert_to_cmyk_pdf_first_line_in_header_correct(client):
 
     data = convert_pdf_to_cmyk(pdf)
     assert data[:9] == b'%PDF-1.7\n'
+
+
+def test_subprocess_fails(client, mocker):
+    mock_popen = mocker.patch('subprocess.Popen')
+    mock_popen.return_value.returncode = 1
+    mock_popen.return_value.communicate.return_value = ('Failed', 'There was an error')
+
+    with pytest.raises(Exception) as excinfo:
+        html = HTML(string=str('<html></html>'))
+        pdf = html.write_pdf()
+        convert_pdf_to_cmyk(pdf)
+        assert 'ghostscript process failed with return code: 1' in str(excinfo.value)


### PR DESCRIPTION
Fixed the trailing comma on the subprocess command. This causes the process to fail so there is no data to check against hence the unit test failed.

Checked that the return code from subprocess and thrown an exception if if is is not 0 i.e. failure print out the stdout and stderr. Added a test to check for failure and that the correct messaged s printed out.