### PR TITLE
Update utils to version 43.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@43.5.5#egg=notifications-utils==43.5.5
+git+https://github.com/alphagov/notifications-utils.git@43.8.3#egg=notifications-utils==43.8.3
 
 # PaaS requirements
 gunicorn==20.0.4


### PR DESCRIPTION
Invalid characters for the first line of a postal address now include < >