### PR TITLE
Start shipping logs to logit

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -5,6 +5,9 @@ applications:
   instances: 1
   memory: 1G
 
+  services:
+    - logit-ssl-syslog-drain
+
   buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi
 


### PR DESCRIPTION
With @allait we found that the logs from template-preview app are not currently shipped to logit.
This pull request fixes it.