### PR TITLE
Use -with-docker consistently in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,22 @@ bootstrap: generate-version-file ## Setup environment to run app commands
 	docker build -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask
-run-flask: ## Run flask in Docker container
+run-flask-with-docker: ## Run flask in Docker container
 	export DOCKER_ARGS="-p ${PORT}:${PORT}" && \
 		./scripts/run_with_docker.sh flask run --host=0.0.0.0 -p ${PORT}
 
 .PHONY: run-celery
-run-celery: ## Run celery in Docker container
+run-celery-with-docker: ## Run celery in Docker container
 	$(if ${NOTIFICATION_QUEUE_PREFIX},,$(error Must specify NOTIFICATION_QUEUE_PREFIX))
 	./scripts/run_with_docker.sh celery -A run_celery.notify_celery worker --loglevel=INFO
 
 .PHONY: test
-test: ## Run tests in Docker container
-	./scripts/run_with_docker.sh ./scripts/run_tests.sh
+test: ## Run tests (used by Concourse)
+	./scripts/run_tests.sh
+
+.PHONY: test
+test-with-docker: ## Run tests in Docker container
+	./scripts/run_with_docker.sh make test
 
 .PHONY: upload-to-dockerhub
 upload-to-dockerhub:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Things to change:
 ## To test the application
 
 ```shell
-make test
+make test-with-docker
 ```
 
 If you need to run a specific command, such as a single test, you can use the `run_with_docker.sh` script. This is what `test` and other `make` rules use.
@@ -49,14 +49,14 @@ If you need to run a specific command, such as a single test, you can use the `r
 
 ```shell
 # run the web app
-make run-flask
+make run-flask-with-docker
 ```
 
 Then visit your app at `http://localhost:6013/`.
 
 ```shell
 # run the background tasks
-make run-celery
+make run-celery-with-docker
 ```
 
 Celery is used for sanitising PDF letters asynchronously. It requires the `NOTIFICATION_QUEUE_PREFIX` environment variable to be set to the same value used in notifications-api.


### PR DESCRIPTION
Previously we removed this suffix as part of other changes to make
dev tasks more consistent [1]. However, this app and Antivirus are
special because they need a Docker environment to run, except on
Concourse, where a build image is used implicitly [2]. This implicit
behaviour on Concourse means **it needs its own test task.**

Options to resolve the inconsistency:

1. Continue to have a "run_tests.sh" script for these two apps. Not
ideal as not consistent with other apps, where we're trying to get
rid of the unnecessary "run_tests.sh" scripts [3], so there's just
one way of running the tests [6].

2. Keep the "test" task as-is, but make it call "test-without-docker"
or "test-ci". Not ideal as inconsistent with API client Makefiles [4].
Also confusing as the shorter task does "more" than the longer one, by
running the longer one in a Docker environment.

3. Rename "test" to "test-with-docker", which calls a new, non-Docker
"test" task. Not ideal as more typing and inconsistent with other apps.

Of these, (3) seems to be the best:

- It reflects that these two apps are different to the others, so will
have some inevitable inconsistency in how the code is run. Arguably
whoever is developing on this repo needs to be aware of the difference
e.g. they need to have Docker setup locally.

- It is consistent with the equivalent tasks in our API client repos.

- It allows us to uniformly switch to "make test" on Concourse, which
is already used for testing API client repos with Docker [5].

- While reverting to the old tasks is more typing, this wasn't a major
issue before they were changed (just a nice side effect).

[1]: https://github.com/alphagov/notifications-template-preview/pull/517/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L101-L115
[2]: https://github.com/alphagov/notifications-aws/blob/85ad6c189f459a0168c0034e7345a5d0586f670b/concourse/templates/macros.yml.j2#L83-L99
[3]: https://github.com/alphagov/notifications-aws/pull/905/files#diff-af98362e2977c4813a77310f5dd7b17eb54e563ec5edd770770be0a42dc460c8R107
[4]: https://github.com/alphagov/notifications-net-client/blob/966f1a0d4a70187789aa5a56917dbff9146f6dc3/Makefile#L45
[5]: https://github.com/alphagov/notifications-aws/blob/85ad6c189f459a0168c0034e7345a5d0586f670b/concourse/api-clients-pipeline.yml.j2#L261
[6]: https://github.com/alphagov/notifications-manuals/issues/9