### PR TITLE
Bump version of utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@44.0.1#egg=notifications-utils==44.0.1
+git+https://github.com/alphagov/notifications-utils.git@44.2.2#egg=notifications-utils==44.2.2
 
 # PaaS requirements
 gunicorn==20.1.0


### PR DESCRIPTION
Bump version of utils includes the addition of `~` as an invalid character for postal addresses.