### PR TITLE
Give Environment Agency a real ID

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ LOGOS = {
     '007': Logo('dept-for-communities'),
     '008': Logo('mmo'),
     '500': Logo('hm-land-registry'),
-    'TBC': Logo('ea'),
+    '501': Logo('ea'),
 }
 
 


### PR DESCRIPTION
We’ll kill this `DVLA_ORG_ID` thing eventually, but now is not the time.