### PR TITLE
Precompiled validate with preview

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -124,7 +124,7 @@ def validate_pdf_document():
     else:
         data['message'] = 'Your PDF passed the layout check'
         file_data = rewrite_address_block(BytesIO(encoded_string))
-        pages = pngs_from_pdf(file_data, overlay=True)
+        pages = pngs_from_pdf(file_data)
 
     data['pages'] = [
         base64.b64encode(page.read()).decode('ascii') for page in pages

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -105,7 +105,7 @@ def add_tag_to_precompiled_letter():
 @statsd(namespace="template_preview")
 def validate_pdf_document():
     encoded_string = request.get_data()
-    generate_preview_pngs = request.args.get('include_preview') in ['true', '1']
+    generate_preview_pngs = request.args.get('include_preview') in ['true', 'True', '1']
 
     if not encoded_string:
         abort(400)

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -1,9 +1,10 @@
+import base64
 import subprocess
 from io import BytesIO
 
 from PIL import ImageFont
 from PyPDF2 import PdfFileWriter, PdfFileReader
-from flask import request, abort, send_file, Blueprint, json, current_app
+from flask import request, abort, send_file, Blueprint, jsonify, current_app
 from notifications_utils.statsd_decorators import statsd
 from pdf2image import convert_from_bytes
 from reportlab.lib.colors import white, black, Color
@@ -14,7 +15,7 @@ from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen import canvas
 
 from app import auth, InvalidRequest
-from app.preview import png_from_pdf
+from app.preview import png_from_pdf, pngs_from_pdf
 from app.transformation import convert_pdf_to_cmyk, does_pdf_contain_cmyk, does_pdf_contain_rgb
 
 NOTIFY_TAG_FROM_TOP_OF_PAGE = 4.3
@@ -104,17 +105,32 @@ def add_tag_to_precompiled_letter():
 @statsd(namespace="template_preview")
 def validate_pdf_document():
     encoded_string = request.get_data()
+    generate_preview_pngs = request.args.get('include_preview') in ['true', '1']
 
     if not encoded_string:
         abort(400)
 
-    file_data = BytesIO(encoded_string)
+    data = {
+        'result': validate_document(BytesIO(encoded_string)),
+    }
 
-    data = json.dumps({
-        'result': validate_document(file_data),
-    })
+    if not generate_preview_pngs:
+        return jsonify(data)
 
-    return data
+    if not data['result']:
+        data['message'] = 'Content in this PDF is outside the printable area'
+        pages = overlay_template_areas(BytesIO(encoded_string), overlay=True)
+
+    else:
+        data['message'] = 'Your PDF passed the layout check'
+        file_data = rewrite_address_block(BytesIO(encoded_string))
+        pages = pngs_from_pdf(file_data, overlay=True)
+
+    data['pages'] = [
+        base64.b64encode(page.read()).decode('ascii') for page in pages
+    ]
+
+    return jsonify(data)
 
 
 @precompiled_blueprint.route("/precompiled/overlay.png", methods=['POST'])
@@ -189,8 +205,10 @@ def add_notify_tag_to_letter(src_pdf):
     return pdf_bytes
 
 
-def overlay_template_areas(src_pdf, page_number, overlay=True):
+def overlay_template_areas(src_pdf, page_number=None, overlay=True):
     pdf = _add_no_print_areas(src_pdf, overlay=overlay)
+    if page_number is None:
+        return pngs_from_pdf(pdf)
     return png_from_pdf(pdf, page_number)
 
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -55,6 +55,27 @@ def png_from_pdf(data, page_number, hide_notify=False):
     return output
 
 
+def pngs_from_pdf(data):
+    pages = []
+    with Image(blob=data, resolution=150) as pdf:
+        pdf_width, pdf_height = pdf.width, pdf.height
+        pdf_colorspace = pdf.colorspace
+        for page in pdf.sequence:
+            output = BytesIO()
+            with Image(width=pdf_width, height=pdf_height) as image:
+                if pdf_colorspace == 'cmyk':
+                    image.transform_colorspace('cmyk')
+
+                image.composite(page, top=0, left=0)
+
+                converted = image.convert('png')
+                converted.save(file=output)
+                output.seek(0)
+                pages.append(output)
+
+    return pages
+
+
 @statsd(namespace="template_preview")
 def get_logo(dvla_org_id):
     try:

--- a/app/preview.py
+++ b/app/preview.py
@@ -66,8 +66,8 @@ def _generate_png_page(pdf_page, pdf_width, pdf_height, pdf_colorspace, hide_not
         image.composite(pdf_page, top=0, left=0)
         if hide_notify:
             hide_notify_tag(image)
-        converted = image.convert('png')
-        converted.save(file=output)
+        with image.convert('png') as converted:
+            converted.save(file=output)
     output.seek(0)
     return output
 


### PR DESCRIPTION
For the new admin endpoint to validate boundaries of pre-compiled
letter PDFs we need to display all PNG pages and any validation
errors on one page. In order to avoid storing the PDF and making
multiple separate requests to template-preview we add a new flag
to the validate route that returns base64-encoded PNG images of
all PDF pages that could be included into the admin app page using
data-uris.

As a part of this we:
- added a preview flag to validate precompiled endpoint
- with flag, it returns preview pngs, with overlay if
validation failed, and without overlay otherwise
- upgraded overlay_template_areas to handle multiple pages pdf
- created pdf_to_pngs function that converts multiple-pages
pdf to pngs and returns a list of png pages

Pivotal ticket: https://www.pivotaltracker.com/story/show/159697071