### PR TITLE
Stop pyup from trying to upgrade Werkzeug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Pillow==5.2.0
 reportlab==3.5.6
 pdf2image==0.1.14
 PyMuPDF==1.13.20
-Werkzeug==0.14.1
+Werkzeug==0.14.1  # pyup: < 0.15.0
 
 
 # weasyprint 0.41 has errors where png previews of PDFs randomly do not render all images


### PR DESCRIPTION
We pinned Werkzeug here https://github.com/alphagov/notifications-template-preview/pull/305, but Pyup is still trying to upgrade it to the latest version