### PR TITLE
Revamp Celery stats and request tracing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,8 +105,6 @@ def create_app():
 
     load_config(application)
 
-    notify_celery.init_app(application)
-
     from app.precompiled import precompiled_blueprint
     from app.preview import preview_blueprint
     from app.status import status_blueprint
@@ -120,6 +118,7 @@ def create_app():
     application.encryption_client.init_app(application)
     utils_logging.init_app(application, application.statsd_client)
     weasyprint_hack.init_app(application)
+    notify_celery.init_app(application)
 
     application.cache = init_cache(application)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from flask import Flask, jsonify
 from flask_httpauth import HTTPTokenAuth
 from kombu import Exchange, Queue
 from notifications_utils import logging as utils_logging
+from notifications_utils import request_helper
 from notifications_utils.clients.encryption.encryption_client import Encryption
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.s3 import S3ObjectNotFound, s3download, s3upload
@@ -118,6 +119,7 @@ def create_app():
     application.encryption_client.init_app(application)
     utils_logging.init_app(application, application.statsd_client)
     weasyprint_hack.init_app(application)
+    request_helper.init_app(application)
     notify_celery.init_app(application)
 
     application.cache = init_cache(application)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -60,16 +60,6 @@ def make_task(app):
 
                 return super().__call__(*args, **kwargs)
 
-        def apply_async(self, args=None, kwargs=None, **other_kwargs):
-            kwargs = kwargs or {}
-
-            if has_request_context() and hasattr(request, 'request_id'):
-                kwargs['request_id'] = request.request_id
-            elif has_app_context() and 'request_id' in g:
-                kwargs['request_id'] = g.request_id
-
-            return super().apply_async(args, kwargs, **other_kwargs)
-
     return NotifyTask
 
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -3,41 +3,45 @@ import time
 from celery import Celery, Task
 
 
+def make_task(app):
+    # this task is nested so that it has access to the original flask application - when celery restarts processes,
+    # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
+    # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
+    class NotifyTask(Task):
+        abstract = True
+        start = None
+
+        def on_success(self, retval, task_id, args, kwargs):
+            elapsed_time = time.time() - self.start
+            app.logger.info(
+                "Celery task {task_name} took {time}".format(
+                    task_name=self.name, time="{0:.4f}".format(elapsed_time)
+                )
+            )
+
+        def on_failure(self, exc, task_id, args, kwargs, einfo):
+            # ensure task will log exceptions to correct handlers
+            with app.app_context():
+                app.logger.exception('Celery task {} failed'.format(self.name))
+                super().on_failure(exc, task_id, args, kwargs, einfo)
+
+        def __call__(self, *args, **kwargs):
+            # ensure task has flask context to access config, logger, etc
+            with app.app_context():
+                self.start = time.time()
+
+                return super().__call__(*args, **kwargs)
+
+    return NotifyTask
+
+
 class NotifyCelery(Celery):
 
     def init_app(self, app):
-        # this task is nested so that it has access to the original flask application - when celery restarts processes,
-        # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
-        # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
-        class NotifyTask(Task):
-            abstract = True
-            start = None
-
-            def on_success(self, retval, task_id, args, kwargs):
-                elapsed_time = time.time() - self.start
-                app.logger.info(
-                    "Celery task {task_name} took {time}".format(
-                        task_name=self.name, time="{0:.4f}".format(elapsed_time)
-                    )
-                )
-
-            def on_failure(self, exc, task_id, args, kwargs, einfo):
-                # ensure task will log exceptions to correct handlers
-                with app.app_context():
-                    app.logger.exception('Celery task {} failed'.format(self.name))
-                    super().on_failure(exc, task_id, args, kwargs, einfo)
-
-            def __call__(self, *args, **kwargs):
-                # ensure task has flask context to access config, logger, etc
-                with app.app_context():
-                    self.start = time.time()
-
-                    return super().__call__(*args, **kwargs)
-
         super().__init__(
             app.import_name,
             broker=app.config['celery']['broker_url'],
-            task_cls=NotifyTask,
+            task_cls=make_task(app),
         )
 
         self.conf.update(app.config['celery'])

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,34 +1,61 @@
 import time
 
 from celery import Celery, Task
+from flask import g
 
 
 def make_task(app):
-    # this task is nested so that it has access to the original flask application - when celery restarts processes,
-    # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
-    # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
     class NotifyTask(Task):
         abstract = True
         start = None
 
         def on_success(self, retval, task_id, args, kwargs):
