### PR TITLE
Restore PaaS artifact make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD 2> /dev/null || cat commit || echo "")
 BUILD_TAG ?= notifications-template-preview-manual
 BUILD_NUMBER ?= $(shell git describe --always --dirty)
 BUILD_URL ?= manual
+DEPLOY_BUILD_NUMBER ?= ${BUILD_NUMBER}
 
 TEMPLATE_PREVIEW_API_KEY ?= "my-secret-key"
 
@@ -28,14 +29,7 @@ $(eval export CF_HOME)
 CF_SPACE ?= sandbox
 
 DOCKER_IMAGE = govuknotifyorg/notifications-template-preview
-
-# When promoting a build, use the original job build number
-# Otherwise use either the CI build number or the git commit SHA
-ifdef DEPLOY_BUILD_NUMBER
-    DOCKER_IMAGE_TAG = ${DEPLOY_BUILD_NUMBER}
-else
-    DOCKER_IMAGE_TAG = ${BUILD_NUMBER}
-endif
+DOCKER_IMAGE_TAG = ${DEPLOY_BUILD_NUMBER}
 
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 DOCKER_TTY ?= $(if ${JENKINS_HOME},,t)
@@ -212,3 +206,17 @@ cf-rollback: ## Rollbacks the app to the previous release
 	@[ $$(cf curl /v2/apps/`cf app --guid ${NOTIFY_APP_NAME}-rollback` | jq -r ".entity.state") = "STARTED" ] || (echo "Error: rollback is not possible because ${NOTIFY_APP_NAME}-rollback is not in a started state" && exit 1)
 	cf delete -f ${NOTIFY_APP_NAME} || true
 	cf rename ${NOTIFY_APP_NAME}-rollback ${NOTIFY_APP_NAME}
+
+.PHONY: build-paas-artifact
+build-paas-artifact: ## Build the deploy artifact for PaaS
+	rm -rf target
+	mkdir -p target
+	$(if ${GIT_COMMIT},echo ${GIT_COMMIT} > commit)
+	zip -y -q -r -x@deploy-exclude.lst target/template-preview.zip ./
+
+
+.PHONY: upload-paas-artifact ## Upload the deploy artifact for PaaS
+upload-paas-artifact:
+	$(if ${DEPLOY_BUILD_NUMBER},,$(error Must specify DEPLOY_BUILD_NUMBER))
+	$(if ${JENKINS_S3_BUCKET},,$(error Must specify JENKINS_S3_BUCKET))
+	aws s3 cp --region eu-west-1 --sse AES256 target/template-preview.zip s3://${JENKINS_S3_BUCKET}/build/${CODEDEPLOY_PREFIX}/${DEPLOY_BUILD_NUMBER}.zip


### PR DESCRIPTION
Due to the way Jenkins jobs are structured we need the PaaS artifact
in order to run the deployment make targets in the deploy job.