### PR TITLE
Catch the TERM signal in the run_app_paas script

### DIFF
--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -82,7 +82,7 @@ echo "Run script pid: $$"
 
 check_params
 
-trap "on_exit" EXIT
+trap "on_exit" EXIT TERM
 
 configure_aws_logs
 


### PR DESCRIPTION
# What
When Cloud Foundry applications are to be rescheduled from one cell to
another, or they are stopped, they are sent a SIGTERM signal and 10
seconds later, a SIGKILL signal.

Currently the scripts trap the POSIX defined EXIT handler, rather than
the signal directly.

# How to test
In order for the signal to properly be propagated to celery, and the
celery workers, the script should call the on_exit function when
receiving a TERM signal.

Co-authored-by: Becca rebecca.law@digital.cabinet.office.gov.uk
Co-authored-by: Toby toby.lornewelch-richards@digital.cabinet.office.gov.uk