### PR TITLE
Tidy up after move to concourse

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,0 @@
-.gitignore

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ TEMPLATE_PREVIEW_API_KEY ?= "my-secret-key"
 DOCKER_CONTAINER_PREFIX = ${USER}-${BUILD_TAG}
 
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
-CF_MANIFEST_FILE ?= manifest-${CF_SPACE}.yml
 
 NOTIFY_APP_NAME ?= notify-template-preview
 CF_APP = notify-template-preview

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,6 @@ define run_docker_container
 		-p "${PORT}:${PORT}" \
 		-e NOTIFY_APP_NAME=${NOTIFY_APP_NAME} \
 		-e GIT_COMMIT=${GIT_COMMIT} \
-		-e http_proxy="${http_proxy}" \
-		-e https_proxy="${https_proxy}" \
-		-e NO_PROXY="${NO_PROXY}" \
 		-e CI_NAME=${CI_NAME} \
 		-e CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		-e CI_BUILD_URL=${BUILD_URL} \
@@ -142,9 +139,6 @@ upload-to-dockerhub: prepare-docker-build-image ## Upload the current version of
 .PHONY: prepare-docker-build-image
 prepare-docker-build-image: ## Build docker image
 	docker build -f docker/Dockerfile \
-		--build-arg http_proxy="${http_proxy}" \
-		--build-arg https_proxy="${https_proxy}" \
-		--build-arg NO_PROXY="${NO_PROXY}" \
 		--build-arg CI_NAME=${CI_NAME} \
 		--build-arg CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		--build-arg CI_BUILD_URL=${BUILD_URL} \
@@ -155,9 +149,6 @@ prepare-docker-build-image: ## Build docker image
 prepare-docker-test-build-image: ## Build docker image
 	docker build -f docker/Dockerfile \
 		--target test \
-		--build-arg http_proxy="${http_proxy}" \
-		--build-arg https_proxy="${https_proxy}" \
-		--build-arg NO_PROXY="${NO_PROXY}" \
 		--build-arg CI_NAME=${CI_NAME} \
 		--build-arg CI_BUILD_NUMBER=${BUILD_NUMBER} \
 		--build-arg CI_BUILD_URL=${BUILD_URL} \

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,6 @@ clean-docker-containers: ## Clean up any remaining docker containers
 
 .PHONY: upload-to-dockerhub
 upload-to-dockerhub: prepare-docker-build-image ## Upload the current version of the docker image to dockerhub
-	$(if ${CF_SPACE},,$(error Must specify CF_SPACE - which is the tag to push to dockerhub with))
 	$(if ${DOCKERHUB_USERNAME},,$(error Must specify DOCKERHUB_USERNAME))
 	$(if ${DOCKERHUB_PASSWORD},,$(error Must specify DOCKERHUB_PASSWORD))
 	@docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ CF_MANIFEST_FILE ?= manifest-${CF_SPACE}.yml
 NOTIFY_APP_NAME ?= notify-template-preview
 CF_APP = notify-template-preview
 
-CODEDEPLOY_PREFIX ?= notifications-template-preview
-
 CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
 CF_HOME ?= ${HOME}
@@ -192,17 +190,3 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 cf-rollback: ## Rollbacks the app to the previous release
 	$(if ${CF_APP},,$(error Must specify CF_APP))
 	cf v3-cancel-zdt-push ${CF_APP}
-
-.PHONY: build-paas-artifact
-build-paas-artifact: ## Build the deploy artifact for PaaS
-	rm -rf target
-	mkdir -p target
-	$(if ${GIT_COMMIT},echo ${GIT_COMMIT} > commit)
-	zip -y -q -r -x@deploy-exclude.lst target/template-preview.zip ./
-
-
-.PHONY: upload-paas-artifact ## Upload the deploy artifact for PaaS
-upload-paas-artifact:
-	$(if ${DEPLOY_BUILD_NUMBER},,$(error Must specify DEPLOY_BUILD_NUMBER))
-	$(if ${JENKINS_S3_BUCKET},,$(error Must specify JENKINS_S3_BUCKET))
-	aws s3 cp --region eu-west-1 --sse AES256 target/template-preview.zip s3://${JENKINS_S3_BUCKET}/build/${CODEDEPLOY_PREFIX}/${DEPLOY_BUILD_NUMBER}.zip

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,12 @@ CF_APP = notify-template-preview
 
 CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
-CF_HOME ?= ${HOME}
-$(eval export CF_HOME)
 CF_SPACE ?= development
 
 DOCKER_IMAGE = govuknotify/notifications-template-preview
 DOCKER_IMAGE_TAG = ${DEPLOY_BUILD_NUMBER}
 
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
-DOCKER_TTY ?= $(if ${JENKINS_HOME},,t)
 
 PORT ?= 6013
 
@@ -86,7 +83,7 @@ _single_test: _test-dependencies
 	pytest -k ${test_name}
 
 define run_docker_container
-	docker run -i${DOCKER_TTY} --rm \
+	docker run -it --rm \
 		--name "${DOCKER_CONTAINER_PREFIX}-${1}" \
 		-p "${PORT}:${PORT}" \
 		-e NOTIFY_APP_NAME=${NOTIFY_APP_NAME} \

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,10 @@ run-with-docker: prepare-docker-build-image ## Build inside a Docker container
 	$(call run_docker_container,build, make _run)
 
 .PHONY: test-with-docker
