### PR TITLE
Added commandline parameters to turn off compression for PDF DVLA

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -20,6 +20,8 @@ def convert_pdf_to_cmyk(input_data):
             '-sColorConversionStrategy=CMYK',
             '-sSourceObjectICC=app/ghostscript/control.txt',
             '-dBandBufferSpace=100000000',
+            '-dAutoFilterColorImages=false',
+            '-dColorImageFilter=/FlateEncode',
             '-dBufferSpace=100000000',
             '-dMaxPatternBitmap=1000000',
             '-c 100000000 setvmthreshold -f',


### PR DESCRIPTION
processing. Whilst compression can be handled their end it means that
processing the  pdfs takes longer. This speeds up the process.

These options are not documented comprehensively by Ghostscript and were
supplied by DVLA.

This website also mentions that they turn off compression
http://ansuz.sooke.bc.ca/software/ps-pdf-tricks.php

Ghostscript docs here https://www.ghostscript.com/doc/current/Ps2pdf.htm