### PR TITLE
Use new address block validation

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -78,18 +78,8 @@ def sanitise_precompiled_letter():
 
     file_data = BytesIO(encoded_string)
 
-    # original address block validation
-    if len(get_invalid_pages(file_data, address_margin=False)) > 0:
-        raise InvalidRequest('Sanitise failed - Document exceeds boundaries')
-
-    # new address block validation
     if len(get_invalid_pages(file_data)) > 0:
-        service_id = request.headers.get('Service-ID')
-        notification_id = request.headers.get('Notification-ID')
-        current_app.logger.info('Notification {} for service {} failed the new address block validation'.format(
-            notification_id,
-            service_id)
-        )
+        raise InvalidRequest('Sanitise failed - Document exceeds boundaries')
 
     # during switchover, DWP will still be sending the notify tag. Only add it if it's not already there
     if not does_pdf_contain_cmyk(encoded_string) or does_pdf_contain_rgb(encoded_string):
@@ -239,12 +229,12 @@ def overlay_template_areas(src_pdf, page_number=None, overlay=True):
     return png_from_pdf(pdf, page_number)
 
 
-def get_invalid_pages(src_pdf, address_margin=True):
-    pdf_to_validate = _add_no_print_areas(src_pdf, address_margin=address_margin)
+def get_invalid_pages(src_pdf):
+    pdf_to_validate = _add_no_print_areas(src_pdf)
     return list(_get_out_of_bounds_pages(PdfFileReader(pdf_to_validate)))
 
 
-def _add_no_print_areas(src_pdf, overlay=False, address_margin=True):
+def _add_no_print_areas(src_pdf, overlay=False):
     """
     Overlays the printable areas onto the src PDF, this is so the code can check for a presence of non white in the
     areas outside the printable area.
@@ -285,9 +275,7 @@ def _add_no_print_areas(src_pdf, overlay=False, address_margin=True):
     y = page_height - (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm)
 
     service_address_width = page_width - (SERVICE_ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm + BORDER_FROM_RIGHT_OF_PAGE * mm)
-    if not address_margin:
-        x -= 5 * mm
-        service_address_width += 5 * mm
+
     height = (SERVICE_ADDRESS_BOTTOM_FROM_TOP_OF_PAGE - BORDER_FROM_TOP_OF_PAGE) * mm
     can.rect(x, y, service_address_width, height, fill=True, stroke=False)
 
@@ -295,10 +283,7 @@ def _add_no_print_areas(src_pdf, overlay=False, address_margin=True):
     x = LOGO_LEFT_FROM_LEFT_OF_PAGE * mm
     y = page_height - (LOGO_BOTTOM_FROM_TOP_OF_PAGE * mm)
 
-    if address_margin:
-        can.rect(x, y, LOGO_WIDTH * mm, LOGO_HEIGHT * mm, fill=True, stroke=False)
-    else:
-        can.rect(x, y, (LOGO_WIDTH - 5) * mm, LOGO_HEIGHT * mm, fill=True, stroke=False)
+    can.rect(x, y, LOGO_WIDTH * mm, LOGO_HEIGHT * mm, fill=True, stroke=False)
 
     # Citizen Address Block
     x = ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm


### PR DESCRIPTION
Previously, we were validating precompiled letters using the 'old' address block margin (the left image) and logging failures for precompiled letters that would fail the new address block validation (image on the right). This updates the code to always validate against the new address margins.

![Screen Shot 2018-12-04 at 11 38 22](https://user-images.githubusercontent.com/12881990/54683141-ce089000-4b08-11e9-9e9d-99a48148bd63.png)


[Pivotal story](https://www.pivotaltracker.com/story/show/163189010)

#### To test
Use one of the clients to send a precompiled letter with content just to the right of the address block (e.g. this PDF https://github.com/alphagov/notifications-template-preview/blob/e46107ad05882221f36743e6cd4a5f69df4a8b44/tests/test_pdfs/address_margin.pdf)

The notification should now have the status of `validation-failed`
