### PR TITLE
Add a Celery app for sanitising letters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ run-with-docker: prepare-docker-build-image ## Build inside a Docker container
 
 .PHONY: run-celery-with-docker ## Build Celery app inside a Docker container
 run-celery-with-docker: prepare-docker-build-image
+	$(if ${NOTIFICATION_QUEUE_PREFIX},,$(error Must specify NOTIFICATION_QUEUE_PREFIX))
 	$(call run_docker_container,celery-build, make _run-celery)
 
 .PHONY: test-with-docker

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ DOCKER_CONTAINER_PREFIX = ${USER}-notifications-template-preview-manual
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
 NOTIFY_APP_NAME ?= notify-template-preview
-CF_APP = notify-template-preview
+CF_APP ?= notify-template-preview
+CF_MANIFEST_FILE ?= manifest$(subst notify-template-preview,,${CF_APP}).yml.j2
 
 CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
@@ -157,7 +158,7 @@ generate-manifest:
 	$(if $(shell which gpg2), $(eval export GPG=gpg2), $(eval export GPG=gpg))
 	$(if ${GPG_PASSPHRASE_TXT}, $(eval export DECRYPT_CMD=echo -n $$$${GPG_PASSPHRASE_TXT} | ${GPG} --quiet --batch --passphrase-fd 0 --pinentry-mode loopback -d), $(eval export DECRYPT_CMD=${GPG} --quiet --batch -d))
 
-	@jinja2 --strict manifest.yml.j2 \
+	@jinja2 --strict ${CF_MANIFEST_FILE} \
 	    -D environment=${CF_SPACE} --format=yaml \
 	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/paas/environment-variables.gpg) 2>&1
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This will create the docker container and install the dependencies.
 
 ## Tests
 
-These can only be run when the app is not running due to port clashes
+The command to run all of the tests is
 
 ```shell
 make test-with-docker
@@ -23,10 +23,10 @@ make test-with-docker
 
 This script will run all the tests. [py.test](http://pytest.org/latest/) is used for testing.
 
-Running tests will also apply syntax checking, using [pycodestyle](https://pypi.python.org/pypi/pycodestyle).
+Running tests will also apply syntax checking, using [flake8](https://pypi.org/project/flake8/).
 
 
-## Running the application
+## Running the Flask application
 
 ```shell
 make run-with-docker
@@ -53,9 +53,17 @@ curl \
   http://localhost:6013/preview.pdf
 ```
 
+## Running the Celery application
+
+The Celery app is used for sanitising PDF letters asynchronously. It requires the `NOTIFICATION_QUEUE_PREFIX` environment variable to be set to the same value used in notifications-api.
+
+```shell
+make run-celery-with-docker
+```
+
 ## Deploying
 
-You shouldn’t need to deploy this manually because there’s a pipeline setup in Concourse. If you do want to deploy it manually, you'll need the notify-credentials repo set up locally.
+You shouldn’t need to deploy this manually because there’s a pipeline setup in Concourse. If you do want to deploy it manually, you'll need the notify-credentials repo set up locally. `CF_APP` should be set to `NOTIFY_TEMPLATE_PREVIEW_CELERY` if deploying the Celery app.
 
 ```shell
 make (preview|staging|production) upload-to-dockerhub

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,7 +37,7 @@ def load_config(application):
         'timezone': 'Europe/London',
         'imports': ['app.celery.tasks'],
         'task_queues': [
-            Queue(QueueNames.TEMPLATE_PREVIEW, Exchange('default'), routing_key=QueueNames.TEMPLATE_PREVIEW)
+            Queue(QueueNames.SANITISE_LETTERS, Exchange('default'), routing_key=QueueNames.SANITISE_LETTERS)
         ],
     }
 
@@ -218,7 +218,7 @@ class ValidationFailed(Exception):
 
 class QueueNames:
     LETTERS = 'letter-tasks'
