### PR TITLE
Change default CF_SPACE to be development, not sandbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
 CF_HOME ?= ${HOME}
 $(eval export CF_HOME)
-CF_SPACE ?= sandbox
+CF_SPACE ?= development
 
 DOCKER_IMAGE = govuknotify/notifications-template-preview
 DOCKER_IMAGE_TAG = ${DEPLOY_BUILD_NUMBER}
@@ -40,11 +40,6 @@ PORT ?= 6013
 .PHONY: help
 help:
 	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
-
-.PHONY: sandbox
-sandbox: ## Set environment to sandbox
-	$(eval export CF_SPACE=sandbox)
-	@true
 
 .PHONY: preview
 preview: ## Set environment to preview

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,8 +43,7 @@ def load_config(application):
     )
 
     application.config['LETTER_LOGO_URL'] = 'https://static-logos.{}/letters'.format({
-        # not called `development` in template preview for some reason
-        'sandbox': 'notify.tools',
+        'development': 'notify.tools',
         'preview': 'notify.works',
         'staging': 'staging-notify.works',
         'production': 'notifications.service.gov.uk'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths = tests
 env =
-    NOTIFY_ENVIRONMENT=sandbox
+    NOTIFY_ENVIRONMENT=development
     STATSD_ENABLED=0

--- a/tests/test_precompiled_preview.py
+++ b/tests/test_precompiled_preview.py
@@ -83,13 +83,13 @@ def test_precompiled_pdf_caches_png_to_s3(
     assert response.headers['Content-Type'] == 'image/png'
     assert response.get_data().startswith(b'\x89PNG')
     mocked_cache_get.assert_called_once_with(
-        'sandbox-template-preview-cache',
+        'development-template-preview-cache',
         'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == response.get_data()
     assert mocked_cache_set.call_args[0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args[0][2] == 'sandbox-template-preview-cache'
+    assert mocked_cache_set.call_args[0][2] == 'development-template-preview-cache'
     assert mocked_cache_set.call_args[0][3] == 'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
 
 
@@ -116,7 +116,7 @@ def test_precompiled_pdf_returns_png_from_cache(
     assert response.headers['Content-Type'] == 'image/png'
     assert response.get_data() == b'\x00'
     mocked_cache_get.assert_called_once_with(
-        'sandbox-template-preview-cache',
+        'development-template-preview-cache',
         'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     assert mocked_cache_set.call_args_list == []

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -115,14 +115,14 @@ def test_get_pdf_caches_with_correct_keys(
     assert resp.headers['Content-Type'] == 'application/pdf'
     assert resp.get_data().startswith(b'%PDF-1.5')
     mocked_cache_get.assert_called_once_with(
-        'sandbox-template-preview-cache',
+        'development-template-preview-cache',
         expected_cache_key
     )
     assert mocked_cache_set.call_count == 1
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == resp.get_data()
     assert mocked_cache_set.call_args[0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args[0][2] == 'sandbox-template-preview-cache'
+    assert mocked_cache_set.call_args[0][2] == 'development-template-preview-cache'
     assert mocked_cache_set.call_args[0][3] == expected_cache_key
 
 
@@ -141,13 +141,13 @@ def test_get_png_caches_with_correct_keys(
     assert resp.headers['Content-Type'] == 'image/png'
     assert resp.get_data().startswith(b'\x89PNG')
     assert mocked_cache_get.call_count == 2
-    assert mocked_cache_get.call_args_list[0][0][0] == 'sandbox-template-preview-cache'
+    assert mocked_cache_get.call_args_list[0][0][0] == 'development-template-preview-cache'
     assert mocked_cache_get.call_args_list[0][0][1] == expected_cache_key
     assert mocked_cache_set.call_count == 2
     mocked_cache_set.call_args_list[1][0][0].seek(0)
     assert mocked_cache_set.call_args_list[1][0][0].read() == resp.get_data()
     assert mocked_cache_set.call_args_list[1][0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args_list[1][0][2] == 'sandbox-template-preview-cache'
+    assert mocked_cache_set.call_args_list[1][0][2] == 'development-template-preview-cache'
     assert mocked_cache_set.call_args_list[1][0][3] == expected_cache_key
 
 
@@ -353,7 +353,7 @@ def test_page_count_from_cache(
             **auth_header
         }
     )
-    assert mocked_cache_get.call_args[0][0] == 'sandbox-template-preview-cache'
+    assert mocked_cache_get.call_args[0][0] == 'development-template-preview-cache'
     assert mocked_cache_get.call_args[0][1] == 'templated/8ce6d5144dc8d89998ebe68aa9b91f0112882798.pdf'
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {'count': 10}


### PR DESCRIPTION
We set the `NOTIFY_ENVIRONMENT` to be the same as the `CF_SPACE`, which
defaulted to `sandbox`. Since we want to prefix bucket names and queues
with `development`, this changes the default of `CF_SPACE` to be
`development`.