### PR TITLE
Update Template Preview app reserved memory

### DIFF
--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -1,7 +1,7 @@
 ---
 command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi
 instances: 1
-memory: 2G
+memory: 1G
 env:
   NOTIFY_APP_NAME: notify-template-preview
   NOTIFY_LOG_PATH: /home/vcap/logs/app.log

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -18,6 +18,7 @@ function check_params {
 function configure_aws_logs {
   # create files so that aws logs agent doesn't complain
   mkdir -p /home/vcap/logs/
+  mkdir -p /home/vcap/app/
   touch /home/vcap/logs/gunicorn_error.log
   touch /home/vcap/logs/app.log.json
 


### PR DESCRIPTION
After monitoring the template preview application does not exceed 1GB therefore reduce it down to be 1GB this will also allow us to launch more preview applications whilst scaling to avoid 500s occurring when there is high demand.

* Updated memory per instance from 2GB to 1GB