### PR TITLE
Give a specific error code if a service tries to send international letters without permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ app/version.py
 !tests/test_pdfs/address_margin.pdf
 !tests/test_pdfs/already_has_notify_tag.pdf
 !tests/test_pdfs/bad_postcode.pdf
+!tests/test_pdfs/non_uk_address.pdf
 !tests/test_pdfs/blank_page.pdf
 !tests/test_pdfs/blank_with_2_line_address.pdf
 !tests/test_pdfs/blank_with_8_line_address.pdf

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -560,9 +560,12 @@ def rewrite_address_block(pdf, *, page_count, allow_international_letters):
     if not address.has_valid_last_line:
         if address.allow_international_letters:
             raise ValidationFailed("not-a-real-uk-postcode-or-country", [1], page_count=page_count)
+        if address.international:
+            raise ValidationFailed("cant-send-international-letters", [1], page_count=page_count)
         raise ValidationFailed("not-a-real-uk-postcode", [1], page_count=page_count)
     if address.has_invalid_characters:
         raise ValidationFailed("invalid-char-in-address", [1], page_count=page_count)
+
     address_regex = turn_extracted_address_into_a_flexible_regex(address.raw_address)
 
     try:

--- a/tests/pdf_consts.py
+++ b/tests/pdf_consts.py
@@ -41,6 +41,8 @@ multi_page_pdf = file('tests/test_pdfs/multi_page_pdf.pdf')
 blank_page = file('tests/test_pdfs/blank_page.pdf')
 # bad postcode
 bad_postcode = file('tests/test_pdfs/bad_postcode.pdf')
+# non-UK address
+non_uk_address = file('tests/test_pdfs/non_uk_address.pdf')
 # wrong number of address lines
 blank_with_2_line_address = file('tests/test_pdfs/blank_with_2_line_address.pdf')
 blank_with_8_line_address = file('tests/test_pdfs/blank_with_8_line_address.pdf')

