### PR TITLE
Use command in manifest instead of Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,6 @@
 applications:
 - name: notify-template-preview
 
-  memory: 2G
   disk_quota: 2G
 
   services:
@@ -11,8 +10,12 @@ applications:
   routes:
     - route: {{ environment }}-notify-template-preview.cloudapps.digital
 
-  health-check-type: http
-  health-check-http-endpoint: '/_status?simple=true'
+  processes:
+    - type: web
+      command: exec scripts/run_app_paas.sh gunicorn -c /home/vcap/app/gunicorn_config.py wsgi
+      health-check-http-endpoint: /_status?simple=true
+      health-check-type: http
+      memory: 2G
 
   env:
     FLASK_APP: application.py


### PR DESCRIPTION
What
----

We were attempting to get the Procfile to use exec so that signals are propagated to the app correctly.

However when prepending "exec" in front of the start command in the Procfile, it did not have an affect.

It is hard to reason about how Docker applications use the Procfile, so we thought it would be better to explicitly set the command in the manifest.

Additionally we have made the manifest look more similar to other notify manifests (taken from [notifications-ftp](https://github.com/alphagov/notifications-ftp))

How to review
----

Code review

```bash
make preview cf-deploy
cf restart
cf logs --recent notifications-template-preview | grep -i terminating
```

Who can review
----

Done as pair with @servingUpAces 