### PR TITLE
Bump utils to 42.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@41.2.0#egg=notifications-utils==41.2.0
+git+https://github.com/alphagov/notifications-utils.git@42.1.0#egg=notifications-utils==42.1.0
 
 # PaaS requirements
 gunicorn==20.0.4


### PR DESCRIPTION
Brings in new yellow for placeholders in letters.

Depends on:
- [x] https://github.com/alphagov/notifications-utils/pull/789

Changes: https://github.com/alphagov/notifications-utils/compare/41.2.0...42.1.0