### PR TITLE
Steps to make precompiled redaction work better

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -1,5 +1,4 @@
 import base64
-import subprocess
 import math
 from io import BytesIO
 import app.pdf_redactor as pdf_redactor
@@ -94,7 +93,7 @@ def sanitise_precompiled_letter():
     """
     Given a PDF, returns a new PDF that has been sanitised and dvla approved 👍
 
-    * makes sure letter meets DVLA's printable boundaries an page dimensions requirements
+    * makes sure letter meets DVLA's printable boundaries and page dimensions requirements
     * re-writes address block (to ensure it's in arial in the right location)
     * adds NOTIFY tag if not present
     """
@@ -626,10 +625,15 @@ def extract_address_block(pdf):
     :param BytesIO pdf: pdf bytestream from which to extract
     :return: multi-line address string
     """
+    # add on a margin to ensure we capture all text
+    x1 = ADDRESS_LEFT_FROM_LEFT_OF_PAGE - 3
+    y1 = ADDRESS_TOP_FROM_TOP_OF_PAGE - 3
+    x2 = ADDRESS_RIGHT_FROM_LEFT_OF_PAGE + 3
+    y2 = ADDRESS_BOTTOM_FROM_TOP_OF_PAGE + 3
     return _extract_text_from_pdf(
         pdf,
-        x1=ADDRESS_LEFT_FROM_LEFT_OF_PAGE * mm, y1=ADDRESS_TOP_FROM_TOP_OF_PAGE * mm,
-        x2=ADDRESS_RIGHT_FROM_LEFT_OF_PAGE * mm, y2=ADDRESS_BOTTOM_FROM_TOP_OF_PAGE * mm
+        x1=x1 * mm, y1=y1 * mm,
+        x2=x2 * mm, y2=y2 * mm
     )
 
 
@@ -644,8 +648,8 @@ def is_notify_tag_present(pdf):
     x1 = NOTIFY_TAG_FROM_LEFT_OF_PAGE - 5
     y1 = NOTIFY_TAG_FROM_TOP_OF_PAGE - 3
     # font.getsize returns values in points, we need to get back into mm
-    x2 = x1 + (line_width / mm) + 10
-    y2 = y1 + (line_height / mm) + 6
+    x2 = NOTIFY_TAG_FROM_LEFT_OF_PAGE + (line_width / mm) + 5
+    y2 = NOTIFY_TAG_FROM_TOP_OF_PAGE + (line_height / mm) + 3
 
     return _extract_text_from_pdf(
         pdf,

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -597,6 +597,14 @@ def rewrite_address_block(pdf):
 def _extract_text_from_pdf(pdf, *, x1, y1, x2, y2):
     """
     Extracts all text within a block.
+    Taken from this script: https://github.com/pymupdf/PyMuPDF-Utilities/blob/master/textboxtract.py
+    Which was referenced in the library docs here:
+    https://pymupdf.readthedocs.io/en/latest/faq/#how-to-extract-text-from-within-a-rectangle
+
+    words and mywords variables are lists of tuples. Each tuple represents one word from the document,
+    and is structured as follows:
+    (x1, y1, x2, y2, word value, paragraph number, line number, word position within the line)
+
     :param BytesIO pdf: pdf bytestream from which to extract
     :param x1: horizontal location parameter for top left corner of rectangle in mm
     :param y1: vertical location parameter for top left corner of rectangle in mm
@@ -612,11 +620,11 @@ def _extract_text_from_pdf(pdf, *, x1, y1, x2, y2):
     mywords = [w for w in words if fitz.Rect(w[:4]).intersects(rect)]
     mywords.sort(key=itemgetter(3, 0))
     group = groupby(mywords, key=itemgetter(3))
-    address = []
+    extracted_text = []
     for y1, gwords in group:
-        address.append(" ".join(w[4] for w in gwords))
+        extracted_text.append(" ".join(w[4] for w in gwords))
     pdf.seek(0)
-    return "\n".join(address)
+    return "\n".join(extracted_text)
 
 
 def extract_address_block(pdf):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pypdf2==1.26.0
 Pillow==5.2.0
 reportlab==3.5.6
 pdf2image==0.1.14
-PyMuPDF==1.13.20
+PyMuPDF==1.16.1
 Werkzeug==0.14.1  # pyup: < 0.15.0
 pdfrw==0.4
 defusedxml==0.6.0

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -867,6 +867,15 @@ def test_extract_address_block():
     ])
 
 
+def extract_address_block_using_fitz_library():
+    assert extract_address_block_using_fitz_library(BytesIO(example_dwp_pdf)) == '\n'.join([
+        'MR J DOE',
+        '13 TEST LANE',
+        'TESTINGTON',
+        'TE57 1NG',
+    ])
+
+
 def test_add_address_to_precompiled_letter_puts_address_on_page():
     address = '\n'.join([
         'MR J DOE',

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -840,10 +840,10 @@ def test_is_notify_tag_calls_extract_with_wider_numbers(mocker):
 
     mock_extract.assert_called_once_with(
         ANY,
-        x=pytest.approx(2.4),
-        y=pytest.approx(1.3),
-        width=pytest.approx(18.11388),
-        height=pytest.approx(8.11666),
+        x1=pytest.approx(6.8031496),
+        y1=pytest.approx(3.685039),
+        x2=pytest.approx(58.149606),
+        y2=pytest.approx(26.692913),
     )
 
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -20,9 +20,9 @@ from reportlab.pdfgen.canvas import Canvas
 from app.precompiled import (
     add_notify_tag_to_letter,
     escape_special_characters_for_regex,
+    extract_address_block,
     is_notify_tag_present,
     get_invalid_pages_with_message,
-    extract_address_block,
     add_address_to_precompiled_letter,
     redact_precompiled_letter_address_block,
     rewrite_address_block
@@ -860,15 +860,6 @@ def test_rewrite_address_block_end_to_end(mocker):
 
 def test_extract_address_block():
     assert extract_address_block(BytesIO(example_dwp_pdf)) == '\n'.join([
-        'MR J DOE',
-        '13 TEST LANE',
-        'TESTINGTON',
-        'TE57 1NG',
-    ])
-
-
-def extract_address_block_using_fitz_library():
-    assert extract_address_block_using_fitz_library(BytesIO(example_dwp_pdf)) == '\n'.join([
         'MR J DOE',
         '13 TEST LANE',
         'TESTINGTON',


### PR DESCRIPTION
- move redaction above adding notify tag and conversion to CMYK, because pdfrw struggled to read the pdf made by us - it only read Notify tag layer for some pdfs
-  change text extraction function so it uses fitz library. Previous function had a problem with recognising some weirdly formatted whitespace characters which affected both redaction and the rewritten address.