### PR TITLE
set startup timeout to 10 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	cf v3-cancel-zdt-push ${CF_APP} || true
 
 	cf v3-apply-manifest ${CF_APP} -f <(make -s generate-manifest)
-	cf v3-zdt-push ${CF_APP} --docker-image ${DOCKER_IMAGE_NAME} --wait-for-deploy-complete  # fails after 5 mins if deploy doesn't work
+	CF_STARTUP_TIMEOUT=10 cf v3-zdt-push ${CF_APP} --docker-image ${DOCKER_IMAGE_NAME} --wait-for-deploy-complete  # fails after 10 mins if deploy doesn't work
 
 .PHONY: cf-rollback
 cf-rollback: ## Rollbacks the app to the previous release


### PR DESCRIPTION
5 minutes isn't long enough to scale template-preview when there are 20 instances, leading to failed concourse jobs (the deploy works but the job fails)