### PR TITLE
add FreeSans as a fallback font

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN echo "Install base packages" && apt-get update \
         gsfonts \
         libcurl4-openssl-dev \
         libssl-dev \
+        fonts-freefont-ttf \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
@@ -41,7 +42,6 @@ RUN wget https://poppler.freedesktop.org/poppler-${POPPLER_VERSION}.tar.xz \
     && cd poppler-${POPPLER_VERSION} && mkdir build && cd build \
     && cmake .. -DCMAKE_INSTALL_PREFIX=/usr && make && make install \
     && cd ../.. && rm -rf poppler-*
-
 
 COPY docker/Arial.ttf /usr/share/fonts/truetype/msttcorefonts/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@43.8.3#egg=notifications-utils==43.8.3
+git+https://github.com/alphagov/notifications-utils.git@44.0.1#egg=notifications-utils==44.0.1
 
 # PaaS requirements
 gunicorn==20.0.4

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -119,7 +119,7 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'templated/13a0bbf4a494b3329e399d8e19682e8f14f1f7e4.pdf'
+    expected_cache_key = 'templated/3ae434857323e58ba2961b84c8b2cb823ebf332f.pdf'
     resp = view_letter_template(filetype='pdf')
 
     assert resp.status_code == 200
@@ -145,7 +145,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = 'templated/13a0bbf4a494b3329e399d8e19682e8f14f1f7e4.page01.png'
+    expected_cache_key = 'templated/3ae434857323e58ba2961b84c8b2cb823ebf332f.page01.png'
     resp = view_letter_template(filetype='png')
 
     assert resp.status_code == 200
@@ -368,7 +368,7 @@ def test_page_count_from_cache(
         }
     )
     assert mocked_cache_get.call_args[0][0] == 'test-template-preview-cache'
-    assert mocked_cache_get.call_args[0][1] == 'templated/a78fc88c557d1294d87fea30f504c5c4202ff780.pdf'
+    assert mocked_cache_get.call_args[0][1] == 'templated/fc41fdf78b76f99dbddca1aed3f660a033fe1101.pdf'
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {'count': 10}
 


### PR DESCRIPTION
We use Nimbus Sans L for our templated letter font, however, some characters aren't included in that font (notably Punjabi). install the freefont package so that utils can render those characters using that character set.

The font is used in the css added here: https://github.com/alphagov/notifications-utils/pull/852

interestingly it appears to have modified the font for al

| Before      | After |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/5020841/111788341-e2c6bc80-88b7-11eb-8637-532b029c7fa4.png) | ![image](https://user-images.githubusercontent.com/5020841/111788420-f7a35000-88b7-11eb-8bb7-9327f9e2f324.png) |
| ![image](https://user-images.githubusercontent.com/5020841/111788110-9aa79a00-88b7-11eb-81f9-fa646105bf36.png)   | ![image](https://user-images.githubusercontent.com/5020841/111788177-adba6a00-88b7-11eb-89ab-9ee7732c743d.png)        |