### PR TITLE
downgrade ghostscript to 9.21

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "Install base packages" && apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Compile a specified version of ghostscript
-ARG GS_VERSION=9.25
+ARG GS_VERSION=9.21
 RUN wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$(echo $GS_VERSION | tr -d '.' )/ghostscript-${GS_VERSION}.tar.gz \
     && tar xvf ghostscript-${GS_VERSION}.tar.gz \
     && cd ghostscript-${GS_VERSION} && ./configure && make install \


### PR DESCRIPTION
we use ghostscript to, among other things, convert our PDFs from RGB to
CMYK. When we upgraded ghostscript to 9.22, something changed and the
grayscale colours it output are no longer srgba(0, 0, 0, x), but are
srgba(7, 5, 5, x). (When looking at output of `identify -verbose`).
DVLA can’t convert these to true blacks when printing, so everything
will be fuzzy and grey.

Pinning to 9.21 fixes this, but also means we are conciously ignoring
this CVE: https://nvd.nist.gov/vuln/detail/CVE-2018-11645

But that's okay because it only allows people to find out what files
are on disk and it's a public docker image anyway 🤷