### PR TITLE
allow content on the right hand side of precompiled pdfs

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -213,16 +213,17 @@ def _add_no_print_areas(src_pdf, overlay=False):
     packet = BytesIO()
     can = canvas.Canvas(packet, pagesize=A4)
 
-    red_transparent = Color(100, 0, 0, alpha=0.2)
-    can.setStrokeColor(white)
-    can.setFillColor(white)
+    page_height = float(page.mediaBox.getHeight())
+    page_width = float(page.mediaBox.getWidth())
 
-    if overlay:
-        can.setStrokeColor(red_transparent)
-        can.setFillColor(red_transparent)
-        width = float(page.mediaBox[2]) - ((BORDER_FROM_LEFT_OF_PAGE + BORDER_FROM_RIGHT_OF_PAGE) * mm)
-    else:
-        width = float(page.mediaBox[2]) - (BORDER_FROM_LEFT_OF_PAGE * mm)
+    red_transparent = Color(100, 0, 0, alpha=0.2)
+
+    colour = red_transparent if overlay else white
+
+    can.setStrokeColor(colour)
+    can.setFillColor(colour)
+
+    width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm)
 
     # Overlay the blanks where the service can print as per the template
     # The first page is more varied because of address blocks etc subsequent pages are more simple
@@ -231,36 +232,29 @@ def _add_no_print_areas(src_pdf, overlay=False):
     x = BORDER_FROM_LEFT_OF_PAGE * mm
     y = BORDER_FROM_BOTTOM_OF_PAGE * mm
 
-    height = float(page.mediaBox[3]) - ((BODY_TOP_FROM_TOP_OF_PAGE + BORDER_FROM_BOTTOM_OF_PAGE) * mm)
+    height = page_height - ((BODY_TOP_FROM_TOP_OF_PAGE + BORDER_FROM_BOTTOM_OF_PAGE) * mm)
     can.rect(x, y, width, height, fill=True, stroke=False)
 
     # Service address block
     x = SERVICE_ADDRESS_FROM_LEFT_OF_PAGE * mm
-    y = float(page.mediaBox[3]) - (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
-    if overlay:
-        service_address_width = float(page.mediaBox[2]) - ((SERVICE_ADDRESS_FROM_LEFT_OF_PAGE +
-                                                            BORDER_FROM_RIGHT_OF_PAGE) * mm)
-    else:
-        service_address_width = float(page.mediaBox[2]) - (SERVICE_ADDRESS_FROM_LEFT_OF_PAGE * mm)
+    y = page_height - (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
+
+    service_address_width = page_width - (SERVICE_ADDRESS_FROM_LEFT_OF_PAGE * mm)
+
     height = (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE - BORDER_FROM_TOP_OF_PAGE) * mm
     can.rect(x, y, service_address_width, height, fill=True, stroke=False)
 
     # Service Logo Block
     x = LOGO_BOTTOM_FROM_LEFT_OF_PAGE * mm
-    y = float(page.mediaBox[3]) - (LOGO_BOTTOM_FROM_TOP_OF_PAGE * mm)
+    y = page_height - (LOGO_BOTTOM_FROM_TOP_OF_PAGE * mm)
     height = (LOGO_BOTTOM_FROM_TOP_OF_PAGE - LOGO_TOP_FROM_TOP_OF_PAGE) * mm
     can.rect(x, y, width, height, fill=True, stroke=False)
 
     # Citizen Address Block
     x = ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm
-    y = float(page.mediaBox[3]) - (ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
+    y = page_height - (ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
 
-    if overlay:
-        address_block_width = float(page.mediaBox[2]) - (
-            (ADDRESS_LEFT_FROM_LEFT_OF_PAGE + BORDER_FROM_RIGHT_OF_PAGE) * mm
-        )
-    else:
-        address_block_width = float(page.mediaBox[2]) - (ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm)
+    address_block_width = page_width - (ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm)
 
     height = (ADDRESS_BOTTOM_FROM_TOP_OF_PAGE - ADDRESS_TOP_FROM_TOP_OF_PAGE) * mm
     can.rect(x, y, address_block_width, height, fill=True, stroke=False)
@@ -277,19 +271,21 @@ def _add_no_print_areas(src_pdf, overlay=False):
     # For each subsequent page its just the body of text
     for page_num in range(1, pdf.numPages):
         page = pdf.getPage(page_num)
+
+        page_height = float(page.mediaBox.getHeight())
+        page_width = float(page.mediaBox.getWidth())
+
         packet = BytesIO()
         can = canvas.Canvas(packet, pagesize=A4)
-        can.setStrokeColor(white)
-        can.setFillColor(white)
 
-        if overlay:
-            can.setStrokeColor(red_transparent)
-            can.setFillColor(red_transparent)
+        can.setStrokeColor(colour)
+        can.setFillColor(colour)
 
         # Each page of content
         x = BORDER_FROM_LEFT_OF_PAGE * mm
         y = BORDER_FROM_BOTTOM_OF_PAGE * mm
-        height = float(page.mediaBox[3]) - ((BORDER_FROM_TOP_OF_PAGE + BORDER_FROM_BOTTOM_OF_PAGE) * mm)
+        height = page_height - ((BORDER_FROM_TOP_OF_PAGE + BORDER_FROM_BOTTOM_OF_PAGE) * mm)
+        width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm)
         can.rect(x, y, width, height, fill=True, stroke=False)
         can.save()
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -267,7 +267,22 @@ def test_validate_document_blank_multi_page():
     assert validate_document(packet)
 
 
-def test_validate_document_black_bottom_corner_second_page():
+@pytest.mark.parametrize('x, y, result', [
+    # four corners
+    (0, 0, False),
+    (0, 830, False),
+    (590, 0, False),
+    (590, 830, False),
+
+    # middle of page
+    (200, 400, True),
+
+    # middle of right margin is okay
+    (590, 400, True),
+    # middle of left margin is not okay
+    (0, 400, False)
+])
+def test_validate_document_second_page(x, y, result):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -279,11 +294,13 @@ def test_validate_document_black_bottom_corner_second_page():
     cv.rect(0, 0, 1000, 1000, stroke=1, fill=1)
     cv.setStrokeColor(black)
     cv.setFillColor(black)
-    cv.rect(0, 0, 10, 10, stroke=1, fill=1)
+
+    cv.rect(x, y, 5, 5, stroke=1, fill=1)
+
     cv.save()
     packet.seek(0)
 
-    assert validate_document(packet) is False
+    assert validate_document(packet) is result
 
 
 @pytest.mark.parametrize('x, y, page, result', [


### PR DESCRIPTION
we have already succesfully processed precompiled pdfs with content on
the right - turns out DVLA don't care about it as much as they care
about the other margins. This commit removes the right hand border.

It also does some refactoring to make the pink overlay.png and the
validation endpoint more similar, and renames some variable names for clarity
