### PR TITLE
Added endpoint for Precompiled CMYK Conversion

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -25,8 +25,10 @@ function display_result {
 if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
+
 flake8 .
 display_result $? 1 "Code style check"
 
-PYTHONPATH=. py.test -vv
-display_result $? 2 "Unit tests"
+## Code coverage
+py.test --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
+display_result $? 4 "Code coverage"


### PR DESCRIPTION
It is not guaranteed that a PDF will be CMYK when received from a service, hecne this endpoint converts the PDF to CYMK. This is so the service does not have to worry about the CYMK conversion and ensures the PDF version is always consistent for the DVLA. 
This may end up being part of an async tasks which converts and adds the NOTIFY tag and validates etc.

Note. Its tricky to validate that the colour space has changed even using conventional tools so validate that the PDF version has changed and as such we know the Ghostscript process has run.

* Added new endpoint
* Added a generic error handler to handle common errors so the the preview.py code is more readable
* Added tests for the new endpoint
* Added test coverage display on test completion.