### PR TITLE
Sanitise checks if letter too long

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -109,7 +109,7 @@ def sanitise_precompiled_letter():
     file_data = BytesIO(encoded_string)
     page_count = pdf_page_count(file_data)
     if is_letter_too_long(page_count):
-        message = "This letter is too long. Letters must be {} pages or fewer".format(LETTER_MAX_PAGE_COUNT)
+        message = "Letters must be {} pages or less.".format(LETTER_MAX_PAGE_COUNT)
         raise ValidationFailed(message, page_count=page_count)
     message = get_invalid_pages_with_message(file_data)
     if message:

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -25,6 +25,10 @@ from app import auth, InvalidRequest, ValidationFailed
 from app.preview import png_from_pdf, pngs_from_pdf
 from app.transformation import convert_pdf_to_cmyk, does_pdf_contain_cmyk, does_pdf_contain_rgb
 
+from notifications_utils import LETTER_MAX_PAGE_COUNT
+from notifications_utils.pdf import is_letter_too_long, pdf_page_count
+
+
 NOTIFY_TAG_FROM_TOP_OF_PAGE = 4.3
 NOTIFY_TAG_FROM_LEFT_OF_PAGE = 7.4
 NOTIFY_TAG_FONT_SIZE = 6
@@ -103,8 +107,11 @@ def sanitise_precompiled_letter():
         raise InvalidRequest('Sanitise failed - No encoded string')
 
     file_data = BytesIO(encoded_string)
+    page_count = pdf_page_count(file_data)
+    if is_letter_too_long(page_count):
+        message = "This letter is too long. Letters must be {} pages or fewer".format(LETTER_MAX_PAGE_COUNT)
+        raise ValidationFailed(message, page_count=page_count)
     message = get_invalid_pages_with_message(file_data)
-    page_count = _get_page_count(file_data)
     if message:
         raise ValidationFailed(message, page_count=page_count)
 
@@ -280,11 +287,6 @@ def get_invalid_pages_with_message(src_pdf):
             prefix_plural='pages'
         )
     return message
-
-
-def _get_page_count(src_pdf):
-    pdf = PdfFileReader(src_pdf)
-    return pdf.numPages
 
 
 def _is_page_A4_portrait(page_height, page_width, rotation):

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ defusedxml==0.6.0
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@33.2.7#egg=notifications-utils==33.2.7
+git+https://github.com/alphagov/notifications-utils.git@35.0.0#egg=notifications-utils==35.0.0
 
 # PaaS requirements
 gunicorn==19.9.0

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -805,6 +805,24 @@ def test_precompiled_sanitise_pdf_with_colour_in_address_margin_returns_400(clie
     }
 
 
+def test_precompiled_sanitise_pdf_that_is_too_long_returns_400(client, auth_header, mocker):
+    mocker.patch('app.precompiled.pdf_page_count', return_value=11)
+    mocker.patch('app.precompiled.is_letter_too_long', return_value=True)
+    response = client.post(
+        url_for('precompiled_blueprint.sanitise_precompiled_letter'),
+        data=address_margin,
+        headers={'Content-type': 'application/json', **auth_header}
+    )
+
+    assert response.status_code == 400
+    assert response.json == {
+        "page_count": 11,
+        "recipient_address": None,
+        "message": "This letter is too long. Letters must be 10 pages or fewer",
+        "file": None
+    }
+
+
 @pytest.mark.xfail(strict=True, reason='Will be fixed with https://www.pivotaltracker.com/story/show/158625803')
 def test_precompiled_sanitise_pdf_with_existing_notify_tag(client, auth_header):
     response = client.post(

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -818,7 +818,7 @@ def test_precompiled_sanitise_pdf_that_is_too_long_returns_400(client, auth_head
     assert response.json == {
         "page_count": 11,
         "recipient_address": None,
-        "message": "This letter is too long. Letters must be 10 pages or fewer",
+        "message": "Letters must be 10 pages or less.",
         "file": None
     }
 


### PR DESCRIPTION
This way we do not have to change it separately for PDF letters in API and admin

Needs this PR merged in to work: https://github.com/alphagov/notifications-utils/pull/654