### PR TITLE
Make sure directories exist before touching files

### DIFF
--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -17,6 +17,7 @@ function check_params {
 
 function configure_aws_logs {
   # create files so that aws logs agent doesn't complain
+  mkdir -p /home/vcap/logs/
   touch /home/vcap/logs/gunicorn_error.log
   touch /home/vcap/logs/app.log.json
 


### PR DESCRIPTION
This runs before the application starts and if the directories are not
there it fails and doesn't allow the application to start.