### PR TITLE
Disable address rewrite and restore right printable area margin 

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -258,7 +258,7 @@ def _add_no_print_areas(src_pdf, overlay=False):
     can.setStrokeColor(colour)
     can.setFillColor(colour)
 
-    width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm)
+    width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm + BORDER_FROM_RIGHT_OF_PAGE * mm)
 
     # Overlay the blanks where the service can print as per the template
     # The first page is more varied because of address blocks etc subsequent pages are more simple
@@ -274,7 +274,7 @@ def _add_no_print_areas(src_pdf, overlay=False):
     x = SERVICE_ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm
     y = page_height - (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
 
-    service_address_width = page_width - (SERVICE_ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm)
+    service_address_width = page_width - (SERVICE_ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm + BORDER_FROM_RIGHT_OF_PAGE * mm)
 
     height = (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE - BORDER_FROM_TOP_OF_PAGE) * mm
     can.rect(x, y, service_address_width, height, fill=True, stroke=False)
@@ -319,7 +319,7 @@ def _add_no_print_areas(src_pdf, overlay=False):
         x = BORDER_FROM_LEFT_OF_PAGE * mm
         y = BORDER_FROM_BOTTOM_OF_PAGE * mm
         height = page_height - ((BORDER_FROM_TOP_OF_PAGE + BORDER_FROM_BOTTOM_OF_PAGE) * mm)
-        width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm)
+        width = page_width - (BORDER_FROM_LEFT_OF_PAGE * mm + BORDER_FROM_RIGHT_OF_PAGE * mm)
         can.rect(x, y, width, height, fill=True, stroke=False)
         can.save()
 

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -87,7 +87,9 @@ def sanitise_precompiled_letter():
     if not is_notify_tag_present(file_data):
         file_data = add_notify_tag_to_letter(file_data)
 
-    file_data = rewrite_address_block(file_data)
+    # TODO Address validation is disabled until we have more confidence it does the right thing
+    # file_data = rewrite_address_block(file_data)
+
     return send_file(filename_or_fp=file_data, mimetype='application/pdf')
 
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -371,8 +371,8 @@ def test_get_invalid_pages_blank_multi_page():
     # middle of page
     (200, 400, []),
 
-    # middle of right margin is okay
-    (590, 400, []),
+    # middle of right margin is not okay
+    (590, 400, [2]),
     # middle of left margin is not okay
     (0, 400, [2])
 ])
@@ -405,7 +405,7 @@ def test_get_invalid_pages_second_page(x, y, result):
     (0, 830, 1, [1]),
     (200, 0, 1, [1]),
     (590, 0, 1, [1]),
-    (590, 200, 1, []),
+    (590, 200, 1, [1]),
     (24.6 * mm, (297 - 90) * mm, 1, [1]),  # under the citizen address block
     (24.6 * mm, (297 - 90) * mm, 2, []),  # Same place on page 2 should be ok
     (24.6 * mm, (297 - 39) * mm, 1, [1]),  # under the logo
@@ -417,7 +417,7 @@ def test_get_invalid_pages_second_page(x, y, result):
     (0, 830, 2, [2]),
     (200, 0, 2, [2]),
     (590, 0, 2, [2]),
-    (590, 200, 2, []),
+    (590, 200, 2, [2]),
 ])
 def test_get_invalid_pages_black_text(x, y, page, result):
     packet = io.BytesIO()


### PR DESCRIPTION
### Disable address rewrite for pre-compiled letters

We don't know whether address rewriting produces the expected result on actual pre-compiled letters since we don't have enough example letters to check that it doesn't break the address block on different PDFs. We're disabling it for now with the intention to turn it back on once we've manually checked it's parsing the correct address from the variety of letter templates.

### Restore right printable area margin

Adds back the right border to the pre-compiled PDF overlay. While anything in the right margin can still be printed correctly we want to enforce since it results in better formatted pre-compiled letters.
