### PR TITLE
Restart gunicorn workers to avoid memory leaks

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -6,6 +6,8 @@ workers = 5
 errorlog = "/home/vcap/logs/gunicorn_error.log"
 bind = "0.0.0.0:{}".format(os.getenv("PORT"))
 
+max_requests = 10
+
 
 def on_starting(server):
     server.log.info("Starting Notifications template preview")


### PR DESCRIPTION
After raising the request timeouts gunicorn workers start consuming
more memory under sustained high load, eventually resulting in OOM
killing a random worker and interrupting a request.

It's unclear whether this is caused by python VM not managing to
free up memory in time or a memory leak somewhere in our code or
one of the compiled libraries we use to process PDF and PNG files.

It's worth digging into this a bit more at some point, but it's
currently complicated by the fact that we are using different tools
for similar tasks, any of which could be causing the problem.

As a quick fix setting `max_requests` makes gunicorn restart the
worker process after it has handled Nth request. This slows down
the next request (by around 300ms, which in case of template
preview is not a big difference) but keeps memory usage from
reaching the instance limit.