### PR TITLE
Reverse validate flag logic in /precompiled/overlay.png

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -128,7 +128,7 @@ def overlay_template():
 
     file_data = BytesIO(encoded_string)
 
-    validate = request.args.get('validate') in ['false', '0']
+    validate = request.args.get('validate') in ['true', '1']
 
     return send_file(
         filename_or_fp=overlay_template_areas(


### PR DESCRIPTION
`validate=false` should mean we want to generate a preview with a red overlay instead of an empty PDF with pixels in non-printable areas, but was doing the opposite in the existing code.

Since we want this behaviour by default (without any params) we explicitly check for `validate=true` instead of `false`, so when the argument isn't set we get a semi-transparent overlay.