### PR TITLE
Bump utils to 41.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@40.6.0#egg=notifications-utils==40.6.0
+git+https://github.com/alphagov/notifications-utils.git@41.2.0#egg=notifications-utils==41.2.0
 
 # PaaS requirements
 gunicorn==20.0.4


### PR DESCRIPTION
Brings in letter address preview with line 7 instead of postcode.

Changes: https://github.com/alphagov/notifications-utils/compare/40.6.0...41.2.0

***

![image](https://user-images.githubusercontent.com/355079/92380806-aa247a00-f101-11ea-9fe1-940916d550c2.png)
