### PR TITLE
Adjust position of white Notify text

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -197,7 +197,9 @@ def add_notify_tag_to_letter(src_pdf):
     font = ImageFont.truetype(TRUE_TYPE_FONT_FILE, NOTIFY_TAG_FONT_SIZE)
     line_width, line_height = font.getsize('NOTIFY')
 
-    x = NOTIFY_TAG_FROM_LEFT_OF_PAGE * mm
+    center_of_left_margin = (BORDER_FROM_LEFT_OF_PAGE * mm) / 2
+    half_width_of_notify_tag = line_width / 2
+    x = center_of_left_margin - half_width_of_notify_tag
 
     # page.mediaBox[3] Media box is an array with the four corners of the page
     # We want height so can use that co-ordinate which is located in [3]

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -236,7 +236,7 @@ def test_add_notify_tag_to_letter_correct_margins(mocker):
         pass
 
     mm_from_top_of_the_page = 4.3
-    mm_from_left_of_page = 7.4
+    mm_from_left_of_page = 3.44
 
     x = mm_from_left_of_page * mm
 
@@ -245,8 +245,12 @@ def test_add_notify_tag_to_letter_correct_margins(mocker):
     # The lets take away the margin and the ont size
     y = float(pdf_original.getPage(0).mediaBox[3]) - (float(mm_from_top_of_the_page * mm + 6 - 1.75))
 
-    can.drawString.assert_called_once()
-    can.drawString.assert_called_with(x, y, "NOTIFY")
+    assert len(can.drawString.call_args_list) == 1
+    positional_args = can.drawString.call_args[0]
+    assert len(positional_args) == 3
+    assert positional_args[0] == pytest.approx(x, 0.01)
+    assert positional_args[1] == y
+    assert positional_args[2] == "NOTIFY"
 
 
 @pytest.mark.parametrize('headers', [{}, {'Authorization': 'Token not-the-actual-token'}])


### PR DESCRIPTION
The hidden NOTIFY text tells the printer when a new letter starts. It has trouble finding the text if it overlaps any other elements on the page. This would be impossible if the NOTIFY text was fully in the
non-printable area. However the right-hand-edge of the text was intruding in the printable area by a fraction of a millimetre.

This commit moves the NOTIFY text to be in the centre of the non-printable left margin, which should make it well clear of anything on the page.

This means DVLA can change the boundaries of where they’re looking for the NOTIFY text. Until then their existing code should work before and after this change ~~(to be confirmed – do not deploy until it is).~~ DVLA have confirmed they are happy for this change to be deployed.

# Before 

![image](https://user-images.githubusercontent.com/355079/61065578-e116d700-a3fb-11e9-9817-4ab6d4b06c7e.png)

# After 

![image](https://user-images.githubusercontent.com/355079/61065493-b298fc00-a3fb-11e9-9383-3b4c17ef986c.png)
