### PR TITLE
Fix the run_tests.sh script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,9 +47,10 @@ COPY docker/Arial.ttf /usr/share/fonts/truetype/msttcorefonts/
 
 WORKDIR /home/vcap/app
 
-# these are declared statically here so that they're cached by the docker image - if we run after the `COPY` command
-# they won't be cached so it'll re-download every time. But these don't involve the filesystem
-COPY requirements.txt .
+COPY requirements.txt policy.xml ./
+
+# Overwrite the default ImageMagick policy which doesn't allow reading or writing PDFs
+RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/policy.xml
 
 ##### Test Image ##############################################################
 
@@ -78,13 +79,10 @@ RUN \
 	&& pip install -r requirements.txt
 
 COPY app app
-COPY wsgi.py gunicorn_config.py Makefile run_celery.py policy.xml ./
+COPY wsgi.py gunicorn_config.py Makefile run_celery.py ./
 COPY scripts/run_app_paas.sh scripts/run_app.sh scripts/run_celery.sh scripts/
 
 # .git folder used only for make _generate-version-file but we don't wish to include it in our final production build
 COPY .git .git
 RUN make _generate-version-file
 RUN rm -rf .git
-
-# Overwrite the default ImageMagick policy which doesn't allow reading or writing PDFs
-RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/policy.xml

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -26,7 +26,8 @@ if [[ -z "$VIRTUAL_ENV" ]] && [[ -d venv ]]; then
   source ./venv/bin/activate
 fi
 
-py.test --maxfail=10 tests/ --strict
-
 flake8 .
 display_result $? 1 "Code style check"
+
+py.test --maxfail=10 tests/ --strict
+display_result $? 2 "Unit tests"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -119,7 +119,7 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'templated/27329371178f7d942d7a48f62038bb9fe720bc0c.pdf'
+    expected_cache_key = 'templated/13a0bbf4a494b3329e399d8e19682e8f14f1f7e4.pdf'
     resp = view_letter_template(filetype='pdf')
 
     assert resp.status_code == 200
@@ -145,7 +145,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'templated/27329371178f7d942d7a48f62038bb9fe720bc0c.page01.png'
+    expected_cache_key = 'templated/13a0bbf4a494b3329e399d8e19682e8f14f1f7e4.page01.png'
     resp = view_letter_template(filetype='png')
 
     assert resp.status_code == 200
@@ -368,7 +368,7 @@ def test_page_count_from_cache(
         }
     )
     assert mocked_cache_get.call_args[0][0] == 'test-template-preview-cache'
-    assert mocked_cache_get.call_args[0][1] == 'templated/8718b851d26000c7722a0a4c501f60756dcd8ff2.pdf'
+    assert mocked_cache_get.call_args[0][1] == 'templated/a78fc88c557d1294d87fea30f504c5c4202ff780.pdf'
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {'count': 10}
 


### PR DESCRIPTION
**Fix the run_tests.sh script**
`run_tests.sh` is used to run the tests on Concourse. This had not been working as expected - unit tests were failing but the Concourse build was passing. This was because although the script was running the unit tests it was only calling the `display_result` function (which causes the script to exit if there are errors) after the code style checks. The `display_result` function should be called after each stage in the test script.

**Update cache keys used in tests**

**Update Dockerfile to use custom policy in test image**
We had made a change to the `policy.xml` file that ImageMagick uses. This change was only made in the production image, but the tests also need the updated `policy.xml` file too. This change moves the lines dealing with the file into the base image.

Also deleted a comment from the Dockerfile - the comment was added from this commit 3c2e8c9 but was now in the wrong place and no longer relevant.