### PR TITLE
Bump disk quota to 2G

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -4,6 +4,7 @@ applications:
 
   instances: 1
   memory: 1G
+  disk_quota: 2G
 
   buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi


### PR DESCRIPTION
Even newly created instances got their disk to 850MB out of 1GB.