### PR TITLE
don't explicitly define instances

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,6 @@
 applications:
 - name: notify-template-preview
 
-  instances: 1
   memory: 2G
   disk_quota: 2G
 


### PR DESCRIPTION
or we'll downscale to that amount on `cf v3-apply-manifest`, which means we might downscale under load