### PR TITLE
Stop Ghostscript from rotating pages

### DIFF
--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -76,6 +76,7 @@ def remove_embedded_fonts(pdf_data):
             '%stdout',
             '-sDEVICE=pdfwrite',
             '-sstdout=%stderr',
+            '-dAutoRotatePages=/None',
             '-c',
             '<</NeverEmbed [ ]>> setdistillerparams',
             '-f',

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -48,6 +48,7 @@ def convert_pdf_to_cmyk(input_data):
             '-dBandBufferSpace=100000000',
             '-dBufferSpace=100000000',
             '-dMaxPatternBitmap=1000000',
+            '-dAutoRotatePages=/None',
             '-c', '100000000 setvmthreshold',
             '-f', '-'
         ],


### PR DESCRIPTION
Ghostscript's default behaviour is to automatically rotate pages
based on the dominant text orientation
(https://www.ghostscript.com/doc/VectorDevices.htm#Orientation).

We use Ghostscript for two things in the code
- Removing embedded fonts
- Converting the PDF to CYMK

Both of these Ghostscript processes can rotate pages if the text
is not horizontal (Ghostscript automatically picks the page
orientation). Because we call Ghostscript _after_ validating that the
pages are portrait, we were not noticing that some of the pages had been
changed to landscape. The `-dAutoRotatePages=/None` Ghostscript
parameter ensures that pages aren't automatically rotated.

To test locally, you can try uploading the `portrait_rotated_page` test
file as a letter (while commenting out the address validation). Before
these changes, the file gets changed to landscape.