-# always run tests against the sandbox image
 test-with-docker: prepare-docker-test-build-image ## Run tests inside a Docker container
 	$(call run_docker_container,test, make _test)
 
 .PHONY: single-test-with-docker
-# always run tests against the sandbox image
 single-test-with-docker: prepare-docker-test-build-image ## Run single test inside a Docker container, make single-test-with-docker test_name=<test name>
 	$(call run_docker_container,test, make _single_test test_name=${test_name})
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,12 @@ Running tests will also apply syntax checking, using [pycodestyle](https://pypi.
 
 ## Running the application
 
-
 ```shell
 make run-with-docker
 ```
 
-
 Then visit your app at `http://localhost:6013/`. For authenticated endpoints, HTTP Token Authentication is used - by default, locally it's set to `my-secret-key`.
 
-If you want to run this locally, follow these [instructions](#running-locally):
 
 ### Hitting the application manually
 ```shell
@@ -63,40 +60,4 @@ You shouldn’t need to deploy this manually because there’s a pipeline setup 
 ```shell
 make (sandbox|preview|staging|production) upload-to-dockerhub
 make (sandbox|preview|staging|production) cf-deploy
-```
-
-## Running locally
-
-During development it may be preferable to run locally.
-
-If you haven't installed the app yet follow these steps - 
-
-```shell
-# binary dependencies
-brew install imagemagick@6 ghostscript cairo pango
-brew link --force imagemagick@6
-
-mkvirtualenv -p /usr/local/bin/python3 notifications-template-preview
-pip install -r requirements.txt
-
-# create a version file
-make _generate-version-file
-```
-
-You will also need to export an environmental variable -
-
-```shell
-export TEMPLATE_PREVIEW_API_KEY="my-secret-key"
-```
-
-Then call the run app script -
-
-```shell
-./scripts/run_app.sh 6013
-```
-
-Thereafter activate the virtualenv prior to executing the run app script above -
-
-```shell
-workon notifications-template-preview
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl \
 
 ## Deploying
 
-You shouldn’t need to deploy this manually because there’s a pipeline setup in Jenkins. If you do want to deploy it manually, you'll need the notify-credentials repo set up locally.
+You shouldn’t need to deploy this manually because there’s a pipeline setup in Concourse. If you do want to deploy it manually, you'll need the notify-credentials repo set up locally.
 
 ```shell
 make (sandbox|preview|staging|production) upload-to-dockerhub

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ curl \
 You shouldn’t need to deploy this manually because there’s a pipeline setup in Concourse. If you do want to deploy it manually, you'll need the notify-credentials repo set up locally.
 
 ```shell
-make (sandbox|preview|staging|production) upload-to-dockerhub
-make (sandbox|preview|staging|production) cf-deploy
+make (preview|staging|production) upload-to-dockerhub
+make (preview|staging|production) cf-deploy
 ```

--- a/app/status.py
+++ b/app/status.py
@@ -17,8 +17,6 @@ def _status():
 
         commit=version.__commit__,
         build_time=version.__time__,
-        build_number=version.__jenkins_job_number__,
-        build_url=version.__jenkins_job_url__,
 
         ghostscript_version=get_ghostscript_version(),
         imagemagick_version=get_imagemagick_version(),

--- a/app/version.py.dist
+++ b/app/version.py.dist
@@ -1,4 +1,2 @@
 __commit__ = ""
 __time__ = ""
-__jenkins_job_number__ = ""
-__jenkins_job_url__ = ""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,8 @@
 FROM python:3.6-slim-stretch as parent
 
-ARG http_proxy
-ARG https_proxy
-ARG NO_PROXY
-
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN ([ -z "$http_proxy" ] || echo "Acquire::http::Proxy \"${http_proxy}\";" > /etc/apt/apt.conf.d/99HttpProxy)
 RUN echo "Install base packages" && apt-get update \
     && apt-get install -y --no-install-recommends \
         apt-transport-https \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN \
 COPY app app
 COPY wsgi.py gunicorn_config.py Makefile ./
 COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/
+COPY .git/ .git/  # used only for make _generate-version-file
 
 RUN make _generate-version-file
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,13 +64,6 @@ RUN \
 # Docker will rebuild from here down every time.
 COPY . .
 
-ARG CI_NAME
-ARG CI_BUILD_NUMBER
-ARG CI_BUILD_URL
-ENV CI_NAME=$CI_NAME
-ENV CI_BUILD_NUMBER=$CI_BUILD_NUMBER
-ENV CI_BUILD_URL=$CI_BUILD_URL
-
 RUN make _generate-version-file
 
 EXPOSE 6013
@@ -86,13 +79,6 @@ RUN \
 COPY app app
 COPY wsgi.py gunicorn_config.py Makefile ./
 COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/
-
-ARG CI_NAME
-ARG CI_BUILD_NUMBER
-ARG CI_BUILD_URL
-ENV CI_NAME=$CI_NAME
-ENV CI_BUILD_NUMBER=$CI_BUILD_NUMBER
-ENV CI_BUILD_URL=$CI_BUILD_URL
 
 RUN make _generate-version-file
 


### PR DESCRIPTION
Review commit by commit

Note, this is not perfect. The steps to manually deploy this don't set the docker image tag as the short git SHA like we do on concourse.

Worth taking a look at our current status page:
https://preview-notify-template-preview.cloudapps.digital/_status

It will now show the correct git commit and drop non useful keys.