--- a/tests/test_pdfs/non_uk_address.pdf
+++ b/tests/test_pdfs/non_uk_address.pdf
@@ -1,0 +1,231 @@
+%PDF-1.5%âãÏÓ
+1 0 obj<</Metadata 2 0 R/Pages 3 0 R/Type/Catalog>>endobj2 0 obj<</Length 11187/Subtype/XML/Type/Metadata>>stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?>
+<x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 5.6-c137 79.159768, 2016/08/11-13:24:42        ">
+   <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+      <rdf:Description rdf:about=""
+            xmlns:xmp="http://ns.adobe.com/xap/1.0/"
+            xmlns:xmpGImg="http://ns.adobe.com/xap/1.0/g/img/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"
+            xmlns:stDim="http://ns.adobe.com/xap/1.0/sType/Dimensions#"
+            xmlns:stFnt="http://ns.adobe.com/xap/1.0/sType/Font#"
+            xmlns:xmpG="http://ns.adobe.com/xap/1.0/g/"
+            xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"
+            xmlns:stEvt="http://ns.adobe.com/xap/1.0/sType/ResourceEvent#"
+            xmlns:pdf="http://ns.adobe.com/pdf/1.3/">
+         <xmp:CreatorTool>Adobe Illustrator CC 2017 (Macintosh)</xmp:CreatorTool>
+         <xmp:CreateDate>2020-09-10T15:10:28+01:00</xmp:CreateDate>
+         <xmp:MetadataDate>2020-09-10T15:10:28+01:00</xmp:MetadataDate>
+         <xmp:ModifyDate>2020-09-10T15:10:28+01:00</xmp:ModifyDate>
+         <xmp:Thumbnails>
+            <rdf:Alt>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpGImg:width>184</xmpGImg:width>
+                  <xmpGImg:height>256</xmpGImg:height>
+                  <xmpGImg:format>JPEG</xmpGImg:format>
+                  <xmpGImg:image>/9j/4AAQSkZJRgABAgEASABIAAD/7QAsUGhvdG9zaG9wIDMuMAA4QklNA+0AAAAAABAASAAAAAEA&#xA;AQBIAAAAAQAB/+4ADkFkb2JlAGTAAAAAAf/bAIQABgQEBAUEBgUFBgkGBQYJCwgGBggLDAoKCwoK&#xA;DBAMDAwMDAwQDA4PEA8ODBMTFBQTExwbGxscHx8fHx8fHx8fHwEHBwcNDA0YEBAYGhURFRofHx8f&#xA;Hx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8fHx8f/8AAEQgBAAC4AwER&#xA;AAIRAQMRAf/EAaIAAAAHAQEBAQEAAAAAAAAAAAQFAwIGAQAHCAkKCwEAAgIDAQEBAQEAAAAAAAAA&#xA;AQACAwQFBgcICQoLEAACAQMDAgQCBgcDBAIGAnMBAgMRBAAFIRIxQVEGE2EicYEUMpGhBxWxQiPB&#xA;UtHhMxZi8CRygvElQzRTkqKyY3PCNUQnk6OzNhdUZHTD0uIIJoMJChgZhJRFRqS0VtNVKBry4/PE&#xA;1OT0ZXWFlaW1xdXl9WZ2hpamtsbW5vY3R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo+Ck5SVlpeYmZ&#xA;qbnJ2en5KjpKWmp6ipqqusra6voRAAICAQIDBQUEBQYECAMDbQEAAhEDBCESMUEFURNhIgZxgZEy&#xA;obHwFMHR4SNCFVJicvEzJDRDghaSUyWiY7LCB3PSNeJEgxdUkwgJChgZJjZFGidkdFU38qOzwygp&#xA;0+PzhJSktMTU5PRldYWVpbXF1eX1RlZmdoaWprbG1ub2R1dnd4eXp7fH1+f3OEhYaHiImKi4yNjo&#xA;+DlJWWl5iZmpucnZ6fkqOkpaanqKmqq6ytrq+v/aAAwDAQACEQMRAD8A9U4q7FXYq7FXYq7FXYq7&#xA;FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7F&#xA;XYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FX&#xA;Yq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FWndERndgqKCW&#xA;YmgAG5JJxVQTUdPcuEuomMal3AdSVVaEk0OwFRiqolzbuAUlRgx4qQwNWpWm3em+KqmKuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxVLPNJth5Z1c3USXFsLK4M8Eknoo8fpNyRpP2A&#xA;w2LduuKvnKQeQ9G8yCOXyXYfpC1e9nSQeZILdTcTWxWeF7OSeR4i7R+mUaqrTx2KqYaF+WdjryQS&#xA;/wDKtYbWykKT2eqQ689xAVe59KZkWCVd2hkkmXixWlF61oq9G03zZ+ZVlDbWEP5ePBp9rY2ohL6p&#xA;HIyOoVJLcsscru0anZujU3IqSqr0rFXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FXYq7FU&#xA;Dr1pc3mh6jZ2qwvc3NrNDAlyOUDSPGyqJVo1UJPxCnTFXkI/KDzcNUk9XSPJ95p/qO6XE9gfrbBy&#xA;yt6hEfFi6qjf6xNagDFXofkPTPNemwXVpraWUNlF6C6Tb2ChERBEPW5BUjFTKSdhTwxVlOKuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Ku&#xA;xV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Kux&#xA;V2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxVpmVVLMQqqKsx2AA7nFW8V&#xA;dirsVaDKSQCCVNGA7GlaH6DireKuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KsX84eQ9F8y6loV&#xA;7faZYXr6XeetM95BHK5tzBMnpoWR/wDdzxvxNB8NeoGKvPrX8oPzDsbfRbSz8x3MNhYywzXdra6t&#xA;dW9XVVD8GltbxTACppbcFRq9Vpuqnnmzyf8AmNqvmrULrSNRfT9NMSLbs2o3USSj6uySW6W0IdIe&#xA;crKxuf71OPwA1OKpFqH5UfmZfwy29zq4ntJrL0mtZtZ1N1WaO+F1BGjLEjfBEiRG6flK1D8O+Kpo&#xA;nkH8zBHpyfpP05raZ2vbr9N6pJ60jSW7C99Fogn2IpU+o19Ac6htsVSvTfyn/M6DUrC7n1+WJI71&#xA;LnU1s9Yu1e6McNtF60z3FnceorNBK31Sixrz4q4C4qyTUfy+82TedrrXLTVmtbCXULa9jtIbu6gV&#xA;xH+i4phcQxARS8rexuY1V+S/GvTqqqCufyq8xf4/vvMtnqP1aKa+iu7f07y7RzGZNM+sxzRKPTdW&#xA;hsbhAjFkPJNhSqKsg/K3yr5q8uaNc2vmXVrnV76af1frNxfNfj7IDGLnbWjQIzAkQ1kC9mOKszxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KsF/MFvzNXXvLh8opI2mJco2uqn1Fo5IPXiEiS/WmjmjH&#xA;omRleAs1RTjuCFWGW+n/AJ8SGL62+pgT3du95xn0lSDH9T9WnBx6dl8N1xEVJ2+DnWrYqrQWP/OQ&#xA;0axGfVbt2bREeWKOz0SX/crJCXlj9Yz2nB4pzwj/AHUkRQfExNTiqf8Ak8/m4ddjHmJLg6VJo6CX&#xA;1G01Vj1EBQ29qPWkkYhmYjhEtaLyoGKqG8pwfnHbWGvW2qG4llj0iBdAluG0801BbWjqhjaWSU+v&#xA;9qS5ehPQUJxVLtQ078+ij6dFfXcyPFJFDqKfoiKpkWTnJclUjkR1Vo/qxt0Hxg+r8OKpvPH+bEGr&#xA;+SYtOW5GiwWtqnmZZv0ZIXcrwn+sNyWRJI6KwNrzVjUUAAqqp6lZ/nR/jK0ntNSmj8uNqMpuLVLb&#xA;S7hBaI8YiR2kltZ445EMhZ0aSQH9jFV35Yxfm+2syTedxOLNIroQes1gtGm+pskZSwdkkEbRziOV&#xA;kDFeoXlxxV6birsVdirsVdirsVdirsVdirsVdirsVdirsVYR5xn8/f4u0S28u/WRphT1NQaOO0+q&#xA;1W6gDi6luFMoX6sZeK259Qtx/ZDHFWGyQf8AOQk8FhF6t5H6sxi1LkdGjZRJDEssqyx8ytvHL6ht&#xA;1SMzMP7wrQVVVLC3/O228uJbt+mRfw/V424t5ec/V1tiP9GaQtyn9cJ65nPDhy9P4uOKqd9af85B&#xA;yLfzQ3Fzb6gUiiSWBdKntlX6xyZrC2mmgDv6NOZu2U15cDTjir1/SRfDSrMag/qX4giF3IUWItNw&#xA;HqH00eVEq1fhV2A7E9cVRWKuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2&#xA;KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Ku&#xA;xV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Kux&#xA;V2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2&#xA;KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Ku&#xA;xV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2Kux&#xA;V2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV&#xA;2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2&#xA;KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2K&#xA;uxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV2KuxV/9k=</xmpGImg:image>
+               </rdf:li>
+            </rdf:Alt>
+         </xmp:Thumbnails>
+         <dc:format>application/pdf</dc:format>
+         <dc:title>
+            <rdf:Alt>
+               <rdf:li xml:lang="x-default">non_uk_address</rdf:li>
+            </rdf:Alt>
+         </dc:title>
+         <xmpTPg:NPages>1</xmpTPg:NPages>
+         <xmpTPg:HasVisibleTransparency>True</xmpTPg:HasVisibleTransparency>
+         <xmpTPg:HasVisibleOverprint>False</xmpTPg:HasVisibleOverprint>
+         <xmpTPg:MaxPageSize rdf:parseType="Resource">
+            <stDim:w>209.902778</stDim:w>
+            <stDim:h>296.686111</stDim:h>
+            <stDim:unit>Millimeters</stDim:unit>
+         </xmpTPg:MaxPageSize>
+         <xmpTPg:Fonts>
+            <rdf:Bag>
+               <rdf:li rdf:parseType="Resource">
+                  <stFnt:fontName>ArialMT</stFnt:fontName>
+                  <stFnt:fontFamily>Arial</stFnt:fontFamily>
+                  <stFnt:fontFace>Regular</stFnt:fontFace>
+                  <stFnt:fontType>Open Type</stFnt:fontType>
+                  <stFnt:versionString>Version 5.01.2x</stFnt:versionString>
+                  <stFnt:composite>False</stFnt:composite>
+                  <stFnt:fontFileName>Arial.ttf</stFnt:fontFileName>
+               </rdf:li>
+            </rdf:Bag>
+         </xmpTPg:Fonts>
+         <xmpTPg:PlateNames>
+            <rdf:Seq>
+               <rdf:li>Cyan</rdf:li>
+               <rdf:li>Yellow</rdf:li>
+               <rdf:li>Black</rdf:li>
+            </rdf:Seq>
+         </xmpTPg:PlateNames>
+         <xmpTPg:SwatchGroups>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <xmpG:groupName>Default Swatch Group</xmpG:groupName>
+                  <xmpG:groupType>0</xmpG:groupType>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpTPg:SwatchGroups>
+         <xmpMM:DocumentID>xmp.did:892e7aa8-fd6d-466d-925b-06b9f9b8c62f</xmpMM:DocumentID>
+         <xmpMM:InstanceID>uuid:af858b97-e85b-c548-a17f-60a1ab525c6f</xmpMM:InstanceID>
+         <xmpMM:OriginalDocumentID>xmp.did:892e7aa8-fd6d-466d-925b-06b9f9b8c62f</xmpMM:OriginalDocumentID>
+         <xmpMM:RenditionClass>proof:pdf</xmpMM:RenditionClass>
+         <xmpMM:DerivedFrom rdf:parseType="Resource"/>
+         <xmpMM:History>
+            <rdf:Seq>
+               <rdf:li rdf:parseType="Resource">
+                  <stEvt:action>saved</stEvt:action>
+                  <stEvt:instanceID>xmp.iid:892e7aa8-fd6d-466d-925b-06b9f9b8c62f</stEvt:instanceID>
+                  <stEvt:when>2020-09-10T15:10:21+01:00</stEvt:when>
+                  <stEvt:softwareAgent>Adobe Illustrator CC 2017 (Macintosh)</stEvt:softwareAgent>
+                  <stEvt:changed>/</stEvt:changed>
+               </rdf:li>
+            </rdf:Seq>
+         </xmpMM:History>
+         <pdf:Producer>Adobe PDF library 15.00</pdf:Producer>
+      </rdf:Description>
+   </rdf:RDF>
+</x:xmpmeta>
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                                                                                                    
+                           
+<?xpacket end="w"?>endstreamendobj3 0 obj<</Count 1/Kids[6 0 R]/Type/Pages>>endobj6 0 obj<</ArtBox[0.0 0.0 595.0 841.0]/BleedBox[0.0 0.0 595.0 841.0]/Contents 7 0 R/Group 8 0 R/MediaBox[0.0 0.0 595.0 841.0]/Parent 3 0 R/Resources<</ExtGState<</GS0 9 0 R/GS1 10 0 R>>/Font<</TT0 5 0 R>>/ProcSet[/PDF/Text]/Properties<</MC0 11 0 R>>/XObject<</Fm0 12 0 R/Fm1 13 0 R>>>>/Thumb 14 0 R/TrimBox[0.0 0.0 595.0 841.0]/Type/Page>>endobj7 0 obj<</Filter/FlateDecode/Length 284>>stream
+H‰”‘MO„0†ïýs,&”¶‚…£Ë‡‰aMÔ&{Øxh » l«Àeÿ½-`b¼™I:íÓy§ï¤Q­®z„hŸSØ9 >Æ3Š^)œ'DB’%ÆktB_ÑÌ[5²Žª…Â¢g;¹hèÒWJê^'ÄVæ’¸#qÊc”“˜ò‚ð¡†^C ßÝÞ¯·$É¸Èak>”gá
+CFøÂóÎ6vP³†J5³¯¾ˆn÷Âµ5­5Ê„«—û§¼ô§Rþc.ök.çÚË\Ê(IÁ ¡a™nˆ#–†O;Ím5ôæN!%0oòqõÆRáÝ±jÛQOô;ƒr6ÔV>¬õÞöO¿Íx¹wÿö-À Ènendstreamendobj8 0 obj<</CS/DeviceRGB/I false/K false/S/Transparency>>endobj14 0 obj<</BitsPerComponent 8/ColorSpace 15 0 R/Filter[/ASCII85Decode/FlateDecode]/Height 105/Length 110/Width 74>>stream
+8;Z]]5mkCM$j=BDs+C,BMc"2L[R-\3QlNaAZ^;%!!'D%'j-4\4Xj=!rV-R9lIe+@F
+1_DOI8niRcT$j!JM<[#k`K"eQ57%;i!8tP#!+%oRMu~>endstreamendobj15 0 obj[/Indexed/DeviceRGB 255 16 0 R]endobj16 0 obj<</Filter[/ASCII85Decode/FlateDecode]/Length 428>>stream
+8;X]O>EqN@%''O_@%e@?J;%+8(9e>X=MR6S?i^YgA3=].HDXF.R$lIL@"pJ+EP(%0
+b]6ajmNZn*!='OQZeQ^Y*,=]?C.B+\Ulg9dhD*"iC[;*=3`oP1[!S^)?1)IZ4dup`
+E1r!/,*0[*9.aFIR2&b-C#s<Xl5FH@[<=!#6V)uDBXnIr.F>oRZ7Dl%MLY\.?d>Mn
+6%Q2oYfNRF$$+ON<+]RUJmC0I<jlL.oXisZ;SYU[/7#<&37rclQKqeJe#,UF7Rgb1
+VNWFKf>nDZ4OTs0S!saG>GGKUlQ*Q?45:CI&4J'_2j<etJICj7e7nPMb=O6S7UOH<
+PO7r\I.Hu&e0d&E<.')fERr/l+*W,)q^D*ai5<uuLX.7g/>$XKrcYp0n+Xl_nU*O(
+l[$6Nn+Z_Nq0]s7hs]`XX1nZ8&94a\~>endstreamendobj12 0 obj<</BBox[69.7324 718.778 173.787 661.636]/Group 17 0 R/Length 54/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ExtGState<</GS0 9 0 R>>>>/Subtype/Form>>stream
+0 0 0 rg
+/GS0 gs
+69.732 718.777 104.055 -57.142 re
+f*
+endstreamendobj13 0 obj<</BBox[83.8071 538.982 340.154 388.51]/Group 18 0 R/Length 55/Matrix[1.0 0.0 0.0 1.0 0.0 0.0]/Resources<</ExtGState<</GS0 9 0 R>>>>/Subtype/Form>>stream
+0 0 0 rg
+/GS0 gs
+83.807 538.982 256.346 -150.473 re
+f*
+endstreamendobj18 0 obj<</I false/K false/S/Transparency/Type/Group>>endobj9 0 obj<</AIS false/BM/Normal/CA 1.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 1.0/op false>>endobj17 0 obj<</I false/K false/S/Transparency/Type/Group>>endobj11 0 obj<</Color[20224 32768 65535]/Dimmed false/Editable true/Preview true/Printed true/Title(Layer 1)/Visible true>>endobj5 0 obj<</BaseFont/DZLLWQ+ArialMT/Encoding/WinAnsiEncoding/FirstChar 32/FontDescriptor 19 0 R/LastChar 121/Subtype/TrueType/Type/Font/Widths[278 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 667 0 722 0 667 611 0 0 0 0 0 556 0 722 0 0 0 722 0 611 0 0 944 0 0 0 0 0 0 0 0 0 556 0 500 556 556 0 0 556 222 0 500 222 0 556 556 556 0 333 500 278 0 0 0 0 500]>>endobj19 0 obj<</Ascent 1006/CapHeight 716/Descent -325/Flags 32/FontBBox[-665 -325 2000 1006]/FontFamily(Arial)/FontFile2 20 0 R/FontName/DZLLWQ+ArialMT/FontStretch/Normal/FontWeight 400/ItalicAngle 0/StemV 88/Type/FontDescriptor/XHeight 519>>endobj20 0 obj<</Filter/FlateDecode/Length 21334/Length1 49336>>stream
+H‰Œ•	TTW@«ú÷¯(;(vÿß¿UÂF&:„àÆ831’èLâDAÅ=*™ CpÃweQATTDQPÔˆ¨¸¸wÛàµLÓ@ç5p˜Ì™““yçT½ª÷ªÎ;ïþ_õR§ÏŒ'H"FŒ|·/´#“¨˜¤è”Üµ;ó0Àå³˜Y©Rû¶ëZ —2)©Ý÷~
+À7MJœç¹òÉa ÍM€žÅñ±ÑoTžÎ‚‚ãÙB{|x9S~ñI©s:|@ÐõÄä˜h~¸`~	óo'EÏIiß?É”45:)vÐä½˜_ LIž‘jõ‡l€Ò»¶ý”é±ñ¥?8TÇe`ð`Çoâû±[ø´Ï\Ä)\íx…)¶¡lë)˜3˜¥ÚÛòG,AHÖf¾¾õcì'„bI Õjeçêù
+Ûi dZØv ;ãÇ,ìÎ„ c‘Í
+…-æ¿Ûä”<	vö*G§.]]\ÝÜ=<½¼»u÷é¡Öˆ’Vçë'ë{öêíÿNÀoú¼øÛ¾ý‚~üû÷úøCÈû¡„4xÈÐð?ûÓŸÿòáðFD|üÉÈQýÛ§Ÿ3vÜç‘ã£¢aBÌÄØ¸Iñ“¦$&MMN™6}FêÌY³çÌ7ÿ‹¥}ù÷¯Ò/ùGÆ×™K—-_±2kÕê5k×e¯ß°qlÙºm{Nn^þŽ»
+
+wíáöî+Þà`É¡ÒÃGÊŽ+¯8~¢òä©Óp¦êlõ¹ój.^º|åj-Ô]«¿~ãæ-¸s×`¼gj ¥s(»h»ª A°­
+I1Z±óåFpÉÜLn!—É-ãr¹+Ü¥“r„r	ïÆŸãŸó¯‰#ò!‘P$Y…$u‚zŠúŒºFmÕ,ÒlÖ|¯y+zˆjq¨8\üT-Ž?ˆ¥b•X/Ä—âk±Uê*é$½ÔG
+”‚¤Rˆ*‘"¥di‘´V:¬åµnZ/­N«×öÑ~¤¥Ô¦k×iu
+éºê\uºî:Q×[÷Žn˜.Zë«ðuöÕÊ +dGÙYv—½å²Ÿ É!r¢œ&§Ëò2yœ+ï•Kärù¸\%_’¯Êwä'ú}˜~>J£ÓOÑ'$ÌîãUÐ½@kQX‚-!–PË@ËËAË3‹µyBË-¯Zš[}[›­Í¶ÿŒýa9
+PhcÅœÁ¥ró¸tFm—ÏÕr?(»(#”ü*¾–ÿŽ€5i)Œ¢„50j‰ê*u«4išÍ+DoQ‡‰ÔÆ‹iâ±Z¼)Þ_‰o$\5F­¯Ô¿“Z£–%å´Qóì 6\;R;–QËê¤æÂ¨uÓi:¨Eé&¶Q“~ZD'µ,9G.ê¤VÃ¨ÝfÔtR‹Õ'0jQ©ŒšWdA‹Úò£fl	·Ô[š›#[BÛ¨I­i6jÖ‡¬>_2¹ÆúÑûLzÛ
+®u²M+k™åß^‚ÍµÍù\6_ûOY6¼T¾`^ð„U·ÙÃìfv1w5;™Íf•ÙÞ,˜ÉÌ›9³ÂÏmß3YÇ$½ñíýÂÆÙ/˜]ö¢?Ó™ æ6–›/?h\aÞÐPØmÊ6å™–˜vÙò¼LÓLã™h
+3õ3ùÃC!ÆþÆ`c?c ±·Qgô1ºÑÐd0žØ²Õ†“†JC³Îvö†ü:ƒÖ y´±ñDãSEœWœ+_ÉJp‹°YØ$ll¿'=£P§»NuŽÏyàbÚºëú\#4ŽÂ$Ï`z5”E;2	¦<áh{¶†I ]_»‰v9ö¬k«<m«*×	‡_ª Õ'L³>­šõ³Õ¶¾Ý¾¢Úò‹¹Kl¢ÊèðÒí¬ŸeŽSEvÚcþøN+Î!Ä!þ8È‡tXÌE²×ç	,°¶ÂnØÎÉ~kà;ø–ÃzÈ@dïéKØEð/x¯!öÂy¨†}0b &BÄÂ9¸ Wà"\‚Ëð-ÄA\…Z(†IÐ«à:\ƒzˆ‡g`†¯!&ÃH‚D˜
+9Ó ¦Ã˜	©0fÃS˜ó`.Ì‡ð”A.,‚…ì•ÿžÃ8†Ù¸È¡y°@3nÀ¸	7C´"¡€v`Å-¸·ávÌÁ\´G: #æa>¼pîÄ]X€…¸‹pîÅ}XŒûñ Ä<ÿ†˜‰K±ã,Ã£è„]ð–cWtFt…F¸nèŽx=Ð—á	¬Ä“x
+Oã7è…Þ°`7ìŽg°
+}°ªQƒg±ÞÂð ¢ˆjQ‡çð<^À¼ˆ—ð2^A_ôCõxk±¯a=^‡rì‰½°7úÃ#xŒ7(“–Ò2ZN+h%eÑ*ZMkh-­£lZOx?ÚH›`m¦-´•¶ÑvÊ¡\Ê£|ÚA;i(”S¨vSí¡½´Ši? ƒTB‡¨T™¨L¢Ãt„Êè(£rª ãt‚*é$¢Óô¡*:KÕtŽÎÓª¡‹t‰.ÓºJµÊfe‹²UiåG^Ás¼’çyâÞŽ·çU¼ÕÑ5ª§t“nÑmºCwÉ@FºG&j FºOè!=¢Çô„¾¥§¬ÖŸ“™^Ð?©	oâ-¼wð.\gÁEpÜwÁCð¼o¡›à#ôÔ‚FIÐ
+:·Ÿh®ïà.‹4àï>û{vŸç}öG
+5” ô’T:Ò{QÑSô¬¨3Š¥÷TÀ»çD=å5¢Ò„PEI @B$·77÷Çþµ³³3Ï|f÷û•ÒPb¤XŽÉq9!'å”œ–ßåŒüá.»JWåªÝwÕÕ¸kîº«uuÑ ª¢`ÛØ¶6Ù¦ØT›fÓm†ÍÄdi$íKöe;Í¾b_µÓí;ÓÎ²³í;×Î³óí»Ð.²‹m-´KìÒà× Ø.Ø×ìr»Â¿^oøWl¥]eWÛ·ìßìßí?ìÛÁÁàPp88ìŽØ5öû®]k×Ù÷ìz»Án´ïÛì‡v“ýÈ~l7Û-ÒD¤©4“æÒB¥¥´’Ö’$m¤­$KŠ¤JZ¤ RHÝ"ÏRwêA=©õŽL¡>tõ¥~ÔŸÐ@Dƒi¥a4œFÐHE£i¥q4žî¤	tMŒ,•tÉLÉ’li'í%Gþ”³R"¥rNr%O:Ð|Z@i-¦*¤%´”–Ñk´œVÐëô½I«£:‰b¨ÊÔuQý¦.©rU¡*U•ªVWÔU•©jÔ5u]Õª,Ÿ­ðA4D Á€†Peƒ€ƒ(Ôƒˆ…8ˆ‡úÐ@µƒ†ÐHµW9Ðš@4…fÐZ@"´ômžÏI*WåAÕÚB2¤@*¤A:d@¦äKG9,¿É9/erA.ÒwÙÐÚCäBt€|è7Àô=ý ÏÂs0ž‡àEx	^†ið
+¼
+ÓéG˜3ií¤]´›öÐ^*¢ŸhýL¿Ð¯´ŸÐA:D‡é7:BG©˜ŽÑq:A'é¦ßéýAg©„Jé§2º@é•S]¦Jª¢jºBWaÌÆXŒ£º†ñXŸ®S-6À†ØS¬°	&°æ#¶LÌ²°Ã¦Ø›cLÄ–åzÃ±Ø
+[c¶á8ŽçúÜ€r#nÌM8›r3nÎ-8‘[r+nÍIÜ&j8™S8•Ó838“³°-&s6·ãöœÃ¹œÇ8Ÿ;ò|#wâ›øfLÁT¾…;s¾•oãÛ¹+wãîÜƒ{r/¹$åÜ›ûDm”¢£u|÷å~ÜŸð@Äƒyåa<œGðHÅ££Ñh½hL4–ÇðXÇãùNžÀwñD¾›ïá{yßÇ÷ó_ø~P*x2?Äó_ù~”ãÇù	~’§ðSü4Ì‡°Áb(€BXKa™\†×`9¬€×áxVÂ*XÍÏH¥TIµ\RyGÖÈ»²VÖÉ{²^6`¹
+ç¡L¿¬_ÑÓõL=[Ï×u¡^ªWè•¾¬Ñëôz½Q 7é-úSý…Þ¦·ëô.¸ ‹ô/ú >¢ëÓúO}N—é‹p.A9TÀe¨„*¨ÆNxÞ,å}ù@jäš\—Z©s\«P×à:ÔB´Ò µŽ@©FLÃ,¼;ã­x»?Ý{`/ìƒ}q Å‘8V·Ä	xÞ“ñ|ŸÖ©ø,¾àsÑ4|gà,œƒóp.òi	.Ãå¾W¾©3q¾…oãZÜ€âfü·âgø%~í›ÍÜƒE:÷á~<ŒÅxRçâ,Á2,Ç*¬Á:ß{¬Ïð1&ÎÔ7u‰I0-|jå}’ikRLšÉ0Y¦ÉÑMžÉ7|CºÕ§ýn¦‡&ÓÓô2½Ms‡ékú™þf€h™Áfˆj†™áf„iF™ÑfŒëwÆÉ&ùøÿóÑ¡íþ73ÞL4“ÌæAÙâÀºz.Þ5rM]¢Kr).Íe¸,—ãò]'×ÙÝîz¸>®¿ì†»Ñn¼›è&¹Üd÷°6‰&¨#ê¨*VÇÔqu‚ëÂ T!„:Œ„šÐ†r†º0ÖcÂØ0.Œë‡ÔIu*R©ŠTG®D®Fjd·ì‘½R$?É>ùY~‘_e¿ƒðü	g¡D¶›‚`ŽÙ®òƒ-Á'Á×êtðq°9øF¾¦Û‚™z ïC}‡¢æ«ò¡GêQz´¦‡‡µaÁeuF”€ºQ´Dà«ÈÁçâ¿[±+qn·Ûãöº"˜+‡‚Á¹àßÁš @Ý,T]ÕÓj±*P…ê™àŸjª°™bž2ÏÀ·ò©l•ÏäsùBþ%_ÊW²¾ƒïáøvÀNØ»aì…"ø	öÁQ(†cpNÀI8§áw8ãuvñ‡áp¡[êVºµNò&ïÅIxŸw:ã¯ô.œˆw{¹ý°?ðÖ¾Áíø­÷¶wáno÷Iœ‚OyÅâcø¸NÕi:]gxÍÏáT|ÞKží=Ïôžçzß/êLåU/ÖÙºn¯st®ÎÓt¾WZ—±Ò‹-ÅsxÞ;õRãÿ{§wšh&{«™‡u‰>ëW©wÙÕËìî¥ÃãxÂëM÷†S½áLìerL®7ì=g{Å·˜Î¦¦cºî¨oÐåº·	ÿa¼ê££*®ø·–$,!_(oy&•lV$”B–lvC€|énd7$M‚­"$<>´¤‚TÛ¢‚ÒÒ—4Ð@¥T=öhEÛŠíD-èIÿ ¶ûú{›³ý£§;ûÞ»3÷ÎÌ;wîü.že?¥ËlJ#2/â¹d}£Íæ%‹o}ùg@â]Ñúk¦þ`}dáÇ£ð·(•Jh/PðNj%Õ e3U (hßÉÒÍNš|,ðô@öàäc4–¥™Ÿ3oï¢×FJ¢	4‹iocóÌTKçäšFó€¿[Ø:3hn7w˜/À+ŽŠ·Ì4œ2€ì—Pù…ò¾ù7ò ÇÓðœslÇ°ÃäÅ,ë ùc`ö=b‘df£ù4p¹÷¤2êaÝÜÑè"Kck„£ì3óuH£EÈö ÓNe³¹K©5ËÌ‹9VbÔÝÔp69N°D¥Ï|Áì£tÊ¥¹XO'dÝ"zc}t&,¦ÀJi:8Ëè·È?N;¿Æ—)‰Jââ£æ{4†&S5´Ýžg_â&Ç].Þ”³˜’a—ZÖ¦7€å3€)°»–ñçÄ”€'£Ô#SÙLÏ`ô³@-G€HzÅ>yP^³Ý=o&cG²éYäN¯!CH¢=¤ú÷ñÅ¸_.ˆòeyÚÁªïE¾³"ûÅòY9ûkbkX+NßnàþSìŸÅ«ø}¸išÄrq\£TÊåxøÛ¥h0úzôÑ/Í<s•ÃÖCû§‘•uÂOz%ÏÐ9ºÀä9É(VnQÍV£<†˜ñ³X¦Ó‰YN±ìSà±«ìpoeZ˜	EãðGpGîÅ¹¶Nöçüß"ULÀ™š*
+EH,ƒV­â)”ÃâC™!{òóPv)ÏãÎ8¨œPúl‰öÇ(áëûnäÜ8¥h[tW´#Úi~H)ØÃXa<BûÊRì÷.xÜ/é]dfiØVÄæÁ2‹ÙR¶œ­„%Ÿ@V÷bL÷CÈ³z\ÎI@|–Îw «ó(÷ò¾÷üÞÉÿÌ¿vÜ	#DŠÈ³Å"Ñ «Ä.aˆwp_ÿ×QLéãå™-Ýr¶\,WÈçäEyQ©EôùÄæ°}ß¶	ùÏ?ìß²ÙÚËí‹€ðØßK[qú×4äÇÎøÅaÚÎ§ÈtÄÆ“ðçÅT/Ê8<•`m|-ëä·)+m3ø6Ÿúd6lý&(`†(c¥¬’–òÉý£ÙÆÈWð)”¿§ËòU¬í$F^iKdñ+¶Dê`Ä§cÎ7ÄÒ-Þ¦Ä9f—?¥¿J2ÏË|¿X/8.‹” ¹Ä^:$–³µt˜û‰×¶Âç³WªXû—0Iðùð¢iâ#Ú@÷ñ÷q?<Bmô#V/i;Makè"½„S1Q¹0…ý7KfÄåËXÝtd¬BCO°Ebí
+?C+¨W:è¬ø9´ïå‡D™ìS*XNÀZÚDËÍõ´J	ÊÓ¬×öÝ”%Ï#º­yÒ…ïUjÓŽàtC˜%ÊÐ’Ï™¿¨F„Øƒòâ„„5ãŒßƒ(v’:mU¼‹•d†¨C$ßŽVPùí6é~syZÍ5ñ }BOÒ¶1ºšZèVœœ³lžà½JÀôpŸá•|WüþÂÚY,>C9„J‘òÒå_¨’fš[Í?Á»oG„ÝMut}ŒU~æˆnšÏÛÍ€hÁzÏQ¹¹ßÏÔd~Ð«ô¢]¡ˆÝ=6Øi¬w55ð
+ó!Ñm†ž„¼°Ö
+ÄŸÍ^_uÕ,ïÌ¢oÎ(˜ž?mê7§äM¾sÒž\wÎÄÛ¿‘u›6Á¥Ž¿õ–q™éi©cSÆŒ5Ò9"9)q¸cX‚Ý¦HÁåúµ@X5²Ã†ÌÖæÌñXu-‚†È†°¡¢)/c¨á˜˜/é…äwÿKÒÛ/é”dNµ
+=¹ª_SžMíb5åAÐÛJ´j\ŽÑe1ú©ÚåBÕŸÖT¢,¬úÀÃMº?\‚áÚ‡;|š¯ÁáÉ¥vÇpÃA©ZK;K-b1‚§úÚ9%$A)#C+ñéZ‰¥!²ü‘zcayÐ_’ér…<¹ó-ÑêÒŠî˜ùbÓ6ŸaM£6[«¡-j{n·¾µËIuawb½V©"²æéÆ¼%Fê£§}]Åà£|ÁÖ¡ÜL¡ûÓšU«ªë­ªñ“òàP®Ëz‡B}yV ¬0õV±´RÅl|c(h°˜RµVb­ª}šßj	/UaZ±Ö¤/ck2tƒ*V¹:22¼GÍó”áWõª æ2ffj¡HÉ¸ö1¤W¬úUºWMçxrÛ#ûÛž<b€HLJ4òbTLÜ¢J+-Ë,´¹pC]¢B“ †5å[¯†|Ò—äC¿C/£;Òló…ugÕnõ7”,§¦êW	 ]þ<¾%2ÐbËr^%‹´üdÐÕÀ¿In·‘“c¹ˆÝ‡=…ŽE±úTOîÃ]\ÓZœ*>0-„m#¡‚I0¿Ëemð–./Õ¡b¬+ö×UªËì ï$wÈàa‹Ó}““RmqÖÝävkðäNb)FBöà„sìhSÁÆþvC?¿´R+-¯	ª~=<`ÛÒª¸Z??7@£}A‘É(ž)b\8eí °U	&2[Ì©ë»ì	ðÊXS†3<§ÿr¸\ÿg§.³Ïêû|Ým@M£À_ŸWS/QPWeiU®;âxpµþ	ç|àñTt©>ƒªq2³ðï2»ó­'”ixa2Ÿ% ÿëo¨Æ	fÐ!ü,ïôäèt= ©=¬GºÌuušêÔô£ü?¡·øÃ7§Ë<¶%ÓlÁVM¬ ‡‚Sq»ÆÚÊÛ½¬­²&xÔI¤¶U;8ã¾pqÈ2$÷U‡î^ìH„<ÄYÞ*¼l'rtÌÂ‹áÊ»®Šîë^…®‘*»qù­“BNa§dÖxä?ŒWlÇžÙ÷ÞîÞ>|ëÛ;ûÎ{>s6·<üÂ°p­·*……&œŠD 4(IKŠ+N Qi£@x(*Ð4u±ã©”X¥i*¥%iÕ(5„´±B±EøÎýgïPQ%ö<óÿ;{çýþ×7ÿà ªQmTßØž¢r«GQ8¢Œxí²Ìµ‰2™Yž¬ÕkßÖˆ+´çèÝÚ;ìï¸ÓÚuMØvh…jk¤ãÚ°<¬EFf&HÃvÂ2Œ¬ŽçeÐèù ,¼ÆSe™jC6/‡àEÓdÍ$k´ÍÈ!ø•gY!ÎÑ\µÞ‘ â/¨~,!Œ%Ïm´Š§¿¾ZË‹½›ÁLÆž´P>Í_”éÝ2–É½¦òïñÔ³|Oñ/©|h9ÚHvCüYCÚP4¢!«5jÌhCð×ÉNrœ­Ú@ç$Ë—X7\WwÝNm` 80ÐÉdC=žw\zlÞñ8¤‡Qiï‡Ó»5®v¼qCÖñ¯$nÂI8Ñ–%èT-ÇÓTÓŸ©¥^Ë8ôWüŸ}³ª+›ØþÛ³ð[ù™Ô2¼çäw^ÜZ=ö1û{ÅÐù7VROÆ(Ü7v­G’¸6ðß5ïD³Q£²º’M±´-¶íg_£ªœ¤{”³ÊŸÐ`l8¦˜‹Ñi®NOWÚU³•Å¡%æâÈö©Øc—±ŸÞÜ_yÿ„:ª¿,ƒþ(ª…´(ðÑëu.¼ó´7±ÎÕT„™Š²¸LWÄQK©sQÊÆG«Â)[À‚LÐ‘øÊå–³@q²ó‡h7aB­C­CzØw9N6»WðFæ˜du5¥Ù¨ijdÂ|*•¬æ(3d”75¶0=g¾ûÊPþÃ¿Æ_>ów<aÆošÎ¼tìŸË×^Ýqä2E5|vç·xÝ¹+¸íÄ¥w'þøG‡óŸýðTþ“oÏ†~îä¸„^öLŽÏ#š‰CúÄ¸„žXÓŒf~=×Ø
+ˆ*Œhc~mkP	àâ›=ªZTÅWn÷ø9[Pü0\÷¤\PVžñxÁpÿÊfæç2¾ý#ƒjÍä2dîäŒ–Ë4Ô7é	3Q‡™šÑWigô}zÛß•oýe^é"6¶ƒ"zÑs|~Àã»f€	mÊ–(**=nOòËÅäÉ? ?0cù}ðïÃ?ˆZ‹Ð³ÿ‹ý(}aô
+u<·àžÞ•[ö ê4 fÑZOÆCÇY$Ø¤4©Ÿ{*OÑíâ›%Œ·J9‚Q»YB˜ËhW³ßT×ž3Ô9¨¤á.xÅAà¹*â?¼õ„!‘xÊÌfÁ’ËaHý$ˆ& ñØ¼ $P<M"CQ"/0´ÍqlßØ§>>PnxÈÜîE‰/Ù¬-a[Z(­ÖK+	D^¦ÀË.(L1(Ÿ?`p`Fû=ƒ¬CLÚ"7$`{+ÆÅ„™˜INçÖÙ"N"zìÒ›²Þ,Ø0!Çio¨‡’s`î¼Y.˜ºw–+xµÑå«#.)øÞ¨•¬&}Õ“’.Á(#÷#½e Æ
+jT“¨·N˜n).D¦vˆ†à$±~ð,MõŸÍ³ýw¾Ï<{{Óq§v$t"Õ‘²P5õ†ÄFKå²ªÕÂÚ* âÁŸy®È~’(ð~_‘KŠTRŒ¾±ËÝF´äõîêÚfÜÇj›µ¢T‹žÿ¥;–*<‡ïkEIž{s@œ[9×~LZ^¹¶r£øÝàfu{à9u¯rLíS¯?Vµ ,ÛºÒuUWeÑ¨ Ñò §)Ef-Q,G#ñ0Iˆ	s8ŒÕ~ýZ–ª…x*x#¬N’ƒ+%(—¼jbÇ‹¹¬]³¾¦£†®©¶¶Ô¹ÿ›UÉG(u-ëgYdÐ¶Îhð)½Ï2îd#Yv;ƒ“öC`òâÎæÜuÒËžêªÚtÝ˜N‚7ÀâI„ŠF\²Ì€ô*]­:£
+ÆÝ´TI4–Ãa”ãËÃåá²$=‰ªM%“:,·´LiN%‡¨üÞÎÏ¯kûÚØÈ™¶uK&&æýÚ¾gÁÞ#ùz¶ÿ‘ßo>øAl\Í‚§ópÃ¶¦I|îiºiêæÙkvV­~ê÷»Ÿç=…¥âpÐEþWì£¾Ýmzˆ79S“iLƒþöNCò.=~£DT—K®-¹:ï·PˆüG¡wßýœ­Tî`ö*qqYêM§>¥Êò1fg¾‚Uººn´„øgHeà¿y©ñ(¥7R–‹Zt×h±æ Ùúc¶µ-Ñ—K,íá•*0€×¤áhÄ1›Ùfy&;Sžg.bÉ›O°OÈO™›ØMòSeM™FØÀ$J 9ÙJ.bõž
+/N3,Kq¼ °H+Q	ªª*3³<lYfßX¦›E–M¤lèDzËL @ÄRð`cd±‚7­iZ†,ŠqÓ ÕÐeUµ5=¤iº!Ê‚e²ª®ÉˆH,miª*Š‚@&Ë0t	Ñp8ª}IÄ"É0›0<ÄâG{mÒ„D"}x×‰BZg£‘ù¹¨•ËE#9kÁWVÍ¼z7£µâ‡d3ièJès¾OŸ¤ß{@@à:ƒÐðÁ”(i÷OÐªÐêÐ¾n,(FÒüÍ;>Ó°x:B8" B¯„•nÙc=øð2Þ˜Mà¦²òpËTˆ2è1i1~5¿åìÅšè´ ÿëÜ#ÉÊ‰WßÎ¯;•·–‡òï°ý£­{_þwýQ.šÿtxWý+ ÕìöªÙwŽ ¯Î»ÆT2_Duh*5Ñ› *b:¢DÓã•tÚUZÌ©ÓÓsÒY%›~RùVzEýNeÇøýå¢Ç³®ÔhÖ’¼÷™ëg‘_ÔõFNÕDÞ«;g^¨f–ã89$è$éãÞ!a
+a¯6¢U…«,gBºÙeÜ	s˜¯NX,´;«ÿËuµÀFq]Ñy3oÞìÌîÌÎ¬wg×ë1k›Ý5dÀx,Zê¡”OjÙ\Lp°›P~M`ÝòSJ€„o›¦¨•ÚTŠZšÆÆ8h¤¸-Bj•È¨¤Züªš:X-r
+Ä¸÷>Û€*{ç}öÍ¾÷î¹çÞs}kÜM½?îé÷\kzÆ ÔœœÌD§–†c+&®Ÿ(Nt&ÕÆŒCÆ°!2Ú;†duÆéáv!	Ü8bš¬Ñ ÕÂÓp¤èiñø©ØÁ°ã(.ŠsJÎ-×¦:’b«Ù*0ÎÖTi³;þvF²{’"¥aÜ—ç»Ü
+Ð¹‚ì‡ß(9ÆõäiñyÏ(÷„´™.IOI·§å,f'ÃÓ§‡/ŸâŠ,ãÆg¦d»³âá,ÉFñl³ñ£©XÙää‡¬‡‰	VÍDfðTày Æs@ Ã¸vcÏ&nÎ*f<ÖyÐÙ.ˆfšûÇb;(÷æMÔß}nuÿPŸ…}t}W!”æè+!Ÿbl|Yº*3mÚtþW•)Gq®”I¬„µ#‘°Ÿ–˜b€bGÁ‹¤ÜKgÖ¶0ÿ[ªÖõ®"•s÷mßZÜ{åÂþ}ÇëM5Zöýú¹õË§¾¼fõÏÓÅo4ÎûõîºuaC'SÚ+ÏÌjÊÇòß«ñZ¿:iËÀƒÝ³f«sBíä-Ï/œµâaýð-©<:N–yœËÛƒ$è'žPU$ÐãWbõ#¢øÐü
+7¥@S*&šRá6øøây^˜˜çš§â§bJ‘7_„3§`N´¡ !ÚRÐ}[|[ú‰~Ô<øôBm­¸FZ+olÐwèÇï«§´÷;°'ð‰(e+‚ëƒÛƒR€z[§x¨8Öá°pC )ú…ÇgtàèIÃÇ=¸¬î—ô»	ˆ™ËX@ŠWð² Ñ&q\Fžu"É…$”j(g\¤h¸HáT*Š2çFó@<âÍm5ãkx"‡úÛîºýmüîàVv²ÙÜÿèyÒœo‚ÂÐ¬Lh€=Z—€,åNßy¯÷áçm·÷ÿæJ¢½pû²}ÇîZûÙým)&Ú»DÜÙ~¤hÝ7ÿø×ËxÕÝ<Àì:ä0K(&ÞQM¤zJÏè_Ñåªp•óœø5mq¸ÁY%¾$¯T_·8Ý‰‹ò¥‚«…7n†ïD?-¼Y|#1œ°	7ž³sñšø†Ä„2ILê“ì™b•^#ÎÕç…ŸužÓ–è«ô›ìö}r×0ID2üP´­-A‹ ýc•DHYÁ”i^°ˆiyV‹µÃ¢	}"á¡—X!kHC‹¡Y1þ/Ðâ–‡ñg<X¨­¾ŒèXß%?Tz”ëÊ°B¢…Š¤Œã.Ç™¬ŒqE\
+OJá¸Lý“Õc¾¶è±¸jÎçÌ~Ðû}ˆY?2¾
+ùÒ*d+Ðu0Û„£…Š©ŒI3VžÛ~iãÚ‹o´ühòÉ¡’w7núÅ/_ÝrdÏÏÞ|ðÎ!"}wÑlÑ¸?O}ôçßŸïýèbV™cð,˜5xÑ„àD hj–›ÕFÿJi¼^]é÷E0NòkCÇ[Œ½bŸå¡¿É÷ÃƒqZšYXáÌÕÆg;‹BË;­¡—ã­Î¶%2(ÆLÁ&A=­·[ì¶d;ÁæaS4MZähŠpV<ŽËƒ4Áj¢ÝM`ÇÁ`OÔƒà
+_:b[ë˜!Ð¤:®WËŸÊtèD'`t2•Î`ëÍÆ@œ 	»ÒL*^ò©ÌR%O åp¤FæpŒlŽ 5ýI¤ÜÚ¡¾:3ïºƒy×‚|î‚ÚÇÉEj>ÇµÂEšy%ù¶1Š™BåTÁ
++¥6âEJÓ<ÌJ/œ}ú³3·Þ!á+—ˆA¾¸¥uî~ñÍ¡^qQ`Æ’ýßùY}§‹$ˆDdÂÃkï™%ígW“ƒ{æ¬>Qd¯ H·€qaÒzF°áæ‘hFÂ¤Ì“GŠVIs¥³:åS3£…™¨Ï
+XaI&BÐ‘•°_¤T¯rZfX%Ý*±9?lQP'ðgY¡bÚ´ÐL*O›j×ÁìàKÔ0¢¥"9ü¸¯ªaêÄïO¡=Õ:Áˆf¦e:ì[Ü`¶;ìa›Úb8…zà†3À}@ó]€øI±ºé-|î{Q<„À·|¸µ@GKžûž[	"Ïý"×âu‘ùõ…8r
+rcæ]×}’j.@À1 ŠÄŠ)s¶z3””ÁED÷‹ˆ€îNÀ'.T·²ÎŽXã-Î7±öv½Ö½é½š®ëê¿Ÿ“Ïýû‡ÍG:´B<²÷Õ†·¶ý¶ä=|K>ö^P§áªÔÃj‡Ú­^WTEPêu‡zhtê†:¬j	òƒBEIeÒkD`2£SR²@ÑÃ´ƒvÓ”uÓ*
+´„^€¥€·}d7ÊíF5Ü•†ÑntD[ñÎHý/<mHë|ÿo½6°Ö/ÕýdLF£ƒ·åÝ‚ªÊˆVÙ×ÕÕE?íéy¡é½XÍÀ¥ÿÂýb«WÄFâ[Â–©RPÿ<È$5€§d(»ðxÚXGëH(GM|±QÚ¬‰!VRPšñ8*ÏÀª.hC2Ÿ(åÞ.˜a”Ê”MWçS9ÅžÑ–j›¥Z¯ô	SŽ12ž¥•”/Ëf¨ÕúB½‰6±¥J“ºn•¬žg¡—Y»­|Îîù"!M“%‰ŠŒ)PŸÀ Š””ÂÂŠÂ$JS²–eM`¨ª)*cáä÷Ô”AO•)×Èe>•–ðÎ…œ? AÊŸÄ!R-,¼
+îã&W¬&÷tŽ˜âžÎS¾ÀåƒPÐÿ^:ÿ1×­»û¤\-ä~Oƒns-ˆÂþG•¤hv¯<É¥ÛÌsÐÆ\:ŠéËùrŽÖ‘zJê.ITcº•ŸÏcÍ2gùROSŸ.Îª¾ââ v­³8ÍÅÎÞœ(Íò#4Av‚%¸.¼qF`ÃÝ¥Y ±»ÓÆæZ§™e#xsÂ?ò²Û4Ã½ÐUJ|av‡süovÆðåøÝÕÛÄ}Æï¾óÙwgßÿîü¸ó#6¶c›8@Hœ¤I¡1
+…tLIì1h—@6(+/-¬ÐŒ–Qš i¢Òµ“e F Q@ÍÔ=5±t*£[Q*T1Ö‡âìÿýÏ!)Û,çî»Ëÿþ¾ï÷ø‚ÖrTh±<,‰º(.Q"“”@:½õÏbz÷¯Å£?"CÓEÔWÜ8²Šl.¶A_¾D6õ‹ã)yÐ‹úÇ²tŸ­µöUÓ­}¬œîså„V>Âæ‡xn1ÙÜãm~ßÃòa-‘µYDw¢„æ­©ÍfÐ ±‚ìDVû|œÕÂXÍª5E'ã h2cÐ$Á(•9æ!F™fîëÂ  0hÂ| 3/õó¾|’)iÅ¢ô>´-§ó6»Î¾‰Ïãlë÷lt;š!¹²›0:ˆQƒ‹:<nO#Zì>—èrËî„AõÁ Z!Q•¨JHUB¢?JŠÑà°¨JHT%Èñ–JHT%$PÚÞ"	‘¯Ôl@ Æ=ƒ]g1úŒƒ3ll×Gsý _U­Lþo¡
+u‚Pp¥Ìä´G…§ÙºÆe‚dõ>¯%Ÿa‚.Ð¦áqõðÙU§èÑfÇIâ(ƒHµ’ŠTl'…T‘ªxëJ³UjºÕÞc/ÜZqô›Xì¯X3ý	.yàäÜu‹ª·¬g_þ~ç¬}7F.‚_›CüZŠTÑÅ˜hÍ9¯¿D'\I›EÒ\‘Iÿ¡	¢)Ï³Ïw,··8ž··;YÜ¨5új¹x¡¶Ð7×ÈóyçR\Ð
+¾¥F'ßé\…;µNß*ã‡Èë´ó®6Û3ü3b›¼Ö¶š_-®•EˆÔ$yAj£ƒ´¢(–¨._ÀÒÔVA@5 ¨(!BôDy¶J@Œ€…(1gÓ‡‚(çŸûFbw‚‘Ý
+!¥G:ß1!Z_jÛêv™ÇG+œ#·Œ0M$aÓ`ãHQÇ+GL\áA¡0¡–tD"Ð4ä\Æ/s®äW:9àX¢ãzR4Æë¡vNŸàºçßuå/È·åî«CÅáwN÷¾|úÌÎÞÓ¬ŽR{6ÿ6róîQrÝ¸~ã·W®¿G^¨·ØÎM"Ô˜2´2·GÆSðL¼sMÑ¾(‰N–ãájouxvx]toÔÑèo.ð/¶8Úä¼?ìp¬‘Ûq§Mp úç–q+ðAÙmÏí²££Q_œËàŒ·–kÄOrp+þ»t7\Ä’ê&†;d‡Üã6ƒ"ÂbN\!öˆ\”–0JËItøNN‚BŠFéøË1þ”Ö’*5”P„^‹C²ÅH¯ak´r† ª†Ž >tqÔ„ã
+¼E¹QuCTÝíDç#`†ÚÑ¥ÔÐ!nŒ4¨+2#óê4îÄK®d¹ŒŸ"U$e<–&&²ŠéÒn–oó°0=¥TÛ„êõoÜ÷½Ÿv¼0´¥õµ©ê_|ûÄ†õ§Šíü¥W–,Ù=zðõâW¯>Ý8ò•íøÍË×ý½?—î$P¼Jj¨2×rOÓæPœËrßà–qÏq8»Su8N—®:]ŒÍ$š|Ft¦÷:#Õ‘ÎÆÔÿï}ªÄç9u¥ÙiË“$õ—$â~ÉþÚ'ØƒfmÞåÿ²¿·qá~7*ivˆÝm VŽÁ×zÝÛ.C®ºQ¡¦”(¿ y%í<öD{SÛ³OÌžýø³ž2.y´k~ã‰Ô¼¦Ý#¿ƒ,4þÃvŠd¡ÊæÏmábžX£ssNbylul«ssGâýíÊßØ\NÀðW-¬üƒŸ²ßbY\D#ïÈ;ób^ÊËyW‡£ÃÙ!vHr‡«?ÙŸRRÉD*1¹.Ñ*¶H«’«Òâ=‰ýâ/ä}é•?¯:.þR~=u<}&y%éKCKÂoñ± 1¤-_YZA|,HŒaâHrZYC«#U.‹\ šôrÒÔpà<ûV.fVBò#f“¹ØüŽyÒ|ß´+fÄü9dró5“5/‘ÚxI_ÐI6çåå‹Ñ ±ˆ#&Û3_ÖšpÝj¡©ùðÚ0y^ƒšt‚Á1{~'§C¹ÐT)@„™Ól5\>@jÖpeú GÌ(\iFá*“ZN“N³æy¶í´¨ —ž5V 
+x
+\Qâ·¡\A‚OÎÁEú¨I©ŠìŠêj¶©º§š­Æ¡cXN•¶\ÔÊ2!à È™ðÑ„B¡®Ð×S¢°L=ŽÂ37<P¡‚3ÄætàløB×¢è‡É&»îf*Æpª+N÷!‡w'û¦á.­ašå‰=Ðivò%=ï·t:—šRç=•IkXÇ6{Ì2Î´Dü²)óÃIîx‰Å]²c²Dé”S´g¸ ÁaPô¸kkÞ5S‘Ù¾};3 `B*èõ>‹jRÉÔT¶6[WoQÁU}Ÿ¸ kÉJ²é´²kËÖkË÷_=´xÖc?[¶íR«Ú'¯oßÚáóMîx÷Àòö«ÛÞÿ3šZÓ½zÎÌ¸Q^ýÔöæy›Ò‘Ìü-ÏKóKëã¡°.&jfmÍ·þö¯ §‰ÑÏØ
+þãgþô#’Œ'abÈÍ"AI¦LÙ%"ãÃÎŒ"‘°I
+Ž11äÒÊe4*8æ:ç®Ö	=Â^cˆFú„aP° ÀU‚%4ø¬8K £f (¾`y5KýAe`(,™ Ë¿ØÆ@u§ž{ÄÞ¢&Nß¾?¤š„@òjM¾†7“)÷Cþ’µj¼¶F­'LW=zžž±rmåŽgÎžÕ3é²£‡ñ«±ßÝ„µÅŸîÙ¿¨2 9šT\bû”K2ôïS,‡Â¢G±I¶©hvÉ®ç4%*åä¨B1§˜Ó2[ãfÀÄ°£ÔJÛ+xF	!¨¤3Ôö,WNŠ¶œ+§°J4]•Å°d§æsZJJÉ)W\çªuR¥´–ÖçûZ´½ÅÛ®µëíÞMö®MêfÏfïN×+ênm·¾ËsP|Sºˆ­^ð|"~ìù—ká•i¥)Î§K¡ §ÌQv(6Å|øúõkJüÁ\½¢ÈXÕ4‘±™]/×D9PþÃ}µWU]áuÎÙçÜKr!7/Éb ¼HIˆä‚<BRž!"mP±^¨(…Z'•0„´>J&€¦IfK Ú¶±£NÛŠ¶
+Ì )¶u‚‰Éé·ö9'½œ P¦ýÓ{ç›oïuöcíµ×Z{o_D¤otx’WXtnåá@ÃüÃÔÔa'†©ÃŽ©9G"`‹@Ì1uY <'*¥–EˆR£Ž)³ŽF(I4'1Œ?IkFúÒ|‹|ÚbŸéS}hq85¶QsÚG–ca¼Þ‡ä	q—Q¼çï¾ï¿€“<!ÎY–(Ž·›ÃŒŸ°ÞÐ',a%UCüÙÙÞßä·)Èo[RZòò™—(Ü¼¤LŸ¾Ü~¿§óý£™YaI™YCàjGb³"“b³¬W+.õx¸ò“2:…C5“ÿJzômC32£Óœƒp¬Í1_Ÿ˜;4rŒÞ·î•÷&$˜p¾­oíÌä´ò¢¯õ­yÑ?6911\ŒíÝ½qKù&5ØóZË¬åìWDºú£’§N—Ed_ñ&z‰MçSÆ3ÿZ¬êjKï?y}¨B{îxfô-¤»ýtµåêc~kœßài†-R³úÑª¾Cß(˜ïNßÓ‹¨D©¢RœHåm8Ä!zm¢>ÜÎ}Ñ¾ø3	¶lp/PÀu´=Î}1ÆzGò*õŽ ‡ô"³óÕêt?Pr“8OŒ,Z‡ú>ô;!ˆ2¹úÔ©òçð}dõàÔQ^~ivy§†â™òqg‡½ÞíeˆæXËrŒ™lÃ‹Ás|´‰Ïª”ªV:Ì&|S%æ¯b90Ûæ\Œ³ßsÐ/õJ” ‡Ž FcÕC”¥ÆÐËàT¬¿ØZ7ÐAðšû×ýmÂÒ1?˜ó—Àj–y<(D77*]˜¯¥S8$KÔ7hø)°×ný"iøÛé}à.±š¢®@Ï½öpX ±ÁìÏQƒÖMÓñí1£ëX{O>£Tõ¯4ÉM›á_³1þ c^’þ°š–aþÉàtqQúÐ6`'æú›c'¶ê[°¯K1×è_ ÌÃ¾T kYÌŸÊ6ç}WŠú²ÐöÚ¬`@>TkgŸä>Üc¶ý°éßLMhS»þ,€XÖÁô3øvãÄ0˜\š€ p'ŒÅÜ„y5é¯ðöMéð½6„nÒg­5ÔËý´b¦Ñ‹çe¢ Q<&Çû,tyÉ›cŠ}ÆaéßAé÷Ÿð:Ù§ú±'ºhë c¾å0Çtæx¨ÅÝ­¼~\É>Ëú9Ìva_“6ALØœ²Ö4#`èÛ×+vlÑÏÐ>Œ¹Ò¸9¥rÅw)W{šî§ÙÚ8š¬§A†õ m«ÚEK½'){¹õÝ.®cx:•õ“Xg3ìÙIÏÃ¦‹N5It*ºÞl~¤“rFoV—åì†rÒúÆÌýöŸÊoêY½9³ÙüXï4M¬çŽ	O—’ŒtòŸÀxï¥ÎTŽypÿ6ˆº‡D€îÔ”)Nbb‘çêÐ	­†¶‹NóJU¨´ÍK÷ªµÈi˜K=K•¼>Ä®ñ9·/9ìø«›9çÛ>5l þÞ´qÁÆgÀøQ>|2žÏÎÏò|@Ž¶Yþj^í÷Ï3ôx‡ãŸ.?ºüÓçöK7Ë³ùÝ‰Sè±ÝY?çGÎqœ#9ÏqžqÚ»9¤ÿ“êAø1çá7¨ÔŽë$yÐñC;ö‘‡±ßÅ¦iÌ5÷mæ-Ê<`LEù€nîÇºí?SKÌ>û<çœ¥–œÂsTO§uv>Û'óÍ§ôcyŽIý-´YïÁ¾#J}ì„=¡wP¬„Í÷ÐN¬#^«B<B¬`›È½ ŠãsÏDmìÌgQUjïâ¾À}Ó)Rž9TÝÏHÎTf–éÅÔdtÑTQˆ\{’Vó^ñ:XÞ{ïFìEžè¤)âE´‰¥0´k6Ð~éÜ7ˆláYEøìB´áñeŸ EÙöØ'm!ûã.Â>Ì¶À˜F,-•÷‰.ú‰^HÅˆ¡FO5âKˆ‹ãô+d]Ð/Až×»èÄW5rS5rIÿ/5{´f¬çQäu@«€š)N¯€ƒrí³…•c«8~´ƒ4†}ÄØ…<Ì÷‰]ô¤˜@sŒ Õ@V£#ObÞ=øMCìnGÿvÞ&Ì½rî›Ãw¾#p¼xmTÈ{ Iøž‚ùµ¨QË£jøñLï.Øa+M‚Kó¥ñv`ŠYÜÆNRæ·X¥ùé,WÓémÌNdòz\l¡o‹"šªMAìFÒ$ñ;Äêç´W‹ 2ñ:íÇh'×E4ÕZ±þ6Ü-Yþ-f¹ú6êuT*²Ñ¿š¾#Êhƒö|ï÷&îÇ^£ŸþCøI2úŠqm(ç©T+BlmCùsó·“s´™Å‘K“d¿H]¸tVó±ª<ì)ôåò5úB×~=¯£Ÿ\'‹~ÜFì¥lØé0Úâ¾%j5êŸènm}_9`¶Ã®s]È­‹iJ90YL£Ÿ[PžþÐbÕqw›Fï[1ö)ða~0ÔY”ÁY=PüÖù
+žçzòPè‰fû5õ#8k ¥Ûlg¸ÛÃÎ˜/CÜe¶3à‹yc3Åx6QŒ–ùíèçªë‰ˆ§#”¬‘ùÏéôUÀ/-ÄŽÐ5:û¾í&p.„G2ÛgÃ-ëv«Àþn¾)íû	ÅZ>DC”³æ9p‘r–üÚFø €ú$Ô£{:ûù³RîÚ?ø
+±ÍÝrwÝ½¯7ª«‡©,ŽôûÃ34ƒ!rÐp×½ghÃxß^Xûo€R¯íaàƒ)ëÆ"Ja¨ÉÐ5û æ€þú[È ·•ýÓ<Ç.CmÃ{èÿ>æ0BìšÁvÕöXßýqöÅ½?Ð/ Þ¤ùà1à,p8ÏáÐ˜uÇ­[æä’ëµqÅFÚ—ùÿÄÎë@pú=—BðUÀçpÉÁ=²÷“{¨’¨¹ä‹Tà§ÈCËÀï@†Ó»o0åHÈÖ€Ÿ'ê¹‚ò#wZ0U‘Hö½2²£v_¯=^Õ¿ç5¢«Ý@‹Õ¿ç ð Êÿ pž÷¼>®CûÑï	ð+Ö÷Þ2Ô7/£Þ…úZ å§À±à‰@4…þµ¾x‡þ×ùúï›eÜYVAÏàvp¹ûqÓììçØýÖpöÿF¬Ûo‰lÙo¦qïk}û|ÕÇaìg_(D¡Ù‹;¥ïÑ|—åû³¼?Ú,ßoò‹y‰b†>ƒøþÊwg¾¿‚yü*C—úB¯•R/ûÜÍ­J7Õ~ ñ_¬—l•åÇŸó]Û"V ]ÚFÄE†ÝQš8e²"]¥ c2äÐÁœ—8‡F·"—MÄ1Ed€Â°ÀæâMØæ/è–053jT4ÈFQkÏ·ßó~ïwzú•Ò žä—ç¼ï÷Þ/Ïó­½œ2Ÿ;§F{ð=¥œïC¼îUHM1ÑËÄ®RbÝ.üî!ìK¤ûc%1-ñ­]|l1í›NkŒü
+1µÖ2-Ewù	g[.PÒ±øXé)våXÞMŒ.ŒÓ_7Äù„âI­Žˆv*i]ÚEôîIçk:­;Ž9Ò%I:M—ïé³—è™*©Ê“ºwÇŠ¾-¼‡:´2†ô=Îß7›fÎ/?Pmcè&üú?êÄ¨è6òn*úRj‹vH-é‡€¸™û›ÕoØ?fVŠ8‡£vÒHŸà½dÊN¶d{:Ïés«úÜèCÖÌøÁ[uür:œ}á¯0'Ùk}CÒ÷ëQWß¹Þ”è·R°G{¦\;H—’.Å—}ðÛ#äOü_‚-Á–àß _>Á6jæ™2cøVï]+£ñós½½´ùnô>}Ž—“Òð8i!v.$†àûê.%]Ž­O–{içQê/×|BœD<,ÖØA¿M².§ìEÞ'r»ÛKFÒÎ@ï])³ö¿M¦k¼
+S‡˜GÞw±ÕÆ¾+C¼©2†ÓÞ05î6ÎÈ>êœ2yÂ/OxÛåjÚ»¿¤UÖ?+ë‹²R_t³¬	Ze»N’·.ü­¬j¤EÛHâªÆÄä?b*ö71é*kë’9§5ßTG\ÞTØoR¯¨žXú	ó§okOÚ†¿²ÌÃÃN÷§kä´F/ÆVfÙ]>æ7ÉTÆ9\×Ô¬íTipoâÝ§1]ûß‚ý·\ê-»Æé±$}±.íÝi¡D›ðŒÖ}6ˆôÓseÎRÌD¿Ù¯tÏüÞÜáRÝÿè1]Ãõ”w¤Ò;œ!§Âùª„[g=wt.w…3è­F3µÊ"e£-¦Þ¦ÞÈ †3®fúiÞë@w½çM”eÖK÷Ï)‹Ã^í¼@_C¥Ô¬ß5Œiûü3ôHë¨ó®ðªÉ×óy1°ÿðkÒÍÜ­5k5‚z¥¼ëtŽh*w°ßŠÜsT_±n¶løˆÔ‡#8¯½¤Þ@ºW¢_þ†¯;‘½Ã¾–ÊB÷9É;[f¸}$«dê£=™X”ºâ|HþëØU¤[dŠóª\ÊzÍ‡+`ón3<V îË/-3§5óm¾¿	—Øÿýãÿä•‡I­²¥ ÊEï@›s;}×IÖy”>60úqOàþ¥ Îe–jÛÏ(ow¬3ç¥¡®ÚÓÓ¯ö;il~UòÕÖ¥!¿îãè®\wãè.Pò}ãè®ÝSÒÊQÆ76ùcaÝ­óÀ4ä<Ê8Æ§!|zø'Þ±¹gx›nÇ¾fãý~ì8,§/÷ÿy_DÍ6ýš-÷¸î„ÿAŸM£Lö¿°:ÈíÆž(æ—ô­†ïASÜ—ÖÍ=÷m°}æˆë·ï°ã-Hç¾ïÇý™¾Õ÷îÄžkmù¥¶ßûã±çVw”×ï:GSïþ"~Ì÷ØÆrÅDObÿoÀ³ðœý’]ó#ÚV‡_/¼µ²Bý¡Æê°UÄÄìdœñ¹/wŠUFcg¶áû†ImÐr·Ô©nPîÏ4å—ûYb“ OÐ
+F/¼-¾÷´Túûdš7WFº£‹GáoéÃû½üDÛV¿­šÃ½E.„	Ãð›Çâs[J4úåÊ”y0Þ;eo¶¥þdé¥þ<LúVæ²Q®÷oyEsdWð1cÝ+ÍÄ«Á4ê/ÑÉÛ6˜#Åþqèk{edFñ‰ä·wß—‘Å-èºWdkvVÒw~B)#_÷¥—cårìý—50ÎŒ™ñ¢Ã<¯=†f2ñú§¬IÖŒg¼ÆOï>ñÜù"þAb÷R£½N—¥Å²!8Ì<úªQ]—_û3ÜVþ\†ø-2ÈŸÈÕ ›ßc/–’ÄâÛw…3$ô§Dmh·Þ,£ûzÛ¤ÂhbWÞ&m´Êþ|YÁ™œÖ5‰ŽÊk
+ßìñÄ¤ü|°?óó·¶@o˜u'ŒW.5~9gÝÑÅÚ1…å²•²Ë=î’1¡‹Ý"ÍÁiô/d]úIcø¤ôGI…ê³04ºnŽÆhÿs´h£âìŸgïû¯@ïÒ({Ç¯%ÿUØßG½_šoî&yíkmþ/àF˜×oÑÍñÿöƒqûæÛqùvîa´‚esTZÞŠ1ï“uªÑ£±¶îlóºÞœŸúmJvgõsFúåõp¢'»ÚÕØYI÷wô6êžA¢£Ó–²kÐ(7ÅÖhCµ›­½GÏšj½´Íëênlwúµ@ÇÆ÷,±±®^œ²—Z;(Ñ×=Ù¼þîd£È¦Ïëõžl“Ýim¸ˆM¬Í/-°A—÷S¡5{"®Õ±ªßÇ¨¾ö6 E‚ž;%XÀèL“â®’ËŽD@$QÂ+:cu~·¿£H}ª0æßÄDwYX6)nFDñV¥‰>5èÛíwÓ/îŽ1úÿ(°rƒ‹úh,<*¨%<hYžEJ²îÉ:&ëÂÜÞgÞ³òcNú·í~Ý}üºûòMÍûhc/„;¹(G7ûcø4FýeûYÖõqØÏ[V+Ü•*îí!w&ç	
+ët9+y›*6­wQ	PvaE|x#}#—i}Â™ñùO×Éo“éV{íc½Õ¿+Ö÷,ž /h’ê[ˆ»zÏÏðþ.Í5_ÔÈ¹©Ô»Aœô)ßÇ¿Vê¢{üyø„£çü›Ñ@_‹,»-bíýû³ÎCå1ì}…ð¶=IÑ2ôwl¶z[uìÕ1¹âüŽq%¾×ýŒy´I¥êo„Tý2[Z Ò=ÀwôsXêN—s5f¸ßG[¡?T/˜» ÒÏ{Ó›u™àn-¸ß5²È›È:j"³OÏ´ü3¦~•õ‹ÕÚ—{9~ü?2À9@9¾Qo©¶á?(óT¹¼(ü‹8”mˆþéÞmùæ2Þ&™í,’ÓÜf©u^Aï”“\Éÿ
+l)\ëà:bòÛ8'_P\ô‹X_²Pë|nY£ß3u’u–,š8K{q¹½¦NL ÙÌ?L_Y·Žö(çðRrQn¹ýð}1õv¡@h/s nË|KÊw”ñ?’ú’f©úÁ-ÑNÿÜhgf¿ó¦Hö´7œÉ^ï±ïÕQ/«­'ý¼ó€LSÜý2Æ°6Úéž
+Öú;d¶ÿC9ÍoG¼Á9x[†ù‡å.¸TˆcÛEÏÒ9 o»fïšèKÎ]£³7Ú“ÙÊX
+&KyñÓ2Š=î‡$ÖÙØÌD„3-UoÛbEÆ»ÃµwÍèÜp¤,ä×Cì‹b­UFÝ½{ü¿ÈÄØÍÒ?Öqú†Ê±Z‘Þ‡F|C	uìnà<mÔ³eµ U£íÎ¿ô]åTE;ÿÏ~¹ÀFqœqü›ÙóÝñ°ï|á|»6ö9¶©Ï9óà;CZóªóHÜ×Á>p|È>@©TXÔHiš(¦4"-mc¡J”¦XëÈ9°%S¹%…¦¥@%’'­Ò¦UêªBMi£^ÿ3»¼	UTU­:·ú}yíÜÌì73|%…œº_°ï¥Ù]à°í~÷˜yv9»_pƒ\ðïö]{h–k&X {Á­>æ3êpÓÜº÷ÑB«åMT¡uí¹¾“ïn 2/Á;î¾¿÷º¸Šº¡;ûüEš&ë­ìVÿé~Áµÿ}'?k\]o×ÖôÇýÿ®¬8#ûÊûÙóð_ß@|=$pQ6‹¼cÎyí	m¾í4î K¨ÄŽáˆ]Bü
+¹žÂÚÃ¹ßnîBlª±qþC±G8ûßãh÷ïâ\ªMFü±gE§}qOªõÅ9qo‰ˆ}93h­ˆµ"¦Ê=gQqOC¼i±…Ÿ¢þ¡ƒØy	‰X¤å#vÔ¡uRK›W81¥ŽÆðü—oÚh¾ì)“òì˜¥ÚËˆx†ý×ŽW…ÚÝvüâçìÄ/¡ÌU.ƒßSßÂ ØsþqXîM³ã¤Œ…ˆÓÂwçþäß âEüNç%çlyä#zàª¾Ó¹Ð©sÄ©skù&jt½Šurs'öä—©<çwíÞET#Æ?ç]y_©G¾8ƒ\?ç‹=Oì“rž0Gkq&ú±Þ\ç©QÌmNŒbïÂ8çnÐÍ6rŸãø[œËÆbß].ß‡ö'b^vú)î'S°NŸ¼v÷»z—»z× ºÏõÒ6ã,TMõÎ~?xÃýö@¬3;âRÅìœV¨ÍkØ)¾v{r6îÁ›sÃ…ëŒŸð¯‘÷®»RàóØjÆ_gb/QÁ!›)óñIÏ±™Šq-<A¤?fc|¨ßHéº[)û‘B¡P(
+…B¡P(
+…B¡P(
+…B¡P(
+…B¡P(
+…B¡P(
+…Bñ#ÊI¦ùô=ò'?Eh‘«ÍUH9ð‰ò%I#ñÛ"¥°=t#û7“•8¶FyìAÇvÁÞìØnØÛÛC±¯¢$sm²ÇfäK›SßäØÒÓŽí‚½×±Ý°èØèÿ&ƒ¢Tg¬5ÔF	è”¢¦Gi›LY¯¶-HOÊUÈ‰S;ƒV#m3ê§©Kz	èJï€lEÉ8ì$êŠ²IY¦¤e{­(ót'mEZŠ6}Š¾ˆV;d‹v½µð’ðÄÛj„Õ"=ûÍHÈÙv›ì«AámGnZöV”®:lD««gkÚÆŠTG*ýè¶„±(Õ¹-ÕÙ’N¦:ªŒx{»±:¹¹-Ýe¬Nt%:w$Z«7-_¾~Ue¼3ÙÒ¾bÍ'yRÉ.£ÅHw¶´&iéÜj¤6}ìûŒd‡‘FÞÚŽd:Ñj4¦[Ò	Tîh¤:r:©íéÎd¢«ê?8¿‹©‰–ãYO«¨ò†Ù^·ŠÒ›1®írŽ?©ä§ÍûŸ]]Nœ lí§ÛüŽÑíž¾ðdýì VN#€kåVe¡~L+Ó
+­ûôXF›Ö˜õÅ?£ˆ)È8
+†€‹šµÒý»	Ž‚!p¸ˆB2× )ÐFDŽV¨-C÷ÇË´)¨;‘Æ§M¢QéÐ šA7ènYN¤¤Àn0þ$sbÚ$k_ú>ÉzRª¾-íQé¶Øî’nßúm½b•­/±‹Í³‹Ý;ÃN®ª³uÙt[J£¦Ðcs£'âZþd:¾’ñŸ1Òé 6‘z×ÜNJLô•„£=Cš‹˜Æ5†‰Ô³'4fåæGãcy–R€tþGþ¾ÃßïËËöÄ—òwè(ÏÛümÚÍGÄ˜CÖ‚0Î€Qàæ#xÞÂs‰_"“" 4ƒ0F‡¿	éçoˆý@Ja×Îß€ôó×ñ·^‡ôñ‹°.ò‹èÚ/­Ùs£Ç¤Qq½Ô1&MuŒ@A4Ã_³®”cE…1ÓXQZ1-¤­Ø*½WÏh“­ùI=ÃÝgTêãÕüõìt~`€•àK`pÃº ë™`/8zV¤ü4x\ j+—Ÿµðš?c…ëôx•¿L“0â¿Àf%ô+ü¤Ô?ç?•útú4?i…tŠC>¡ŽÚA~ÿq_I@ÏÆóùÆN‡Œ€ZÐ šA7pó!^lµê42@§½„’½'õ÷éy/Å¶è±ð",@Cˆð¼° zŒž0…÷®á§÷Á"üØS°„y,!Âí;`	nÝKˆpS3,!Âk`Adøs/•”é³¶2#îã;1J;1J;1J;ÉÅwŠ‡®¸Dß¾cUT`ÄÄ*Ë+tó83™¹š™Ï33ÁÌ]ÌÜÃÌùÌÜÀÌJf™bfŒ™l†Âd±orçÆ&3ó43_`f3ÃÌ,ef	36;–áEÖ’©î—ª/.>:è}|¼#Z„5_„˜0yd¥C!£Ø.<%$tq_E­íWÍ‹¦âõ|‡1Ãôpa‚†±Œ†ÑÈ0ðAÖ‚fpŒ‚,p£t1:Þ-¥2jA3ØF[vgpJ9]<*;q:Ý <>Œ§O/ŠúƒþJ½Öd¾keC|6 "ò½ù–ÛÿAî_?È¥1ñ1üiÞM…˜ˆ½Žî¶®êö-+< Ç'²g)äÂªcs)ÌJ¡çP—ôgRÐ+ôœÊŽ@G­à:TóYáéúq–'jõëW‚¿Ñßf8Ìßô_³ôóH9Ò¯Ÿ>¡ŸŠd¼HgÔqC=œ£¿pZÝƒŒ–¾K¨~ý+ÁÏé[ƒ2#aglè‚óé«ÃMz=Ú[|Xu¡Í~½6¸AŸo—š)êôëÕèB¥mV ³åAùÒi!ÙàÚÙÖ›îÙïyÀÓà™å‰z¦{Š<º§Ð3Õ3Áðú½yÞñÞ±^¯×íuy¹—¼2Ù‘X%aê&¸ýB¹]Bº¤íçBŠµzÌËi)õÞ¥-ãËëØ²ÞiÙÃFï_§eØØUM½ÿd¼|z“Â0>Ãj(bµínÊŸl³`Œ“jbš ]CévW{Á–4;¸ZBRo&=6\šØ˜z1ñà'h<ÍÊðâ™OÑ`ûð}g°'Ì¼Ãóüf^f˜e—»ºIÅŠCœš)^0§ï‰"sD¼úÖ(ýÄA±}JjnŸŽQ:K‹•]w@(]>»Hc||vÁ9QS'ÛêöJiùåkkNÓˆZ6+ê­~V|qö]ñ-ËÅsìŒ³ÜŸ÷5ÏÐúË¶ôwJ‰ÞØ{¨+%‹s§O$G4zœ˜kÉ-À9¢-äBîkÈ`<pyÀ%¤ ¹B"!¹;¹ÀÏÛVÏKfU#¾düUíOfT ¦PLªKF’¥ºÈˆ’D2@r‰Ð5’‘H†®Iä`†<‹ó)r.3)tÆdBfñjÂ,^Ãþ·´LÆhÏàMÏnévC·[PâãÉ±*ºGš49šP5ŽšÇ[‚ë-K4uKoŽí¡mèV@<»æ^¹e}7Ê†­Z¼W©noå:ŸæÚ¬Î™¬Š“mb®JqŽ]D»‚¹Š˜«ˆ¹*åŠÌEä¯ºÁ1ù®Æ^,yÎk#½ÎÍÔÒû’<¼ÆºzšÂÓÊ%I2.îë¦X„ŠÖÆÎÆZpM¡õ ä‡‘¥žëé!½Œ¬%—u“°vÇïÕ~g…/
+HínxØ2ÿ_<[”-¿Mˆ#žì;bûMÝâqP¸$±5Ñ’I»?þŠOAÜBQQ¦ j¯PK$"ðïï¿Å]¼
+º±=ZÎQøsÂ‘sj1ø)¨Õa­^ÝÂ³Þ|ô)£þdŽèc3FÂ÷×<©íNÔ‹ö¢Åp$ñ'[2-¸YlºcmÆ~0 Û%è­endstreamendobj10 0 obj<</AIS false/BM/Normal/CA 0.0/OP false/OPM 1/SA true/SMask/None/Type/ExtGState/ca 0.0/op false>>endobj21 0 obj<</CreationDate(D:20200910151028+01'00')/Creator(Adobe Illustrator CC 2017 \(Macintosh\))/ModDate(D:20200910151028+01'00')/Producer(Adobe PDF library 15.00)/Title(non_uk_address)>>endobjxref0 220000000000 65535 f
+0000000016 00000 n
+0000000076 00000 n
+0000011340 00000 n
+0000000000 00000 f
+0000013806 00000 n
+0000011391 00000 n
+0000011738 00000 n
+0000012090 00000 n
+0000013504 00000 n
+0000035854 00000 n
+0000013679 00000 n
+0000012967 00000 n
+0000013204 00000 n
+0000012154 00000 n
+0000012406 00000 n
+0000012454 00000 n
+0000013616 00000 n
+0000013441 00000 n
+0000014188 00000 n
+0000014435 00000 n
+0000035967 00000 n
+trailer<</Size 22/Root 1 0 R/Info 21 0 R/ID[<F602EB0CFDE243F28CBD263C5CDC539D><8C5D37AAA6CE4CAAAE67FFDE9E04A909>]>>startxref36164%%EOF

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -32,6 +32,7 @@ from tests.pdf_consts import (
     blank_with_2_line_address,
     blank_with_8_line_address,
     blank_with_address,
+    non_uk_address,
     not_pdf,
     a3_size,
     a5_size,
@@ -516,6 +517,7 @@ def test_sanitise_precompiled_letter_with_missing_address_returns_400(client, au
 @pytest.mark.parametrize('file, allow_international, expected_error_message', (
     (bad_postcode, '', 'not-a-real-uk-postcode'),
     (bad_postcode, 'true', 'not-a-real-uk-postcode-or-country'),
+    (non_uk_address, '', 'cant-send-international-letters'),
     (blank_with_2_line_address, '', 'not-enough-address-lines'),
     (blank_with_8_line_address, '', 'too-many-address-lines'),
     (invalid_address_character, '', 'invalid-char-in-address'),


### PR DESCRIPTION
If a service doesn’t have permission to send international letters but someone tries to upload a letter with a valid international address we just tell them that the last line must be a UK postcode.

This is a bit opaque and:
- suggests that we’re not recognising at all that it’s not a UK letter
- doesn’t explain why it must be a UK postcode

This commit adds a new error code which will let us write a more helpful error message in this case.

***

Depends on:
- [x] https://github.com/alphagov/notifications-admin/pull/3621