### PR TITLE
Address sanitising fixes

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -88,8 +88,7 @@ def sanitise_precompiled_letter():
     if not is_notify_tag_present(file_data):
         file_data = add_notify_tag_to_letter(file_data)
 
-    # TODO Address validation is disabled until we have more confidence it does the right thing
-    # file_data = rewrite_address_block(file_data)
+    file_data = rewrite_address_block(file_data)
 
     return send_file(filename_or_fp=file_data, mimetype='application/pdf')
 


### PR DESCRIPTION
# Rewrite address block

we've had a couple of problems with non-conforming address blocks lately, misaligned and encroaching in to the MDI return address block at the top. While we've changed the validation to stop this, we should also look at bringing back the address sanitisation to make sure we don't get this problem in future.

To recap, this will take all text in the address block, split it into lines, and then cover it up with a white bg and re-write it in 8pt arial with correct line spacing etc.

* Are we confident this works properly? does `pdftotext` correctly read stuff?
* What if it's a bitmap? or separate text blocks dumped near each other - will it still work then?


I've checked this manually with a letter from each of the five services currently sending precompiled, and it looks like it handles them fine