### PR TITLE
Add logging to test the letters before adding code to fail the letters

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -220,6 +220,11 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters):
 
     if contains_unembedded_fonts(file_data):
         file_data = remove_embedded_fonts(file_data)
+        if contains_unembedded_fonts(file_data):
+            # To start with log this is happening, later mark file as validation-failed
+            current_app.logger.info("File still contains embedded fonts after remove_embedded_fonts")
+        else:
+            current_app.logger.info("File no longer contains embedded fonts")
 
     # during switchover, DWP and CYSP will still be sending the notify tag. Only add it if it's not already there
     if not is_notify_tag_present(file_data):


### PR DESCRIPTION
Add logging when the PDF still contains unembedded fonts after the remove function has run.
I'd like to mark the letters as validation failed for the letters that
do, but without real letters to test with I am worried it might fail
good letters. This is just an extra precaution.

Once I'm happy with the test, if the letter still contains unembedded
fonts after the remove function mark the letter as validation failed.
But what should the failure message look like?