### PR TITLE
Upgrade Ghostscript to 9.53.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "Install base packages" && apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Compile a specified version of ghostscript
-ARG GS_VERSION=9.21
+ARG GS_VERSION=9.53.3
 RUN wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$(echo $GS_VERSION | tr -d '.' )/ghostscript-${GS_VERSION}.tar.gz \
     && tar xvf ghostscript-${GS_VERSION}.tar.gz \
     && cd ghostscript-${GS_VERSION} && ./configure && make install \


### PR DESCRIPTION
We had been using version 9.21 of Ghostscript. Upgrading fixes an issue we saw where embedded images in PDFs can be removed when we use Ghostscript to embed fonts.

We've had to revert a Ghostscript upgrade before (1e24492) To test that this version is ok, I've run `identify -verbose` on PDFs generated with the old and new versions and can't see any significant differences in the colours. I've also sent a few PDFs to the DVLA to check and they said they processed fine.

[Pivotal story](https://www.pivotaltracker.com/story/show/172077354)