### PR TITLE
Fixed Jenkins deploy issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,6 +47,8 @@ RUN \
 	echo "Clean up" \
 	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
+WORKDIR /home/vcap/app
+
 # these are declared statically here so that they're cached by the docker image - if we run after the `COPY` command
 # they won't be cached so it'll re-download every time. But these don't involve the filesystem
 COPY requirements.txt .
@@ -60,8 +62,6 @@ COPY requirements-dev.txt .
 RUN \
 	echo "Installing python dependencies" \
 	&& pip install -r requirements-dev.txt
-
-WORKDIR /home/vcap/app
 
 # Copy from the real world, one dir up (project root) into the environment's current working directory
 # Docker will rebuild from here down every time.
@@ -85,8 +85,6 @@ FROM parent as production
 RUN \
 	echo "Installing python dependencies" \
 	&& pip install -r requirements.txt
-
-WORKDIR /home/vcap/app
 
 COPY app app
 COPY wsgi.py gunicorn_config.py Makefile ./


### PR DESCRIPTION
The build on Jenkins was failing because it could not find the requirements.txt files. See https://github.com/moby/moby/issues/36643 for similar explanation. I think it is fixed in later version of docker as I could not replicate locally but this should make it more robust whatever version.

Moved the WORKDIR /home/vcap/app to the parent image and removed any
WORKDIR calls from the children.

* Updated Dockerfile to move WORKDIR calls to the parent