-            elapsed_time = time.time() - self.start
+            elapsed_time = time.monotonic() - self.start
+            delivery_info = self.request.delivery_info or {}
+            queue_name = delivery_info.get('routing_key', 'none')
+
             app.logger.info(
-                "Celery task {task_name} took {time}".format(
-                    task_name=self.name, time="{0:.4f}".format(elapsed_time)
+                "Celery task {task_name} (queue: {queue_name}) took {time}".format(
+                    task_name=self.name,
+                    queue_name=queue_name,
+                    time="{0:.4f}".format(elapsed_time)
                 )
             )
 
+            app.statsd_client.timing(
+                "celery.{queue_name}.{task_name}.success".format(
+                    task_name=self.name,
+                    queue_name=queue_name
+                ), elapsed_time
+            )
+
         def on_failure(self, exc, task_id, args, kwargs, einfo):
-            # ensure task will log exceptions to correct handlers
-            with app.app_context():
-                app.logger.exception('Celery task {} failed'.format(self.name))
-                super().on_failure(exc, task_id, args, kwargs, einfo)
+            delivery_info = self.request.delivery_info or {}
+            queue_name = delivery_info.get('routing_key', 'none')
+
+            app.logger.exception(
+                "Celery task {task_name} (queue: {queue_name}) failed".format(
+                    task_name=self.name,
+                    queue_name=queue_name,
+                )
+            )
+
+            app.statsd_client.incr(
+                "celery.{queue_name}.{task_name}.failure".format(
+                    task_name=self.name,
+                    queue_name=queue_name
+                )
+            )
+
+            super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
-                self.start = time.time()
+                self.start = time.monotonic()
+                # Remove piggyback values from kwargs
+                # Add 'request_id' to 'g' so that it gets logged
+                g.request_id = kwargs.pop('request_id', None)
 
                 return super().__call__(*args, **kwargs)
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,7 +1,8 @@
 import time
 
 from celery import Celery, Task
-from flask import g
+from flask import g, request
+from flask.ctx import has_app_context, has_request_context
 
 
 def make_task(app):
@@ -59,6 +60,16 @@ def make_task(app):
 
                 return super().__call__(*args, **kwargs)
 
+        def apply_async(self, args=None, kwargs=None, **other_kwargs):
+            kwargs = kwargs or {}
+
+            if has_request_context() and hasattr(request, 'request_id'):
+                kwargs['request_id'] = request.request_id
+            elif has_app_context() and 'request_id' in g:
+                kwargs['request_id'] = g.request_id
+
+            return super().apply_async(args, kwargs, **other_kwargs)
+
     return NotifyTask
 
 
@@ -72,3 +83,13 @@ class NotifyCelery(Celery):
         )
 
         self.conf.update(app.config['celery'])
+
+    def send_task(self, name, args=None, kwargs=None, **other_kwargs):
+        kwargs = kwargs or {}
+
+        if has_request_context() and hasattr(request, 'request_id'):
+            kwargs['request_id'] = request.request_id
+        elif has_app_context() and 'request_id' in g:
+            kwargs['request_id'] = g.request_id
+
+        return super().send_task(name, args, kwargs, **other_kwargs)

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -6,7 +6,6 @@ from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
 from flask_weasyprint import HTML
 from notifications_utils.s3 import s3download, s3upload
-from notifications_utils.statsd_decorators import statsd
 from notifications_utils.template import LetterPrintTemplate
 
 from app import QueueNames, TaskNames, notify_celery
@@ -17,7 +16,6 @@ from app.weasyprint_hack import WeasyprintError
 
 
 @notify_celery.task(name='sanitise-and-upload-letter')
-@statsd(namespace='template-preview')
 def sanitise_and_upload_letter(notification_id, filename, allow_international_letters=False):
     current_app.logger.info('Sanitising notification with id {}'.format(notification_id))
 
@@ -97,7 +95,6 @@ def copy_redaction_failed_pdf(source_filename):
 
 
 @notify_celery.task(bind=True, name='create-pdf-for-templated-letter', max_retries=3, default_retry_delay=180)
