### PR TITLE
Fix broken command that didn't like bash comment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,8 +79,10 @@ RUN \
 COPY app app
 COPY wsgi.py gunicorn_config.py Makefile ./
 COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/
-COPY .git/ .git/  # used only for make _generate-version-file
 
+# .git folder used only for make _generate-version-file but we don't wish to include it in our final production build
+COPY .git .git
 RUN make _generate-version-file
+RUN rm -rf .git
 
 EXPOSE 6013


### PR DESCRIPTION
This was causing it to try to put files in the '#' directory. I've moved
the command to a separate line which fixes it.

Whilst at it, I've taken the opportunity to remove the .git directory
from our image after it's done using it in the build process.