### PR TITLE
Fix cmyk preview precompiled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ _run:
 _test: _test-dependencies
 	./scripts/run_tests.sh
 
+.PHONY: _single_test
+_single_test: _test-dependencies
+	pytest -k ${test_name}
+
 define run_docker_container
 	docker run -i${DOCKER_TTY} --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-${1}" \
@@ -122,6 +126,12 @@ bash-with-docker: prepare-docker-build-image ## Build inside a Docker container
 test-with-docker: export DOCKER_IMAGE_TAG = sandbox
 test-with-docker: prepare-docker-build-image ## Run tests inside a Docker container
 	$(call run_docker_container,test, make _test)
+
+.PHONY: single-test-with-docker
+# always run tests against the sandbox image
+single-test-with-docker: export DOCKER_IMAGE_TAG = sandbox
+single-test-with-docker: prepare-docker-build-image ## Run single test inside a Docker container, make single-test-with-docker test_name=<test name>
+	$(call run_docker_container,test, make _single_test test_name=${test_name})
 
 .PHONY: clean-docker-containers
 clean-docker-containers: ## Clean up any remaining docker containers

--- a/app/preview.py
+++ b/app/preview.py
@@ -22,7 +22,9 @@ preview_blueprint = Blueprint('preview_blueprint', __name__)
 # When the background is set to white traces of the Notify tag are visible in the preview png
 # As modifying the pdf text is complicated, a quick solution is to place a white block over it
 def hide_notify_tag(image):
-    with Image(width=130, height=50, background=Color('white')) as cover:
+    with Image(width=130, height=50, background=Color('blue')) as cover:
+        if image.colorspace == 'cmyk':
+            cover.transform_colorspace('cmyk')
         image.composite(cover, left=0, top=0)
 
 
@@ -30,13 +32,17 @@ def hide_notify_tag(image):
 def png_from_pdf(data, page_number, hide_notify=False):
     output = BytesIO()
     with Image(blob=data, resolution=150) as pdf:
-        with Image(width=pdf.width, height=pdf.height, background=Color('white')) as image:
+        with Image(width=pdf.width, height=pdf.height) as image:
             try:
                 page = pdf.sequence[page_number - 1]
             except IndexError:
                 abort(400, 'Letter does not have a page {}'.format(page_number))
 
+            if pdf.colorspace == 'cmyk':
+                image.transform_colorspace('cmyk')
+
             image.composite(page, top=0, left=0)
+            print('hidden', hide_notify)  # noqa
             if hide_notify:
                 hide_notify_tag(image)
             converted = image.convert('png')
@@ -162,9 +168,13 @@ def view_precompiled_letter():
             abort(400)
 
         pdf = base64.decodestring(encoded_string)
+        hide_notify = request.args.get('hide_notify', '') == 'true'
+        print(hide_notify)  # noqa
 
         return send_file(**png_from_pdf(
-            pdf, page_number=int(request.args.get('page', 1)), hide_notify=True
+            pdf,
+            page_number=int(request.args.get('page', 1)),
+            hide_notify=hide_notify
         ))
 
     # catch invalid pdfs

--- a/app/preview.py
+++ b/app/preview.py
@@ -22,7 +22,7 @@ preview_blueprint = Blueprint('preview_blueprint', __name__)
 # When the background is set to white traces of the Notify tag are visible in the preview png
 # As modifying the pdf text is complicated, a quick solution is to place a white block over it
 def hide_notify_tag(image):
-    with Image(width=130, height=50, background=Color('blue')) as cover:
+    with Image(width=130, height=50, background=Color('white')) as cover:
         if image.colorspace == 'cmyk':
             cover.transform_colorspace('cmyk')
         image.composite(cover, left=0, top=0)
@@ -42,7 +42,6 @@ def png_from_pdf(data, page_number, hide_notify=False):
                 image.transform_colorspace('cmyk')
 
             image.composite(page, top=0, left=0)
-            print('hidden', hide_notify)  # noqa
             if hide_notify:
                 hide_notify_tag(image)
             converted = image.convert('png')
@@ -169,7 +168,6 @@ def view_precompiled_letter():
 
         pdf = base64.decodestring(encoded_string)
         hide_notify = request.args.get('hide_notify', '') == 'true'
-        print(hide_notify)  # noqa
 
         return send_file(**png_from_pdf(
             pdf,


### PR DESCRIPTION
## What

CMYK pdfs were showing as inverted due to the way colour is handled in the CMYK colour space vs how it is handled in the RGB colour space. 
To fix this we transform the colour space to CMYK to match the PDF.

## How to review

Upload a CMYK pdf via API and view on the Admin site, you should be able to view the colours without them being inverted.