### PR TITLE
Add letter address to celery task data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ NOTIFY_APP_NAME ?= notify-template-preview
 CF_APP ?= notify-template-preview
 CF_MANIFEST_FILE ?= manifest$(subst notify-template-preview,,${CF_APP}).yml.j2
 
+DANGEROUS_SALT ?= "dev-notify-salt"
+SECRET_KEY ?= "dev-notify-secret-key"
+
 CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
 CF_SPACE ?= development
@@ -82,6 +85,8 @@ define run_docker_container
 		-e NOTIFY_ENVIRONMENT=${CF_SPACE} \
 		-e AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID:-$$(aws configure get aws_access_key_id)} \
 		-e AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY:-$$(aws configure get aws_secret_access_key)} \
+		-e DANGEROUS_SALT=${DANGEROUS_SALT} \
+		-e SECRET_KEY=${SECRET_KEY} \
 		-e NOTIFICATION_QUEUE_PREFIX=${NOTIFICATION_QUEUE_PREFIX} \
 		${3} \
 		${DOCKER_IMAGE_NAME} \

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,8 @@ def load_config(application):
     application.config['API_KEY'] = os.environ['TEMPLATE_PREVIEW_API_KEY']
     application.config['NOTIFY_ENVIRONMENT'] = os.environ['NOTIFY_ENVIRONMENT']
     application.config['NOTIFY_APP_NAME'] = 'template-preview'
+    application.config['DANGEROUS_SALT'] = os.environ['DANGEROUS_SALT']
+    application.config['SECRET_KEY'] = os.environ['SECRET_KEY']
 
     application.config['celery'] = {
         'broker_url': 'sqs://',

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -12,6 +12,7 @@ from flask_httpauth import HTTPTokenAuth
 
 from notifications_utils import logging as utils_logging
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
+from notifications_utils.clients.encryption.encryption_client import Encryption
 from notifications_utils.s3 import s3upload, s3download, S3ObjectNotFound
 
 from app.celery.celery import NotifyCelery
@@ -105,6 +106,8 @@ def create_app():
 
     application.statsd_client = StatsdClient()
     application.statsd_client.init_app(application)
+    application.encryption_client = Encryption()
+    application.encryption_client.init_app(application)
     utils_logging.init_app(application, application.statsd_client)
 
     def evil_error(msg, *args, **kwargs):

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -50,6 +50,7 @@ def sanitise_and_upload_letter(notification_id, filename):
         'validation_status': validation_status,
         'filename': filename,
         'notification_id': notification_id,
+        'address': sanitisation_details['recipient_address']
     }
     encrypted_data = current_app.encryption_client.encrypt(sanitise_data)
 

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -43,15 +43,18 @@ def sanitise_and_upload_letter(notification_id, filename):
         )
         return
 
+    sanitise_data = {
+        'page_count': sanitisation_details['page_count'],
+        'message': sanitisation_details['message'],
+        'invalid_pages': sanitisation_details['invalid_pages'],
+        'validation_status': validation_status,
+        'filename': filename,
+        'notification_id': notification_id,
+    }
+    encrypted_data = current_app.encryption_client.encrypt(sanitise_data)
+
     notify_celery.send_task(
         name=TaskNames.PROCESS_SANITISED_LETTER,
-        kwargs={
-            'page_count': sanitisation_details['page_count'],
-            'message': sanitisation_details['message'],
-            'invalid_pages': sanitisation_details['invalid_pages'],
-            'validation_status': validation_status,
-            'filename': filename,
-            'notification_id': notification_id,
-        },
+        args=(encrypted_data,),
         queue=QueueNames.LETTERS
     )

--- a/manifest-celery.yml.j2
+++ b/manifest-celery.yml.j2
@@ -25,5 +25,8 @@ applications:
 
     TEMPLATE_PREVIEW_API_KEY: {{ TEMPLATE_PREVIEW_API_KEY }}
 
+    DANGEROUS_SALT: {{ DANGEROUS_SALT }}
+    SECRET_KEY: {{ SECRET_KEY }}
+
     STATSD_ENABLED: 1
     STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -30,5 +30,8 @@ applications:
 
     TEMPLATE_PREVIEW_API_KEY: {{ TEMPLATE_PREVIEW_API_KEY }}
 
+    DANGEROUS_SALT: {{ DANGEROUS_SALT }}
+    SECRET_KEY: {{ SECRET_KEY }}
+
     STATSD_ENABLED: 1
     STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,5 @@ testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
     STATSD_ENABLED=0
+    DANGEROUS_SALT='test-notify-salt'
+    SECRET_KEY='test-notify-secret-key'

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ defusedxml==0.6.0
 # weasyprint 0.42 has errors where it gets stuck in an infinite loop and we had to kill jenkins after 7 hrs
 WeasyPrint==0.40  # pyup: != 0.41, != 0.42
 
-git+https://github.com/alphagov/notifications-utils.git@35.0.0#egg=notifications-utils==35.0.0
+git+https://github.com/alphagov/notifications-utils.git@36.5.0#egg=notifications-utils==36.5.0
 
 # PaaS requirements
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # app requirements
 CairoSVG==2.2.1
-celery[sqs]==4.3.0
+celery[sqs]==4.4.0
 Flask==1.0.3
 Flask-WeasyPrint==0.5
 Flask-HTTPAuth==3.2.4

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,5 +7,4 @@ pytest-cov==2.7.1
 pytest-env==0.6.2
 pytest-mock==1.10.4
 pytest==4.6.2
-requests-mock==1.6.0
 pdbpp==0.10.0

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -28,7 +28,8 @@ def test_sanitise_and_upload_valid_letter(mocker, client):
                                                                  'invalid_pages': None,
                                                                  'validation_status': 'passed',
                                                                  'filename': 'filename.pdf',
-                                                                 'notification_id': 'abc-123'})
+                                                                 'notification_id': 'abc-123',
+                                                                 'address': 'Bugs Bunny,\nLooney Town\nLT10 0OP'})
 
     mock_celery.assert_called_once_with(
         args=(encrypted_task_args,),
@@ -51,7 +52,8 @@ def test_sanitise_invalid_letter(mocker, client):
                                                                  'invalid_pages': [1, 2],
                                                                  'validation_status': 'failed',
                                                                  'filename': 'filename.pdf',
-                                                                 'notification_id': 'abc-123'})
+                                                                 'notification_id': 'abc-123',
+                                                                 'address': None})
 
     assert not mock_upload.called
     mock_celery.assert_called_once_with(


### PR DESCRIPTION
The `sanitise_and_upload_letter` Celery task now calls the `process_sanitised_letter` task in notifications-api with a single argument of encrypted data, instead of with kwargs of unencrypted data. The letter address is also added to the data sent to api.

To encrypt the data, this brings in the encryption client from the latest version of utils and adds two environment variables - `DANGEROUS_SALT` and `SECRET_KEY`.

Since the `process_sanitised_letter` task in api is not currently used anywhere, this change doesn't need to be backwards compatible.

See https://github.com/alphagov/notifications-api/pull/2699

[Pivotal story](https://www.pivotaltracker.com/story/show/170649957)