### PR TITLE
Build latest versions of ghostscript and poppler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ CF_HOME ?= ${HOME}
 $(eval export CF_HOME)
 CF_SPACE ?= sandbox
 
-DOCKER_IMAGE = govuknotify/notifications-template-preview
+DOCKER_IMAGE = govuknotifyorg/notifications-template-preview
 DOCKER_IMAGE_TAG = $(shell git describe --always --dirty)
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 DOCKER_TTY ?= $(if ${JENKINS_HOME},,t)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ DATE = $(shell date +%Y-%m-%dT%H:%M:%S)
 
 APP_VERSION_FILE = app/version.py
 
-GIT_BRANCH ?= $(shell git symbolic-ref --short HEAD 2> /dev/null || echo "detached")
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || cat commit || echo "")
 
 BUILD_TAG ?= notifications-template-preview-manual
@@ -30,7 +29,7 @@ $(eval export CF_HOME)
 CF_SPACE ?= sandbox
 
 DOCKER_IMAGE = govuknotify/notifications-template-preview
-DOCKER_IMAGE_TAG = ${CF_SPACE}
+DOCKER_IMAGE_TAG = $(shell git describe --always --dirty)
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 DOCKER_TTY ?= $(if ${JENKINS_HOME},,t)
 
@@ -123,13 +122,11 @@ run-with-docker: prepare-docker-build-image ## Build inside a Docker container
 
 .PHONY: test-with-docker
 # always run tests against the sandbox image
-test-with-docker: export DOCKER_IMAGE_TAG = sandbox
 test-with-docker: prepare-docker-test-build-image ## Run tests inside a Docker container
 	$(call run_docker_container,test, make _test)
 
 .PHONY: single-test-with-docker
 # always run tests against the sandbox image
-single-test-with-docker: export DOCKER_IMAGE_TAG = sandbox
 single-test-with-docker: prepare-docker-test-build-image ## Run single test inside a Docker container, make single-test-with-docker test_name=<test name>
 	$(call run_docker_container,test, make _single_test test_name=${test_name})
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim as parent
+FROM python:3.6-slim-stretch as parent
 
 ARG http_proxy
 ARG https_proxy
@@ -7,49 +7,45 @@ ARG NO_PROXY
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN \
-	echo "Install base packages" \
-	&& ([ -z "$http_proxy" ] || echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/99HttpProxy) \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		apt-transport-https \
-		make \
-		curl \
-		git \
-		build-essential \
-		libffi-dev \
-		wget \
-		cabextract \
-		jq
+RUN ([ -z "$http_proxy" ] || echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/99HttpProxy)
+RUN echo "Install base packages" && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        make \
+        cmake \
+        curl \
+        git \
+        build-essential \
+        libffi-dev \
+        wget \
+        cabextract \
+        jq \
+        procps \
+    && echo "Install binary app dependencies" \
+    && apt-get install -y --no-install-recommends \
+        libpango1.0-dev \
+        libmagickwand-dev \
+        imagemagick \
+        xfonts-utils \
+        gsfonts \
+        libcairo2=1.14.8-1 \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
-RUN \
-	echo "Install binary app dependencies" \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
-		libpango1.0-dev \
-		libmagickwand-dev \
-		imagemagick \
-		xfonts-utils \
-		gsfonts \
-		poppler-utils
+# Compile a specified version of ghostscript
+ARG GS_VERSION=9.25
+RUN wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$(echo $GS_VERSION | tr -d '.' )/ghostscript-${GS_VERSION}.tar.gz \
+    && tar xvf ghostscript-${GS_VERSION}.tar.gz \
+    && cd ghostscript-${GS_VERSION} && ./configure && make install \
+    && cd .. && rm -rf ghostscript-*
 
-RUN echo "Install libcairo2 from stretch" \
-	&& echo 'APT::Default-Release "jessie";' > /etc/apt/apt.conf \
-	&& mv /etc/apt/sources.list /etc/apt/sources.list.d/jessie.list \
-	&& echo "deb http://deb.debian.org/debian stretch main" \
-		> /etc/apt/sources.list.d/stretch.list
+ARG POPPLER_VERSION=0.69.0
+RUN wget https://poppler.freedesktop.org/poppler-${POPPLER_VERSION}.tar.xz \
+    && tar xvf poppler-${POPPLER_VERSION}.tar.xz \
+    && cd poppler-${POPPLER_VERSION} && mkdir build && cd build \
+    && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make && make install \
+    && cd ../.. && rm -rf poppler-*
 
-RUN \
- 	echo "installing a couple of bits from stretch" \
-	&& apt-get -y update \
-	&& apt-get -t stretch install -y \
-	  libcairo2=1.14.8-1 \
-	  ghostscript
-RUN apt-get -y clean
-
-RUN \
-	echo "Clean up" \
-	&& rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY docker/Arial.ttf /usr/share/fonts/truetype/msttcorefonts/
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -9,7 +9,6 @@ applications:
   services:
     - logit-ssl-syslog-drain
 
-  buildpack: python_buildpack
   command: scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi
 
   routes:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -26,9 +26,9 @@ if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
 
-flake8 .
-display_result $? 1 "Code style check"
-
-## Code coverage
 py.test --maxfail=10 --cov=app --cov-report=term-missing tests/ --junitxml=test_results.xml --strict
 display_result $? 4 "Code coverage"
+
+## Code coverage
+flake8 .
+display_result $? 1 "Code style check"


### PR DESCRIPTION
### Use git commit SHA as the Docker image tag

Due to how CloudFoundry stages docker containers deployed apps will scale using the latest container version tagged with a given tag.

This means that Docker tags need to be immutable in order to avoid accidentally starting up instances with a failed release code.

Changing the image tag to use a short git commit SHA (and a `-dirty` suffix for builds with uncommitted changes) makes sure that each release gets it's own separate tag, which makes it easier to rollback and deploy the app locally.

### Move docker image to a Docker Hub organization

govuknotify is a user account that is used by Jenkins to push images to Docker Hub.

Switching images to an organization allows us to give permissions to push containers from dev machines without having to switch to Jenkins user credentials.

Jenkins user account is an owner of the organization, so it should be able to push images without any changes to our CI configuration.

### Switch the order of tests and code style check

Running flake8 before running tests makes it harder to try experimental changes since it requires all code to be properly formatted right away.

### Remove buildpack from PaaS manifest

Buildpacks aren't used for docker deployments to CF. While cf-cli used to ignore them in the past newer versions seem to treat it as an error and fail the release.

### Build latest versions of ghostscript and poppler

Upgrading gs to 9.25 solves the problem with RGB-to-CMYK pre-compiled PDF conversion creating an invalid PDF on some files.

We're running into a number of issues with our PDF/PNG generation related to version of the underlying tools we're using. Relying on system packages makes it hard to upgrade/downgrade these tools to a specific version since there's usually only one available in the system's package repository.

As a partial workaround for this we used to use a mix of Debian Jessie and Stretch repositories to install package versions that were close enough to what we wanted. This approach still left us with few choices of available versions (most of them not up-to-date) and made apt hard to work with (since it now required explicitly choosing the Debian release).

Instead, this switches our base container to the latest stable Debian release (Stretch) and compiles the required versions of the tools we rely on after installing all the build dependencies.

This increases the time it takes to build the container from scratch and can potentially lead to conflicts with system packages (but this hopefully shouldn't be a big problem since not a lot of things rely on pdf libraries), but it gives us direct control over gs/poppler versions.