-    TEMPLATE_PREVIEW = 'template-preview-tasks'
+    SANITISE_LETTERS = 'sanitise-letter-tasks'
 
 
 class TaskNames:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -63,7 +63,7 @@ def load_config(application):
             application.config['NOTIFY_ENVIRONMENT']
         )
     )
-    application.config['S3_LETTER_CACHE_BUCKET'] = (
+    application.config['LETTER_CACHE_BUCKET_NAME'] = (
         '{}-template-preview-cache'.format(
             application.config['NOTIFY_ENVIRONMENT']
         )
@@ -142,7 +142,7 @@ def init_cache(application):
 
                 with suppress(S3ObjectNotFound):
                     return s3download(
-                        application.config['S3_LETTER_CACHE_BUCKET'],
+                        application.config['LETTER_CACHE_BUCKET_NAME'],
                         cache_key,
                     )
 
@@ -151,7 +151,7 @@ def init_cache(application):
                 s3upload(
                     data,
                     application.config['AWS_REGION'],
-                    application.config['S3_LETTER_CACHE_BUCKET'],
+                    application.config['LETTER_CACHE_BUCKET_NAME'],
                     cache_key,
                 )
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,7 +31,7 @@ def load_config(application):
         'broker_transport_options': {
             'region': application.config['AWS_REGION'],
             'visibility_timeout': 310,
-            'queue_name_prefix': get_queue_prefix(application.config['NOTIFY_ENVIRONMENT']),
+            'queue_name_prefix': queue_prefix[application.config['NOTIFY_ENVIRONMENT']],
             'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
         },
         'timezone': 'Europe/London',
@@ -225,14 +225,10 @@ class TaskNames:
     PROCESS_SANITISED_LETTER = 'process-sanitised-letter'
 
 
-def get_queue_prefix(environment):
-    if environment == 'development' and not os.environ.get('NOTIFICATION_QUEUE_PREFIX'):
-        raise Exception('The NOTIFICATION_QUEUE_PREFIX environment variable must be set in development')
-
-    return {
-        'test': 'test',
-        'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX'),
-        'preview': 'preview',
-        'staging': 'staging',
-        'production': 'live',
-    }[environment]
+queue_prefix = {
+    'test': 'test',
+    'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX', 'development'),
+    'preview': 'preview',
+    'staging': 'staging',
+    'production': 'live',
+}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -26,21 +26,20 @@ def load_config(application):
     application.config['NOTIFY_ENVIRONMENT'] = os.environ['NOTIFY_ENVIRONMENT']
     application.config['NOTIFY_APP_NAME'] = 'template-preview'
 
