### PR TITLE
Reduce the log level for the boundary check.

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -339,7 +339,7 @@ def _validate_pdf(src_pdf):
 
         for colour in colours:
             if str(colour[1]) != "(255, 255, 255)":
-                current_app.logger.error('Letter exceeds boundaries on page {}'.format(i + 1))
+                current_app.logger.warn('Letter exceeds boundaries on page {}'.format(i + 1))
                 return False
 
     return True


### PR DESCRIPTION
This is just temporary until our client has updated their letters.