### PR TITLE
Squash unexpected pdf exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ test_results.xml
 target/
 .idea/
 .DS_Store
+.vscode
 
 environment.sh
 .envrc

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -138,15 +138,6 @@ def init_app(app):
         app.logger.warning(error.message)
         return jsonify(result='error', message=error.message or ""), error.code
 
-    @app.errorhandler(ValidationFailed)
-    def validation_failed(error):
-        return jsonify({
-            "page_count": error.page_count,
-            "recipient_address": None,
-            "message": error.message,
-            "file": None
-        }), error.code
-
     @app.errorhandler(Exception)
     def exception(error):
         app.logger.exception(error)

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -70,7 +70,11 @@ def unexpected_exception(error):
     to handle it. If the exception object has "message", "page_count", or "code" properties it uses those to populate
     those fields in the return json.
     """
-    current_app.logger.warning('Unhandled exception with precompiled pdf: {}'.format(repr(error)))
+    if isinstance(error, ValidationFailed):
+        current_app.logger.warning('Validation Failed for precompiled pdf: {}'.format(repr(error)))
+    else:
+        current_app.logger.exception('Unhandled exception with precompiled pdf: {}'.format(repr(error)))
+
     return jsonify({
         "page_count": getattr(error, 'page_count', None),
         "recipient_address": None,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pytest-cov==2.7.1
 pytest-mock==1.10.4
 pytest==4.6.2
 requests-mock==1.6.0
+pdbpp

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,4 @@ pytest-cov==2.7.1
 pytest-mock==1.10.4
 pytest==4.6.2
 requests-mock==1.6.0
-pdbpp
+pdbpp==0.10.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ def app():
 
 @pytest.fixture
 def client(app):
-    app.config['DEBUG'] = True
     app.config['TESTING'] = True
 
     with app.test_request_context(), app.test_client() as client:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ def app():
 
 @pytest.fixture
 def client(app):
+    app.config['DEBUG'] = True
+    app.config['TESTING'] = True
+
     with app.test_request_context(), app.test_client() as client:
         yield client
 


### PR DESCRIPTION
move ValidationFailed error handler to generic precompiled one. If validation fails unexpectedly, we should handle this the same as if it cannot open the PDF.

the /precompiled/ blueprint currently has four endpoints:

* /precompiled/sanitise
* /precompiled/add_tag
* /precompiled/validate
* /precompiled/overlay.<file_type>

add_tag isn't used and validate is going away soon (when the one-off pdf epic is shipped), so we don't need to worry about them. overlay is used to display images that have already been through the validation process so we know they are at least processable.

So really, sanitise is the only endpoint that looks at PDFs for the first time, running the risk of being unable to open them. We've seen errors with PyPDF2 where it raised a NoneTypeError rather than a regular validation error, so we're now catching all `Exception` errors in a blueprint level handler (so it doesn't interfere with exceptions in other endpoints).

It looks for `page_count`, `message` and `code` attributes on exceptions, but otherwise returns the same json as the existing ValidationFailed error handler.