### PR TITLE
Use 1GB of memory per instance

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -3,7 +3,7 @@ applications:
 - name: notify-template-preview
 
   instances: 1
-  memory: 512M
+  memory: 1G
 
   buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi


### PR DESCRIPTION
The template preview app needs 1GB of memory to do the PDF to PNG conversion without crashing.

We believe that the value of 512GB was a copy/paste mistake, introduced here (no explanation for the change in the commit message): https://github.com/alphagov/notifications-template-preview/commit/4f344d183fef54d51e0ad4f3e13ca0580ea25035#diff-797a2c267a7577bde1eb3cb26ad42ee3

This commit reverts it to the previous value of 1GB, a value reached by some performance testing according to 61eb51e3a98e603c79d83541fb60c0d02b39d571