### PR TITLE
Use letter filename if available instead of dvla_org_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ curl \
     },
     "values": null,
     "letter_contact_block": "baz",
-    "dvla_org_id": "001"
+    "filename": "hm-government"
   }'
   http://localhost:6013/preview.pdf
 ```

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -27,9 +27,9 @@ preview_schema = {
             "required": ["subject", "content"]
         },
         "dvla_org_id": {"type": ["string", "null"]},
-        "filename": {"type": ["string", "null"]},
+        "filename": {"type": "string"},
         "date": {"type": ["string", "null"]},
     },
-    "required": ["letter_contact_block", "template", "values"],
+    "required": ["letter_contact_block", "template", "values", "filename"],
     "additionalProperties": False,
 }

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -26,10 +26,10 @@ preview_schema = {
             },
             "required": ["subject", "content"]
         },
-        "dvla_org_id": {"type": "string"},
+        "dvla_org_id": {"type": ["string", "null"]},
         "filename": {"type": ["string", "null"]},
         "date": {"type": ["string", "null"]},
     },
-    "required": ["letter_contact_block", "template", "values", "dvla_org_id"],
+    "required": ["letter_contact_block", "template", "values"],
     "additionalProperties": False,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def preview_post_body():
             'version': 1
         },
         'values': {'placeholder': 'abc'},
-        'dvla_org_id': '001',
+        'filename': 'hm-government',
     }
 
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -264,7 +264,7 @@ def test_precompiled_endpoint_incorrect_data(client, auth_header):
                 'content': ' letter content',
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',
@@ -478,7 +478,7 @@ def test_precompiled_validation_endpoint_incorrect_data(client, auth_header):
                 'content': ' letter content',
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',
@@ -529,7 +529,7 @@ def test_overlay_endpoint_incorrect_data(client, auth_header):
                 'content': ' letter content',
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -13,7 +13,7 @@ import pytest
 
 from notifications_utils.s3 import S3ObjectNotFound
 
-from app.preview import get_logo
+from app.preview import get_logo, get_logo_from_filename
 from app.transformation import Logo
 from werkzeug.exceptions import BadRequest
 
@@ -225,7 +225,7 @@ def test_get_image_by_page(
                 'version': 1
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',
@@ -257,19 +257,10 @@ def test_invalid_filetype_404s(view_letter_template):
 
 
 @pytest.mark.parametrize('missing_item', {
-    'letter_contact_block', 'values', 'template', 'dvla_org_id'
+    'letter_contact_block', 'values', 'template'
 })
 def test_missing_field_400s(view_letter_template, preview_post_body, missing_item):
     preview_post_body.pop(missing_item)
-
-    resp = view_letter_template(data=preview_post_body)
-
-    assert resp.status_code == 400
-
-
-def test_bad_org_id_400s(view_letter_template, preview_post_body):
-
-    preview_post_body.update({'dvla_org_id': '404'})
 
     resp = view_letter_template(data=preview_post_body)
 
@@ -321,7 +312,7 @@ def test_page_count(
                 'version': 1
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',
@@ -356,7 +347,7 @@ def test_page_count_from_cache(
                 'content': ' letter content',
             },
             'values': {},
-            'dvla_org_id': '001',
+            'filename': 'hm-government',
         }),
         headers={
             'Content-type': 'application/json',
@@ -390,6 +381,12 @@ def test_print_letter_returns_200(print_letter_template):
 ])
 def test_getting_logos(client, dvla_org_id, expected_filename):
     assert get_logo(dvla_org_id).raster == expected_filename
+
+
+def test_getting_logos_by_filename():
+    logo = get_logo_from_filename('my_file_name')
+
+    assert type(logo) == Logo
 
 
 def test_logo_class():

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -257,7 +257,7 @@ def test_invalid_filetype_404s(view_letter_template):
 
 
 @pytest.mark.parametrize('missing_item', {
-    'letter_contact_block', 'values', 'template'
+    'letter_contact_block', 'values', 'template', 'filename'
 })
 def test_missing_field_400s(view_letter_template, preview_post_body, missing_item):
     preview_post_body.pop(missing_item)


### PR DESCRIPTION
In the preview_schema, dvla_org_id is now optional instead of required.

For POST endpoints which were expecting to receive the dvla_org_id we
now check for a letter filename in the data first and only use the
dvla_org_id if a filename is not provided. notifications-api and
notifications-admin are already passing the filename through, so this
commit ensures that we now start using this value.

[Pivotal story](https://www.pivotaltracker.com/story/show/159991865)