### PR TITLE
Bump utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ PyYAML==3.12
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@25.2.0#egg=notifications-utils==25.2.0
+git+https://github.com/alphagov/notifications-utils.git@26.3.0#egg=notifications-utils==26.3.0
 
 
 # PaaS requirements


### PR DESCRIPTION
Fixes exceptions caused by upgrade to pip 10.

Changes: https://github.com/alphagov/notifications-utils/compare/25.2.0...26.3.0