### PR TITLE
Upgrade Ghostscript to 9.53.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN echo "Install base packages" && apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
 # Compile a specified version of ghostscript
-ARG GS_VERSION=9.21
+ARG GS_VERSION=9.53.3
 RUN wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs$(echo $GS_VERSION | tr -d '.' )/ghostscript-${GS_VERSION}.tar.gz \
     && tar xvf ghostscript-${GS_VERSION}.tar.gz \
     && cd ghostscript-${GS_VERSION} && ./configure && make install \


### PR DESCRIPTION
This was tried [in October 2020](https://github.com/alphagov/notifications-template-preview/pull/486), then [reverted](https://github.com/alphagov/notifications-template-preview/pull/489) when it seemed like it might be causing DVLA problems. It now seems that the problems were unrelated, so they are happy for us to have another attempt at upgrading.

[Pivotal story](https://www.pivotaltracker.com/story/show/172077354)