-    application.config['BROKER_URL'] = 'sqs://'
-    application.config['BROKER_TRANSPORT_OPTIONS'] = {
-        'region': application.config['AWS_REGION'],
-        'polling_interval': 1,
-        'visibility_timeout': 310,
-        'queue_name_prefix': get_queue_prefix(application.config['NOTIFY_ENVIRONMENT']),
+    application.config['celery'] = {
+        'broker_url': 'sqs://',
+        'broker_transport_options': {
+            'region': application.config['AWS_REGION'],
+            'visibility_timeout': 310,
+            'queue_name_prefix': get_queue_prefix(application.config['NOTIFY_ENVIRONMENT']),
+            'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
+        },
+        'timezone': 'Europe/London',
+        'imports': ['app.celery.tasks'],
+        'task_queues': [
+            Queue(QueueNames.TEMPLATE_PREVIEW, Exchange('default'), routing_key=QueueNames.TEMPLATE_PREVIEW)
+        ],
     }
-    application.config['CELERY_ENABLE_UTC'] = True
-    application.config['CELERY_TIMEZONE'] = 'Europe/London'
-    application.config['CELERY_ACCEPT_CONTENT'] = ['json']
-    application.config['CELERY_TASK_SERIALIZER'] = 'json'
-    application.config['CELERY_IMPORTS'] = ['app.celery.tasks']
-    application.config['CELERY_QUEUES'] = [
-        Queue(QueueNames.TEMPLATE_PREVIEW, Exchange('default'), routing_key=QueueNames.TEMPLATE_PREVIEW)
-    ]
 
     # if we use .get() for cases that it is not setup
     # it will still create the config key with None value causing

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,0 +1,30 @@
+from celery import Celery, Task
+
+
+class NotifyCelery(Celery):
+
+    def init_app(self, app):
+        # this task is nested so that it has access to the original flask application - when celery restarts processes,
+        # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
+        # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
+        class NotifyTask(Task):
+            abstract = True
+
+            def on_failure(self, exc, task_id, args, kwargs, einfo):
+                # ensure task will log exceptions to correct handlers
+                with app.app_context():
+                    app.logger.exception('Celery task {} failed'.format(self.name))
+                    super().on_failure(exc, task_id, args, kwargs, einfo)
+
+            def __call__(self, *args, **kwargs):
+                # ensure task has flask context to access config, logger, etc
+                with app.app_context():
+                    return super().__call__(*args, **kwargs)
+
+        super().__init__(
+            app.import_name,
+            broker=app.config['BROKER_URL'],
+            task_cls=NotifyTask,
+        )
+
+        self.conf.update(app.config)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -23,8 +23,8 @@ class NotifyCelery(Celery):
 
         super().__init__(
             app.import_name,
-            broker=app.config['BROKER_URL'],
+            broker=app.config['celery']['broker_url'],
             task_cls=NotifyTask,
         )
 
-        self.conf.update(app.config)
+        self.conf.update(app.config['celery'])

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -1,0 +1,57 @@
+import base64
+
+from botocore.exceptions import ClientError as BotoClientError
+from flask import current_app
+from notifications_utils.s3 import s3download, s3upload
+from notifications_utils.statsd_decorators import statsd
+
+from app import notify_celery, TaskNames, QueueNames
+from app.precompiled import sanitise_file_contents
+
+
+@notify_celery.task(name='sanitise-and-upload-letter')
+@statsd(namespace='template-preview')
+def sanitise_and_upload_letter(notification_id, filename):
+    current_app.logger.info('Sanitising notification with id {}'.format(notification_id))
+
+    try:
+        pdf_content = s3download(current_app.config['LETTERS_SCAN_BUCKET_NAME'], filename).read()
+        sanitisation_details = sanitise_file_contents(pdf_content)
+
+        # Only files that have failed sanitisation have 'message' in the sanitisation_details dict
+        if sanitisation_details.get('message'):
+            validation_status = 'failed'
+        else:
+            validation_status = 'passed'
+            file_data = base64.b64decode(sanitisation_details['file'].encode())
+
+            # If the file already exists in S3, it will be overwritten
+            s3upload(
+                filedata=file_data,
+                region=current_app.config['AWS_REGION'],
+                bucket_name=current_app.config['SANITISED_LETTER_BUCKET_NAME'],
+                file_location=filename,
+            )
+
+        current_app.logger.info('Notification {} sanitisation: {}'.format(validation_status, notification_id))
+
+    except BotoClientError:
+        current_app.logger.exception(
+            "Error downloading {} from scan bucket or uploading to sanitise bucket for notification {}".format(
+                filename, notification_id
+            )
+        )
+        return
+
+    notify_celery.send_task(
+        name=TaskNames.PROCESS_SANITISED_LETTER,
+        kwargs={
+            'page_count': sanitisation_details['page_count'],
+            'message': sanitisation_details['message'],
+            'invalid_pages': sanitisation_details['invalid_pages'],
+            'validation_status': validation_status,
+            'filename': filename,
+            'notification_id': notification_id,
+        },
+        queue=QueueNames.LETTERS
+    )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,8 @@ RUN echo "Install base packages" && apt-get update \
         xfonts-utils \
         gsfonts \
         libcairo2=1.14.8-1 \
+        libcurl4-openssl-dev \
+        libssl-dev \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -70,6 +70,8 @@ RUN make _generate-version-file
 
 FROM parent as production
 
+RUN useradd celeryuser
+
 RUN \
 	echo "Installing python dependencies" \
 	&& pip install -r requirements.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,8 +66,6 @@ COPY . .
 
 RUN make _generate-version-file
 
-EXPOSE 6013
-
 ##### Production Image #######################################################
 
 FROM parent as production
@@ -77,12 +75,10 @@ RUN \
 	&& pip install -r requirements.txt
 
 COPY app app
-COPY wsgi.py gunicorn_config.py Makefile ./
-COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/
+COPY wsgi.py gunicorn_config.py Makefile run_celery.py ./
+COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/run_celery.sh scripts/
 
 # .git folder used only for make _generate-version-file but we don't wish to include it in our final production build
 COPY .git .git
 RUN make _generate-version-file
 RUN rm -rf .git
-
-EXPOSE 6013

--- a/manifest-celery.yml.j2
+++ b/manifest-celery.yml.j2
@@ -1,0 +1,29 @@
+---
+applications:
+- name: notify-template-preview-celery
+
+  disk_quota: 2G
+  memory: 2G
+  health-check-type: process
+  command: exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
+
+  services:
+    - logit-ssl-syslog-drain
+
+  routes:
+    - route: {{ environment }}-notify-template-preview-celery.cloudapps.digital
+
+
+  env:
+    NOTIFY_ENVIRONMENT: {{ environment }}
+
+    NOTIFY_APP_NAME: template-preview-celery
+    NOTIFY_LOG_PATH: /home/vcap/logs/app.log
+
+    AWS_ACCESS_KEY_ID: {{ AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: {{ AWS_SECRET_ACCESS_KEY }}
+
+    TEMPLATE_PREVIEW_API_KEY: {{ TEMPLATE_PREVIEW_API_KEY }}
+
+    STATSD_ENABLED: 1
+    STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths = tests
 env =
-    NOTIFY_ENVIRONMENT=development
+    NOTIFY_ENVIRONMENT=test
     STATSD_ENABLED=0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # app requirements
 CairoSVG==2.2.1
+celery==3.1.26.post2 # pyup: <4
 Flask==1.0.3
 Flask-WeasyPrint==0.5
 Flask-HTTPAuth==3.2.4
@@ -21,6 +22,7 @@ defusedxml==0.6.0
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
 git+https://github.com/alphagov/notifications-utils.git@35.0.0#egg=notifications-utils==35.0.0
+git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
 # PaaS requirements
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # app requirements
 CairoSVG==2.2.1
-celery==3.1.26.post2 # pyup: <4
+celery[sqs]==4.3.0
 Flask==1.0.3
 Flask-WeasyPrint==0.5
 Flask-HTTPAuth==3.2.4
@@ -22,7 +22,6 @@ defusedxml==0.6.0
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
 git+https://github.com/alphagov/notifications-utils.git@35.0.0#egg=notifications-utils==35.0.0
-git+https://github.com/alphagov/boto.git@2.43.0-patch3#egg=boto==2.43.0-patch3
 
 # PaaS requirements
 gunicorn==19.9.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,8 @@
 flake8==3.7.7
 flake8-print==3.1.0
 freezegun==0.3.12
-jinja2-cli[yaml]==0.6.0
+jinja2-cli[yaml]==0.7.0
+pytest-cov==2.7.1
 pytest-env==0.6.2
 pytest-mock==1.10.4
 pytest==4.6.2

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+from app import notify_celery, create_app  # noqa
+
+
+application = create_app()
+application.app_context().push()

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery.pid" --loglevel=INFO --concurrency=5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
-[pycodestyle]
-max-line-length = 120
-exclude = ./migrations,./venv,./cache
-
 [tool:pytest]
 xfail_strict=true

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -1,0 +1,79 @@
+from io import BytesIO
+
+from botocore.exceptions import ClientError as BotoClientError
+from flask import current_app
+
+from app.celery.tasks import sanitise_and_upload_letter
+from tests.pdf_consts import blank_page, no_colour
+
+
+def test_sanitise_and_upload_valid_letter(mocker, client):
+    valid_file = BytesIO(blank_page)
+
+    mocker.patch('app.celery.tasks.s3download', return_value=valid_file)
+    mock_upload = mocker.patch('app.celery.tasks.s3upload')
+    mock_celery = mocker.patch('app.celery.tasks.notify_celery.send_task')
+
+    sanitise_and_upload_letter('abc-123', 'filename.pdf')
+
+    mock_upload.assert_called_once_with(
+        filedata=mocker.ANY,
+        region=current_app.config['AWS_REGION'],
+        bucket_name=current_app.config['SANITISED_LETTER_BUCKET_NAME'],
+        file_location='filename.pdf',
+    )
+    mock_celery.assert_called_once_with(
+        kwargs={
+            'page_count': 1,
+            'message': None,
+            'invalid_pages': None,
+            'validation_status': 'passed',
+            'filename': 'filename.pdf',
+            'notification_id': 'abc-123'
+        },
+        name='process-sanitised-letter',
+        queue='letter-tasks'
+    )
+
+
+def test_sanitise_invalid_letter(mocker, client):
+    file_with_content_in_margins = BytesIO(no_colour)
+
+    mocker.patch('app.celery.tasks.s3download', return_value=file_with_content_in_margins)
+    mock_upload = mocker.patch('app.celery.tasks.s3upload')
+    mock_celery = mocker.patch('app.celery.tasks.notify_celery.send_task')
+
+    sanitise_and_upload_letter('abc-123', 'filename.pdf')
+
+    assert not mock_upload.called
+    mock_celery.assert_called_once_with(
+        kwargs={
+            'page_count': 2,
+            'message': 'content-outside-printable-area',
+            'invalid_pages': [1, 2],
+            'validation_status': 'failed',
+            'filename': 'filename.pdf',
+            'notification_id': 'abc-123'
+        },
+        name='process-sanitised-letter',
+        queue='letter-tasks'
+    )
+
+
+def test_sanitise_and_upload_letter_raises_a_boto_error(mocker, client):
+    mocker.patch('app.celery.tasks.s3download', side_effect=BotoClientError({}, 'operation-name'))
+    mock_upload = mocker.patch('app.celery.tasks.s3upload')
+    mock_celery = mocker.patch('app.celery.tasks.notify_celery.send_task')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.exception')
+
+    filename = 'filename.pdf'
+    notification_id = 'abc-123'
+
+    sanitise_and_upload_letter(notification_id, filename)
+
+    assert not mock_upload.called
+    assert not mock_celery.called
+    mock_logger.assert_called_once_with(
+        'Error downloading {} from scan bucket or uploading to sanitise bucket for notification {}'.format(
+            filename, notification_id)
+    )

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -200,7 +200,7 @@ def test_precompiled_validation_with_preview_throws_error_if_file_is_not_a_pdf(c
 
     assert response.status_code == 400
     json_data = json.loads(response.get_data())
-    assert json_data['message'] == 'unable-to-read-the-file'
+    assert json_data['message'] == 'Unable to read the PDF data: Could not read malformed PDF file'
 
 
 def test_precompiled_validation_endpoint_no_colour_pdf(client, auth_header):
@@ -824,6 +824,25 @@ def test_precompiled_sanitise_pdf_that_is_too_long_returns_400(client, auth_head
         "page_count": 11,
         "recipient_address": None,
         "message": "letter-too-long",
+        "invalid_pages": None,
+        "file": None
+    }
+
+
+def test_precompiled_sanitise_pdf_that_with_an_unknown_error_raised_returns_400(client, auth_header, mocker):
+    mocker.patch('app.precompiled.get_invalid_pages_with_message', side_effect=Exception())
+
+    response = client.post(
+        url_for('precompiled_blueprint.sanitise_precompiled_letter'),
+        data=address_margin,
+        headers={'Content-type': 'application/json', **auth_header}
+    )
+
+    assert response.status_code == 400
+    assert response.json == {
+        "page_count": None,
+        "recipient_address": None,
+        "message": 'unable-to-read-the-file',
         "invalid_pages": None,
         "file": None
     }

--- a/tests/test_precompiled_preview.py
+++ b/tests/test_precompiled_preview.py
@@ -83,13 +83,13 @@ def test_precompiled_pdf_caches_png_to_s3(
     assert response.headers['Content-Type'] == 'image/png'
     assert response.get_data().startswith(b'\x89PNG')
     mocked_cache_get.assert_called_once_with(
-        'development-template-preview-cache',
+        'test-template-preview-cache',
         'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == response.get_data()
     assert mocked_cache_set.call_args[0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args[0][2] == 'development-template-preview-cache'
+    assert mocked_cache_set.call_args[0][2] == 'test-template-preview-cache'
     assert mocked_cache_set.call_args[0][3] == 'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
 
 
@@ -116,7 +116,7 @@ def test_precompiled_pdf_returns_png_from_cache(
     assert response.headers['Content-Type'] == 'image/png'
     assert response.get_data() == b'\x00'
     mocked_cache_get.assert_called_once_with(
-        'development-template-preview-cache',
+        'test-template-preview-cache',
         'precompiled/c5462c3b6825a44e84dc201671a7c2fb02904f67.page01.png'
     )
     assert mocked_cache_set.call_args_list == []

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -115,14 +115,14 @@ def test_get_pdf_caches_with_correct_keys(
     assert resp.headers['Content-Type'] == 'application/pdf'
     assert resp.get_data().startswith(b'%PDF-1.5')
     mocked_cache_get.assert_called_once_with(
-        'development-template-preview-cache',
+        'test-template-preview-cache',
         expected_cache_key
     )
     assert mocked_cache_set.call_count == 1
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == resp.get_data()
     assert mocked_cache_set.call_args[0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args[0][2] == 'development-template-preview-cache'
+    assert mocked_cache_set.call_args[0][2] == 'test-template-preview-cache'
     assert mocked_cache_set.call_args[0][3] == expected_cache_key
 
 
@@ -141,13 +141,13 @@ def test_get_png_caches_with_correct_keys(
     assert resp.headers['Content-Type'] == 'image/png'
     assert resp.get_data().startswith(b'\x89PNG')
     assert mocked_cache_get.call_count == 2
-    assert mocked_cache_get.call_args_list[0][0][0] == 'development-template-preview-cache'
+    assert mocked_cache_get.call_args_list[0][0][0] == 'test-template-preview-cache'
     assert mocked_cache_get.call_args_list[0][0][1] == expected_cache_key
     assert mocked_cache_set.call_count == 2
     mocked_cache_set.call_args_list[1][0][0].seek(0)
     assert mocked_cache_set.call_args_list[1][0][0].read() == resp.get_data()
     assert mocked_cache_set.call_args_list[1][0][1] == 'eu-west-1'
-    assert mocked_cache_set.call_args_list[1][0][2] == 'development-template-preview-cache'
+    assert mocked_cache_set.call_args_list[1][0][2] == 'test-template-preview-cache'
     assert mocked_cache_set.call_args_list[1][0][3] == expected_cache_key
 
 
@@ -353,7 +353,7 @@ def test_page_count_from_cache(
             **auth_header
         }
     )
-    assert mocked_cache_get.call_args[0][0] == 'development-template-preview-cache'
+    assert mocked_cache_get.call_args[0][0] == 'test-template-preview-cache'
     assert mocked_cache_get.call_args[0][1] == 'templated/8ce6d5144dc8d89998ebe68aa9b91f0112882798.pdf'
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {'count': 10}


### PR DESCRIPTION
We currently create a synchronous https request to template-preview when we need to validate letters but this can create large numbers of requests on the app, causing it to become overloaded and fail. This PR adds a new Celery app for template-preview so that we can put the validation of letters on a template-preview queue.

See commit messages for details, but this essentially:
- Adds the Celery config and new task
- Refactors the `/precompiled/sanitise` endpoint so that it can be used in an HTTP request and task
- Makes some changes to the Dockerfile and Makefile so that they work with both apps

[Pivotal story](https://www.pivotaltracker.com/story/show/169148522)