### PR TITLE
Raise gunicorn timeout to 120 seconds

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -3,6 +3,7 @@ import sys
 import traceback
 
 workers = 5
+timeout = 120
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 


### PR DESCRIPTION
By default gunicorn will terminate any sync workers that don't respond
to a request within 30 seconds. This is mostly used to protect the
service from slow connections, expensive or locked requests tying
up all available workers. This is also a reasonable timeout for a
user request, since the connection is likely to be closed by then.

For template preview however, since generating a response requires
a lot of processing, a spike of incoming requests results in a lot
of timeouts even when many instances are available (5 workers on
an instance processing 5 simultaneous requests will spike the CPU
to 400%). Most of these requests come from API workers, so when they
fail, the task is retried after a delay. But the 502s from restarted
workers trigger our alerts and there's no easy way to separate them
from the service outage.

Raising the timeout to 120s gives template preview enough time to
generate responses under high load. This potentially slows down the
queue workers, since they have to wait longer for the response, which
might affect other tasks that use the same workers. Additionally,
since gunicorn doesn't recycle workers anymore, the overall memory
usage increases and under prolonged load some of the workers get
killed by OOM. It's not clear whether this is due to a memory leak
or Python VM not freeing memory in time, so I'm still investigating
if there's a way to fix this. Alternatively, gunicorn can be configured
to restart workers after a certain number of requests.