### PR TITLE
Remove letter org ids and filenames

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,40 +14,10 @@ from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.s3 import s3upload, s3download, S3ObjectNotFound
 
 from app import version  # noqa
-from app.transformation import Logo
-
-
-LOGOS = {
-    '001': Logo('hm-government'),
-    '002': Logo('opg'),
-    '003': Logo('dwp'),
-    '004': Logo('geo'),
-    '005': Logo('ch'),
-    '006': Logo('dwp-welsh'),
-    '007': Logo('dept-for-communities'),
-    '008': Logo('mmo'),
-    '009': Logo('hmpo'),
-    '500': Logo('hm-land-registry'),
-    '501': Logo('ea'),
-    '502': Logo('wra'),
-    '503': Logo('eryc'),
-    '504': Logo('rother'),
-    '505': Logo('cadw'),
-    '506': Logo('twfrs'),
-    '507': Logo('thames-valley-police'),
-    '508': Logo('ofgem'),
-    '509': Logo('hackney'),
-    '510': Logo('pension-wise'),
-    '511': Logo('nhs'),
-    '512': Logo('vale-of-glamorgan'),
-    '513': Logo('wdc'),
-    '514': Logo('brighton-hove'),
-}
 
 
 def load_config(application):
     application.config['API_KEY'] = os.environ['TEMPLATE_PREVIEW_API_KEY']
-    application.config['LOGOS'] = LOGOS
     application.config['NOTIFY_ENVIRONMENT'] = os.environ['NOTIFY_ENVIRONMENT']
     application.config['NOTIFY_APP_NAME'] = 'template-preview'
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -274,45 +274,6 @@ def print_letter_template():
     return response
 
 
-@preview_blueprint.route("/logos.pdf", methods=['GET'])
-# No auth on this endpoint to make debugging easier
-@statsd(namespace="template_preview")
-def print_logo_sheet():
-
-    html = HTML(string="""
-        <html>
-            <head>
-            </head>
-            <body>
-                <h1>All letter logos</h1>
-                {}
-            </body>
-        </html>
-    """.format('\n<br><br>'.join(
-        '<img src="/static/images/letter-template/{}" width="100%">'.format(logo.vector)
-        for org_id, logo in current_app.config['LOGOS'].items()
-    )))
-
-    pdf = html.write_pdf()
-    cmyk_pdf = convert_pdf_to_cmyk(pdf)
-
-    return send_file(
-        BytesIO(cmyk_pdf),
-        as_attachment=True,
-        attachment_filename='print.pdf'
-    )
-
-
-@preview_blueprint.route("/logos.json", methods=['GET'])
-@auth.login_required
-@statsd(namespace="template_preview")
-def get_available_logos():
-    return jsonify({
-        key: logo.raster
-        for key, logo in current_app.config['LOGOS'].items()
-    })
-
-
 @preview_blueprint.route("/convert.pdf", methods=['POST'])
 @auth.login_required
 @statsd(namespace="template_preview")

--- a/app/preview.py
+++ b/app/preview.py
@@ -72,14 +72,6 @@ def _generate_png_page(pdf_page, pdf_width, pdf_height, pdf_colorspace, hide_not
     return output
 
 
-@statsd(namespace="template_preview")
-def get_logo(dvla_org_id):
-    try:
-        return current_app.config['LOGOS'][dvla_org_id]
-    except KeyError:
-        abort(400)
-
-
 def get_logo_from_filename(filename):
     return Logo(filename)
 
@@ -148,10 +140,7 @@ def view_letter_template(filetype):
 
 
 def get_html(json):
-    if json.get('filename'):
-        logo = get_logo_from_filename(json['filename'])
-    else:
-        logo = get_logo(json['dvla_org_id'])
+    logo = get_logo_from_filename(json['filename'])
 
     return str(LetterPreviewTemplate(
         json['template'],
@@ -244,12 +233,7 @@ def print_letter_template():
     """
     json = get_and_validate_json_from_request(request, preview_schema)
 
-    if json.get('filename'):
-        logo = get_logo_from_filename(json['filename'])
-    else:
-        logo = get_logo(json['dvla_org_id'])
-
-    logo = logo.vector
+    logo = get_logo_from_filename(json['filename'])
 
     template = LetterPrintTemplate(
         json['template'],
@@ -257,7 +241,7 @@ def print_letter_template():
         contact_block=json['letter_contact_block'],
         # letter assets are hosted on s3
         admin_base_url=current_app.config['LETTER_LOGO_URL'],
-        logo_file_name=logo,
+        logo_file_name=logo.vector,
     )
     html = HTML(string=str(template))
     pdf = html.write_pdf()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -26,7 +26,6 @@ preview_schema = {
             },
             "required": ["subject", "content"]
         },
-        "dvla_org_id": {"type": ["string", "null"]},
         "filename": {"type": "string"},
         "date": {"type": ["string", "null"]},
     },

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -13,9 +13,8 @@ import pytest
 
 from notifications_utils.s3 import S3ObjectNotFound
 
-from app.preview import get_logo, get_logo_from_filename
+from app.preview import get_logo_from_filename
 from app.transformation import Logo
-from werkzeug.exceptions import BadRequest
 
 from tests.pdf_consts import one_page_pdf, multi_page_pdf, not_pdf
 from tests.conftest import set_config
@@ -367,20 +366,6 @@ def test_print_letter_returns_200(print_letter_template):
     assert resp.headers['Content-Type'] == 'application/pdf'
     assert resp.headers['X-pdf-page-count'] == '1'
     assert len(resp.get_data()) > 0
-
-
-@pytest.mark.parametrize('dvla_org_id, expected_filename', [
-    ('001', 'hm-government.png'),
-    ('002', 'opg.png'),
-    ('003', 'dwp.png'),
-    ('004', 'geo.png'),
-    ('005', 'ch.png'),
-    ('500', 'hm-land-registry.png'),
-    pytest.param(500, 'strings_only.png', marks=pytest.mark.xfail(raises=BadRequest)),
-    pytest.param('999', 'doesnt_exist.png', marks=pytest.mark.xfail(raises=BadRequest)),
-])
-def test_getting_logos(client, dvla_org_id, expected_filename):
-    assert get_logo(dvla_org_id).raster == expected_filename
 
 
 def test_getting_logos_by_filename():


### PR DESCRIPTION
We now store the letter logo filename in the database and are also
including the filename in POST requests to template-preview. This means
that we don't need to get the store the list of filenames and org ids
here.

Also deleted two unused endpoints.