### PR TITLE
Decrease number of workers from 10 to 5

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -2,7 +2,7 @@ import os
 import sys
 import traceback
 
-workers = 10
+workers = 5
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-gunicorn -w 10 -b 0.0.0.0:$1 wsgi
+gunicorn -w 5 -b 0.0.0.0:$1 wsgi


### PR DESCRIPTION
Decrease number of workers from 10 to 5 to reduce memory used per app instance. Each worker uses a maximum of 400MB when loading a png page. So if we have less of them, it is less likely that we will overspend our memory usage (which is being put up to 2GB). Hence it is less likely that a worker would die.

We theoretically could increase memory for our app instead. In practice this would not be an optimum solution, because we have a second bottleneck: our CPU. With 10 workers it reaches 200% CPU when all of them are engaged in loading png pages. Hence, increasing memory would still leave our app struggling, unless we also increase CPU.