### PR TITLE
Don’t hash page number in precompiled PNG cache key

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,9 +97,10 @@ auth = HTTPTokenAuth(scheme='Token')
 
 def init_cache(application):
 
-    def cache(*args, extension='file'):
+    def cache(*args, folder=None, extension='file'):
 
-        cache_key = '{}.{}'.format(
+        cache_key = '{}/{}.{}'.format(
+            folder,
             sha1(''.join(str(arg) for arg in args).encode('utf-8')).hexdigest(),
             extension,
         )

--- a/app/preview.py
+++ b/app/preview.py
@@ -138,7 +138,7 @@ def get_html(json):
 
 def get_pdf(html):
 
-    @current_app.cache(html, extension='pdf')
+    @current_app.cache(html, folder='templated', extension='pdf')
     def _get():
         return BytesIO(HTML(string=html).write_pdf())
 
@@ -147,7 +147,7 @@ def get_pdf(html):
 
 def get_png(html, page_number):
 
-    @current_app.cache(html, extension='page{0:02d}.png'.format(page_number))
+    @current_app.cache(html, folder='templated', extension='page{0:02d}.png'.format(page_number))
     def _get():
         return png_from_pdf(
             get_pdf(html).read(),
@@ -160,7 +160,9 @@ def get_png(html, page_number):
 def get_png_from_precompiled(encoded_string, page_number, hide_notify):
 
     @current_app.cache(
-        encoded_string.decode('ascii'), page_number, hide_notify, extension='png'
+        encoded_string.decode('ascii'), hide_notify,
+        folder='precompiled',
+        extension='page{0:02d}.png'.format(page_number)
     )
     def _get():
         return png_from_pdf(

--- a/tests/test_precompiled_preview.py
+++ b/tests/test_precompiled_preview.py
@@ -84,13 +84,13 @@ def test_precompiled_pdf_caches_png_to_s3(
     assert response.get_data().startswith(b'\x89PNG')
     mocked_cache_get.assert_called_once_with(
         'sandbox-template-preview-cache',
-        'c96858ed34197dead089a9512acac7cb206e734b.png'
+        'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == response.get_data()
     assert mocked_cache_set.call_args[0][1] == 'eu-west-1'
     assert mocked_cache_set.call_args[0][2] == 'sandbox-template-preview-cache'
-    assert mocked_cache_set.call_args[0][3] == 'c96858ed34197dead089a9512acac7cb206e734b.png'
+    assert mocked_cache_set.call_args[0][3] == 'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
 
 
 def test_precompiled_pdf_returns_png_from_cache(
@@ -117,7 +117,7 @@ def test_precompiled_pdf_returns_png_from_cache(
     assert response.get_data() == b'\x00'
     mocked_cache_get.assert_called_once_with(
         'sandbox-template-preview-cache',
-        'c96858ed34197dead089a9512acac7cb206e734b.png'
+        'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     assert mocked_cache_set.call_args_list == []
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -109,7 +109,7 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'd3f498795bd213df530c2618ed0755cdcb76194b.pdf'
+    expected_cache_key = 'templated/d3f498795bd213df530c2618ed0755cdcb76194b.pdf'
     resp = view_letter_template(filetype='pdf')
 
     assert resp.status_code == 200
@@ -135,7 +135,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'd3f498795bd213df530c2618ed0755cdcb76194b.page01.png'
+    expected_cache_key = 'templated/d3f498795bd213df530c2618ed0755cdcb76194b.page01.png'
     resp = view_letter_template(filetype='png')
 
     assert resp.status_code == 200
@@ -364,7 +364,7 @@ def test_page_count_from_cache(
         }
     )
     assert mocked_cache_get.call_args[0][0] == 'sandbox-template-preview-cache'
-    assert mocked_cache_get.call_args[0][1] == '8c1a7b0470011615930aeebe074ff4e5e6c926c7.pdf'
+    assert mocked_cache_get.call_args[0][1] == 'templated/8c1a7b0470011615930aeebe074ff4e5e6c926c7.pdf'
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {'count': 10}
 


### PR DESCRIPTION
This will make it easier to debug because we’ll be able to match which PNGs were generated from the same letter.

We’re already doing this for templated letters; this makes it consistent for precompiled letters.

This commit also namespaces precompiled and templated letters to make it clearer what’s going on for someone looking in the bucket.