### PR TITLE
Increase instance memory size to avoid worker restarts from OOM

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -3,7 +3,7 @@ applications:
 - name: notify-template-preview
 
   instances: 1
-  memory: 1G
+  memory: 2G
   disk_quota: 2G
 
   services:


### PR DESCRIPTION
We had a number of 502s while generating preview PNG files. We've
looked into them with @CrystalPea and found out that gunicorn is
starting new workers when the requests fail, but doesn't log
anything else apart from the worker boot up message. The most
likely explanation for this behaviour is that workers are being
killed by OOM killer when the overall memory usage exceeds the
cgroups limit set by PaaS.

Looking at the gunicorn memory usage we've seen individual processes
spike up to 350MB, so when multiple workers are generating a PNG
preview at the same (which is what happens when a user views a
multi-page letter template) they exceed the PaaS memory limit.