### PR TITLE
Revert "Upgrade Ghostscript to 9.53.3"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "Install base packages" && apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Compile a specified version of ghostscript
-ARG GS_VERSION=9.53.3
+ARG GS_VERSION=9.21
 RUN wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$(echo $GS_VERSION | tr -d '.' )/ghostscript-${GS_VERSION}.tar.gz \
     && tar xvf ghostscript-${GS_VERSION}.tar.gz \
     && cd ghostscript-${GS_VERSION} && ./configure && make install \


### PR DESCRIPTION
Reverts alphagov/notifications-template-preview#486

DVLA having been having big problems printing since this was deployed. Let's revert to check if this upgrade was the cause of the issues.