### PR TITLE
Add filename to preview_schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -27,6 +27,7 @@ preview_schema = {
             "required": ["subject", "content"]
         },
         "dvla_org_id": {"type": "string"},
+        "filename": {"type": ["string", "null"]},
         "date": {"type": ["string", "null"]},
     },
     "required": ["letter_contact_block", "template", "values", "dvla_org_id"],


### PR DESCRIPTION
Added an optional field, `filename`, to the preview_schema. This will
replace `dvla_org_id` eventually, so is optional initially to allow both
fields to be sent through from notifications-api and notifications-admin.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)