-@statsd(namespace="template_preview")
 def create_pdf_for_templated_letter(self, encrypted_letter_data):
     letter_details = current_app.encryption_client.decrypt(encrypted_letter_data)
     current_app.logger.info(f"Creating a pdf for notification with id {letter_details['notification_id']}")

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -9,7 +9,6 @@ import fitz
 from flask import Blueprint, current_app, jsonify, request, send_file
 from notifications_utils.pdf import is_letter_too_long, pdf_page_count
 from notifications_utils.postal_address import PostalAddress
-from notifications_utils.statsd_decorators import statsd
 from pdf2image import convert_from_bytes
 from PIL import ImageFont
 from PyPDF2 import PdfFileReader, PdfFileWriter
@@ -142,7 +141,6 @@ class PrecompiledPostalAddress(PostalAddress):
 
 @precompiled_blueprint.route('/precompiled/sanitise', methods=['POST'])
 @auth.login_required
-@statsd(namespace='template_preview')
 def sanitise_precompiled_letter():
     encoded_string = request.get_data()
     allow_international_letters = (
@@ -242,7 +240,6 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
 
 @precompiled_blueprint.route("/precompiled/overlay.png", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def overlay_template_png_for_page():
     """
     The admin app calls this multiple times to get pngs of each separate page to show on the front end.
@@ -277,7 +274,6 @@ def overlay_template_png_for_page():
 
 @precompiled_blueprint.route("/precompiled/overlay.pdf", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def overlay_template_pdf():
     """
     The api app calls this with a PDF as the POST body, expecting to receive a PDF back with the red overlay applied.

--- a/app/preview.py
+++ b/app/preview.py
@@ -4,7 +4,6 @@ from io import BytesIO
 import dateutil.parser
 from flask import Blueprint, abort, current_app, jsonify, request, send_file
 from flask_weasyprint import HTML
-from notifications_utils.statsd_decorators import statsd
 from notifications_utils.template import (
     LetterPreviewTemplate,
     LetterPrintTemplate,
@@ -29,7 +28,6 @@ def hide_notify_tag(image):
         image.composite(cover, left=0, top=0)
 
 
-@statsd(namespace="template_preview")
 def png_from_pdf(data, page_number, hide_notify=False):
     with Image(blob=data, resolution=150) as pdf:
         pdf_width, pdf_height = pdf.width, pdf.height
@@ -41,7 +39,6 @@ def png_from_pdf(data, page_number, hide_notify=False):
     return _generate_png_page(page, pdf_width, pdf_height, pdf_colorspace, hide_notify)
 
 
-@statsd(namespace="template_preview")
 def _generate_png_page(pdf_page, pdf_width, pdf_height, pdf_colorspace, hide_notify=False):
     output = BytesIO()
     with Image(width=pdf_width, height=pdf_height) as image:
@@ -58,7 +55,6 @@ def _generate_png_page(pdf_page, pdf_width, pdf_height, pdf_colorspace, hide_not
     return output
 
 
-@statsd(namespace="template_preview")
 def get_page_count(pdf_data):
     with Image(blob=pdf_data) as image:
         return len(image.sequence)
@@ -66,7 +62,6 @@ def get_page_count(pdf_data):
 
 @preview_blueprint.route("/preview.json", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def page_count():
     json = get_and_validate_json_from_request(request, preview_schema)
     return jsonify(
@@ -78,7 +73,6 @@ def page_count():
 
 @preview_blueprint.route("/preview.<filetype>", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def view_letter_template(filetype):
     """
     POST /preview.pdf with the following json blob
@@ -175,7 +169,6 @@ def get_png_from_precompiled(encoded_string, page_number, hide_notify):
 
 @preview_blueprint.route("/precompiled-preview.png", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def view_precompiled_letter():
     try:
         encoded_string = request.get_data()
@@ -200,7 +193,6 @@ def view_precompiled_letter():
 
 @preview_blueprint.route("/print.pdf", methods=['POST'])
 @auth.login_required
-@statsd(namespace="template_preview")
 def print_letter_template():
     """
     POST /print.pdf with the following json blob

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,7 +2,7 @@
 isort==5.7.0
 flake8==3.8.4
 flake8-print==4.0.0
-freezegun==1.0.0
+freezegun==1.1.0
 jinja2-cli[yaml]==0.7.0
 moto==1.3.16
 pytest-env==0.6.2

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -87,47 +87,6 @@ def test_call_exports_request_id_from_kwargs(mocker, celery_task):
     assert g.request_id == '1234'
 
 
-def test_apply_async_injects_global_request_id_into_kwargs(mocker, app, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-
-    with app.app_context():
-        g.request_id = '1234'
-        celery_task.apply_async()
-
-    super_apply.assert_called_with(None, {'request_id': '1234'})
-
-
-def test_apply_async_inject_request_id_with_other_kwargs(mocker, app, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-
-    with app.app_context():
-        g.request_id = '1234'
-        celery_task.apply_async(kwargs={'something': 'else'})
-
-    super_apply.assert_called_with(None, {'request_id': '1234', 'something': 'else'})
-
-
-def test_apply_async_inject_request_id_with_positional_args(mocker, app, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-
-    with app.app_context():
-        g.request_id = '1234'
-        celery_task.apply_async(['args'], {'something': 'else'})
-
-    super_apply.assert_called_with(['args'], {'request_id': '1234', 'something': 'else'})
-
-
-def test_apply_async_injects_id_into_kwargs_from_request(mocker, app, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-    request_id_header = app.config['NOTIFY_TRACE_ID_HEADER']
-    request_headers = {request_id_header: '1234'}
-
-    with app.test_request_context(headers=request_headers):
-        celery_task.apply_async()
-
-    super_apply.assert_called_with(None, {'request_id': '1234'})
-
-
 def test_send_task_injects_global_request_id_into_kwargs(mocker, app):
     super_apply = mocker.patch('celery.Celery.send_task')
 

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from flask import g
 from freezegun import freeze_time
 
 from app import notify_celery
@@ -84,3 +85,85 @@ def test_call_exports_request_id_from_kwargs(mocker, celery_task):
     # this would fail if the kwarg was passed through unexpectedly
     celery_task(request_id='1234')
     assert g.request_id == '1234'
+
+
+def test_apply_async_injects_global_request_id_into_kwargs(mocker, app, celery_task):
+    super_apply = mocker.patch('celery.app.task.Task.apply_async')
+
+    with app.app_context():
+        g.request_id = '1234'
+        celery_task.apply_async()
+
+    super_apply.assert_called_with(None, {'request_id': '1234'})
+
+
+def test_apply_async_inject_request_id_with_other_kwargs(mocker, app, celery_task):
+    super_apply = mocker.patch('celery.app.task.Task.apply_async')
+
+    with app.app_context():
+        g.request_id = '1234'
+        celery_task.apply_async(kwargs={'something': 'else'})
+
+    super_apply.assert_called_with(None, {'request_id': '1234', 'something': 'else'})
+
+
+def test_apply_async_inject_request_id_with_positional_args(mocker, app, celery_task):
+    super_apply = mocker.patch('celery.app.task.Task.apply_async')
+
+    with app.app_context():
+        g.request_id = '1234'
+        celery_task.apply_async(['args'], {'something': 'else'})
+
+    super_apply.assert_called_with(['args'], {'request_id': '1234', 'something': 'else'})
+
+
+def test_apply_async_injects_id_into_kwargs_from_request(mocker, app, celery_task):
+    super_apply = mocker.patch('celery.app.task.Task.apply_async')
+    request_id_header = app.config['NOTIFY_TRACE_ID_HEADER']
+    request_headers = {request_id_header: '1234'}
+
+    with app.test_request_context(headers=request_headers):
+        celery_task.apply_async()
+
+    super_apply.assert_called_with(None, {'request_id': '1234'})
+
+
+def test_send_task_injects_global_request_id_into_kwargs(mocker, app):
+    super_apply = mocker.patch('celery.Celery.send_task')
+
+    with app.app_context():
+        g.request_id = '1234'
+        notify_celery.send_task('some-task')
+
+    super_apply.assert_called_with('some-task', None, {'request_id': '1234'})
+
+
+def test_send_task_injects_request_id_with_other_kwargs(mocker, app):
+    super_apply = mocker.patch('celery.Celery.send_task')
+
+    with app.app_context():
+        g.request_id = '1234'
+        notify_celery.send_task('some-task', kwargs={'something': 'else'})
+
+    super_apply.assert_called_with('some-task', None, {'request_id': '1234', 'something': 'else'})
+
+
+def test_send_task_injects_request_id_with_positional_args(mocker, app):
+    super_apply = mocker.patch('celery.Celery.send_task')
+
+    with app.app_context():
+        g.request_id = '1234'
+        notify_celery.send_task('some-task', ['args'], {'kw': 'args'})
+
+    super_apply.assert_called_with('some-task', ['args'], {'request_id': '1234', 'kw': 'args'})
+
+
+def test_send_task_injects_id_into_kwargs_from_request(mocker, app):
+    super_apply = mocker.patch('celery.Celery.send_task')
+    request_id_header = app.config['NOTIFY_TRACE_ID_HEADER']
+    request_headers = {request_id_header: '1234'}
+
+    with app.test_request_context(headers=request_headers):
+        notify_celery.send_task('some-task')
+
+    super_apply.assert_called_with('some-task', None, {'request_id': '1234'})

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -1,0 +1,86 @@
+import uuid
+
+import pytest
+from freezegun import freeze_time
+
+from app import notify_celery
+
+
+# requiring app ensures notify_celery.init_app has been called
+@pytest.fixture(scope='session')
+def celery_task(app):
+    @notify_celery.task(name=uuid.uuid4(), base=notify_celery.task_cls)
+    def test_task(delivery_info=None):
+        pass
+
+    return test_task
+
+
+@pytest.fixture
+def async_task(celery_task):
+    celery_task.push_request(delivery_info={'routing_key': 'test-queue'})
+    yield celery_task
+    celery_task.pop_request()
+
+
+def test_success_should_log_and_call_statsd(mocker, app, async_task):
+    statsd = mocker.patch.object(app.statsd_client, 'timing')
+    logger = mocker.patch.object(app.logger, 'info')
+
+    with freeze_time() as frozen:
+        async_task()
+        frozen.tick(5)
+
+        async_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) took 5.0000')
+
+
+def test_success_queue_when_applied_synchronously(mocker, app, celery_task):
+    statsd = mocker.patch.object(app.statsd_client, 'timing')
+    logger = mocker.patch.object(app.logger, 'info')
+
+    with freeze_time() as frozen:
+        celery_task()
+        frozen.tick(5)
+
+        celery_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) took 5.0000')
+
+
+def test_failure_should_log_and_call_statsd(mocker, app, async_task):
+    statsd = mocker.patch.object(app.statsd_client, 'incr')
+    logger = mocker.patch.object(app.logger, 'exception')
+
+    async_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) failed')
+
+
+def test_failure_queue_when_applied_synchronously(mocker, app, celery_task):
+    statsd = mocker.patch.object(app.statsd_client, 'incr')
+    logger = mocker.patch.object(app.logger, 'exception')
+
+    celery_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')
+
+
+def test_call_exports_request_id_from_kwargs(mocker, celery_task):
+    g = mocker.patch('app.celery.celery.g')
+    # this would fail if the kwarg was passed through unexpectedly
+    celery_task(request_id='1234')
+    assert g.request_id == '1234'

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -168,7 +168,7 @@ def test_sanitise_and_upload_letter_raises_a_boto_error(mocker, client):
 
 
 @mock_s3
-def test_copy_redaction_failed_pdf():
+def test_copy_redaction_failed_pdf(client):
     filename = 'my_dodgy_letter.pdf'
     conn = boto3.resource('s3', region_name=current_app.config['AWS_REGION'])
     bucket = conn.create_bucket(
@@ -247,7 +247,8 @@ def test_create_pdf_for_templated_letter_boto_error(mocker, client, data_for_cre
 
 def test_create_pdf_for_templated_letter_html_error(
     mocker,
-    data_for_create_pdf_for_templated_letter_task
+    data_for_create_pdf_for_templated_letter_task,
+    client
 ):
     encrypted_data = current_app.encryption_client.encrypt(data_for_create_pdf_for_templated_letter_task)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def app():
     yield create_app()
 
 
-@pytest.fixture(autouse=True, scope='session')
+@pytest.fixture
 def client(app):
     # every test should have a client instantiated so that log messages don't crash
     app.config['TESTING'] = True

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -123,7 +123,7 @@ def test_add_notify_tag_to_letter_correct_margins(mocker):
     assert positional_args[2] == "NOTIFY"
 
 
-def test_get_invalid_pages_blank_page():
+def test_get_invalid_pages_blank_page(client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -135,7 +135,7 @@ def test_get_invalid_pages_blank_page():
     assert get_invalid_pages_with_message(packet) == ("", [])
 
 
-def test_get_invalid_pages_black_bottom_corner():
+def test_get_invalid_pages_black_bottom_corner(client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -150,7 +150,7 @@ def test_get_invalid_pages_black_bottom_corner():
     assert get_invalid_pages_with_message(packet) == ('content-outside-printable-area', [1])
 
 
-def test_get_invalid_pages_grey_bottom_corner():
+def test_get_invalid_pages_grey_bottom_corner(client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -165,7 +165,7 @@ def test_get_invalid_pages_grey_bottom_corner():
     assert get_invalid_pages_with_message(packet) == ('content-outside-printable-area', [1])
 
 
-def test_get_invalid_pages_blank_multi_page():
+def test_get_invalid_pages_blank_multi_page(client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -191,7 +191,7 @@ def test_get_invalid_pages_blank_multi_page():
     # middle of left margin is not okay
     (0, 400, True)
 ])
-def test_get_invalid_pages_second_page(x, y, expected_failed):
+def test_get_invalid_pages_second_page(x, y, expected_failed, client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -238,7 +238,7 @@ def test_get_invalid_pages_second_page(x, y, expected_failed):
     (590, 0, 2, ('content-outside-printable-area', [2])),
     (590, 200, 2, ('content-outside-printable-area', [2])),
 ])
-def test_get_invalid_pages_black_text(x, y, page, expected_message):
+def test_get_invalid_pages_black_text(x, y, page, expected_message, client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -258,7 +258,7 @@ def test_get_invalid_pages_black_text(x, y, page, expected_message):
     assert get_invalid_pages_with_message(packet) == expected_message
 
 
-def test_get_invalid_pages_address_margin():
+def test_get_invalid_pages_address_margin(client):
     packet = io.BytesIO()
     cv = canvas.Canvas(packet, pagesize=A4)
     cv.setStrokeColor(white)
@@ -281,26 +281,26 @@ def test_get_invalid_pages_address_margin():
     a3_size, a5_size, landscape_oriented_page, landscape_rotated_page
 ], ids=['a3_size', 'a5_size', 'landscape_oriented_page', 'landscape_rotated_page']
 )
-def test_get_invalid_pages_not_a4_oriented(pdf):
+def test_get_invalid_pages_not_a4_oriented(pdf, client):
     message, invalid_pages = get_invalid_pages_with_message(BytesIO(pdf))
     assert message == 'letter-not-a4-portrait-oriented'
     assert invalid_pages == [1]
 
 
-def test_get_invalid_pages_is_ok_with_landscape_pages_that_are_rotated():
+def test_get_invalid_pages_is_ok_with_landscape_pages_that_are_rotated(client):
     # the page is orientated landscape but rotated 90º - all the text is sideways but it's still portrait
     message, invalid_pages = get_invalid_pages_with_message(BytesIO(portrait_rotated_page))
     assert message == ''
     assert invalid_pages == []
 
 
-def test_get_invalid_pages_ignores_notify_tags_on_page_1():
+def test_get_invalid_pages_ignores_notify_tags_on_page_1(client):
     message, invalid_pages = get_invalid_pages_with_message(BytesIO(already_has_notify_tag))
     assert message == ''
     assert invalid_pages == []
 
 
-def test_get_invalid_pages_rejects_later_pages_with_notify_tags():
+def test_get_invalid_pages_rejects_later_pages_with_notify_tags(client):
     message, invalid_pages = get_invalid_pages_with_message(BytesIO(notify_tags_on_page_2_and_4))
     assert message == 'notify-tag-found-in-content'
     assert invalid_pages == [2, 4]
@@ -596,7 +596,7 @@ def test_rewrite_address_block_end_to_end(pdf_data, address_snippet):
     assert address_snippet in address.lower()
 
 
-def test_rewrite_address_block_doesnt_overwrite_if_it_cant_redact_address():
+def test_rewrite_address_block_doesnt_overwrite_if_it_cant_redact_address(client):
     old_pdf = BytesIO(repeated_address_block)
     old_address = extract_address_block(old_pdf).raw_address
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -394,7 +394,7 @@ def test_returns_500_if_logo_not_found(app, view_letter_template):
     ('hm-government', True),
     (None, False),
 ])
-def test_get_html(logo, is_svg_expected, preview_post_body):
+def test_get_html(logo, is_svg_expected, preview_post_body, client):
     image_tag = '<img src="https://static-logos.notify.tools/letters'  # just see if any logo is in the letter at all
     preview_post_body['filename'] = logo
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176261229

This applies the same change we made in the API, and goes a bit further
to enable end-to-end request tracing, which is part of the same code.

Please see the commit messages for more details. If we have concerns about
the request tracing part, I can split that into a separate PR.