### PR TITLE
Updated the Dockerfile to be a multi stage build Docker file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ _generate-version-file:
 
 .PHONY: _test-dependencies
 _test-dependencies:
-	pip install -r requirements_for_test.txt
+	pip install -r requirements-dev.txt
 
 .PHONY: _run
 _run:
@@ -124,13 +124,13 @@ bash-with-docker: prepare-docker-build-image ## Build inside a Docker container
 .PHONY: test-with-docker
 # always run tests against the sandbox image
 test-with-docker: export DOCKER_IMAGE_TAG = sandbox
-test-with-docker: prepare-docker-build-image ## Run tests inside a Docker container
+test-with-docker: prepare-docker-test-build-image ## Run tests inside a Docker container
 	$(call run_docker_container,test, make _test)
 
 .PHONY: single-test-with-docker
 # always run tests against the sandbox image
 single-test-with-docker: export DOCKER_IMAGE_TAG = sandbox
-single-test-with-docker: prepare-docker-build-image ## Run single test inside a Docker container, make single-test-with-docker test_name=<test name>
+single-test-with-docker: prepare-docker-test-build-image ## Run single test inside a Docker container, make single-test-with-docker test_name=<test name>
 	$(call run_docker_container,test, make _single_test test_name=${test_name})
 
 .PHONY: clean-docker-containers
@@ -148,6 +148,19 @@ upload-to-dockerhub: prepare-docker-build-image ## Upload the current version of
 .PHONY: prepare-docker-build-image
 prepare-docker-build-image: ## Build docker image
 	docker build -f docker/Dockerfile \
+		--build-arg http_proxy="${http_proxy}" \
+		--build-arg https_proxy="${https_proxy}" \
+		--build-arg NO_PROXY="${NO_PROXY}" \
+		--build-arg CI_NAME=${CI_NAME} \
+		--build-arg CI_BUILD_NUMBER=${BUILD_NUMBER} \
+		--build-arg CI_BUILD_URL=${BUILD_URL} \
+		-t ${DOCKER_IMAGE_NAME} \
+		.
+
+.PHONY: prepare-docker-test-build-image
+prepare-docker-test-build-image: ## Build docker image
+	docker build -f docker/Dockerfile \
+		--target test \
 		--build-arg http_proxy="${http_proxy}" \
 		--build-arg https_proxy="${https_proxy}" \
 		--build-arg NO_PROXY="${NO_PROXY}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-slim as parent
 
 ARG http_proxy
 ARG https_proxy
@@ -50,7 +50,13 @@ RUN \
 # these are declared statically here so that they're cached by the docker image - if we run after the `COPY` command
 # they won't be cached so it'll re-download every time. But these don't involve the filesystem
 COPY requirements.txt .
+
+##### Test Image ##############################################################
+
+FROM parent as test
+
 COPY requirements-dev.txt .
+
 RUN \
 	echo "Installing python dependencies" \
 	&& pip install -r requirements-dev.txt
@@ -60,6 +66,31 @@ WORKDIR /home/vcap/app
 # Copy from the real world, one dir up (project root) into the environment's current working directory
 # Docker will rebuild from here down every time.
 COPY . .
+
+ARG CI_NAME
+ARG CI_BUILD_NUMBER
+ARG CI_BUILD_URL
+ENV CI_NAME=$CI_NAME
+ENV CI_BUILD_NUMBER=$CI_BUILD_NUMBER
+ENV CI_BUILD_URL=$CI_BUILD_URL
+
+RUN make _generate-version-file
+
+EXPOSE 6013
+
+##### Production Image #######################################################
+
+FROM parent as production
+
+RUN \
+	echo "Installing python dependencies" \
+	&& pip install -r requirements.txt
+
+WORKDIR /home/vcap/app
+
+COPY app app
+COPY wsgi.py gunicorn_config.py Makefile ./
+COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/
 
 ARG CI_NAME
 ARG CI_BUILD_NUMBER

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
 -r requirements.txt
-
-pytest==3.4.0
-pytest-mock==1.6.3
+flake8==3.5.0
+flake8-print==3.1.0
+freezegun==0.3.10
+pytest==3.6.1
+pytest-mock==1.10.0
 pytest-cov==2.5.1
-
 requests-mock==1.4.0
-
 coveralls==1.2.0
-
 jinja2-cli[yaml]==0.6.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,0 @@
--r requirements.txt
-flake8==3.5.0
-flake8-print==3.1.0
-freezegun==0.3.10
-pytest==3.6.1
-pytest-mock==1.10.0


### PR DESCRIPTION
This will allow production images to have less files installed. Currently all the repo is copied to the Docker image and all of the dev/test dependencies, this means there is extra files and packages
which are open to vulnerabilities etc as well as a chance that secrets files etc can get copied. The multi stage build allows a parent image to be produced and then the test and production images to be build off of that which allows for a whitelist of files and directories rather than a copy all in the repo.

* Updated Dockerfile to use a multi stage build
* Updated Makefile to use multi stage build
* Consolidated dev and test requirements files