### PR TITLE
Add some endpoints to manage letter logos

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -251,3 +251,13 @@ def print_logo_sheet():
         as_attachment=True,
         attachment_filename='print.pdf'
     )
+
+
+@preview_blueprint.route("/logos.json", methods=['GET'])
+@auth.login_required
+@statsd(namespace="template_preview")
+def get_available_logos():
+    return jsonify({
+        key: logo.raster
+        for key, logo in current_app.config['LOGOS'].items()
+    })

--- a/app/preview.py
+++ b/app/preview.py
@@ -222,3 +222,32 @@ def print_letter_template():
     except Exception as e:
         current_app.logger.error(str(e))
         raise e
+
+
+@preview_blueprint.route("/logos.pdf", methods=['GET'])
+# No auth on this endpoint to make debugging easier
+@statsd(namespace="template_preview")
+def print_logo_sheet():
+
+    html = HTML(string="""
+        <html>
+            <head>
+            </head>
+            <body>
+                <h1>All letter logos</h1>
+                {}
+            </body>
+        </html>
+    """.format('\n<br><br>'.join(
+        '<img src="/static/images/letter-template/{}" width="100%">'.format(logo.vector)
+        for org_id, logo in current_app.config['LOGOS'].items()
+    )))
+
+    pdf = html.write_pdf()
+    cmyk_pdf = convert_pdf_to_cmyk(pdf)
+
+    return send_file(
+        BytesIO(cmyk_pdf),
+        as_attachment=True,
+        attachment_filename='print.pdf'
+    )


### PR DESCRIPTION
## `logos.pdf` lets us check that none of the logos we add are getting mangled by the CMYK conversion

![image](https://user-images.githubusercontent.com/355079/38035747-f32c7c00-329c-11e8-9308-7b80861b1c34.png)


## `logos.json` lists available logos so that the admin app can make an interface for picking them

```json
{
  "001": "hm-government.png", 
  "002": "opg.png", 
  "003": "dwp.png", 
  "004": "geo.png", 
  "005": "ch.png", 
  "006": "dwp-welsh.png", 
  "007": "dept-for-communities.png", 
  "008": "mmo.png", 
  "500": "hm-land-registry.png", 
  "501": "ea.png", 
  "502": "wra.png", 
  "503": "eryc.png", 
  "504": "rother.png"
}
```