### PR TITLE
Move original precompiled PDFs to backup S3 bucket

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,6 +90,12 @@ def load_config(application):
         )
     )
 
+    application.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'] = (
+        '{}-letters-precompiled-originals-backup'.format(
+            application.config['NOTIFY_ENVIRONMENT']
+        )
+    )
+
     application.config['LETTER_LOGO_URL'] = 'https://static-logos.{}/letters'.format({
         'test': 'notify.tools',
         'development': 'notify.tools',

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -20,7 +20,8 @@ def sanitise_and_upload_letter(notification_id, filename, allow_international_le
     current_app.logger.info('Sanitising notification with id {}'.format(notification_id))
 
     try:
-        pdf_content = s3download(current_app.config['LETTERS_SCAN_BUCKET_NAME'], filename).read()
+        original_pdf = s3download(current_app.config['LETTERS_SCAN_BUCKET_NAME'], filename)
+        pdf_content = original_pdf.read()
         sanitisation_details = sanitise_file_contents(
             pdf_content,
             allow_international_letters=allow_international_letters,
@@ -44,6 +45,13 @@ def sanitise_and_upload_letter(notification_id, filename, allow_international_le
                 filedata=file_data,
                 region=current_app.config['AWS_REGION'],
                 bucket_name=current_app.config['SANITISED_LETTER_BUCKET_NAME'],
+                file_location=filename,
+            )
+            # upload a backup copy of the original PDF that will be held in the bucket for a week
+            s3upload(
+                filedata=original_pdf,
+                region=current_app.config['AWS_REGION'],
+                bucket_name=current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'],
                 file_location=filename,
             )
 

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -33,11 +33,21 @@ def test_sanitise_and_upload_valid_letter(mocker, client):
 
     sanitise_and_upload_letter('abc-123', 'filename.pdf')
 
-    mock_upload.assert_called_once_with(
-        filedata=mocker.ANY,
-        region=current_app.config['AWS_REGION'],
-        bucket_name=current_app.config['SANITISED_LETTER_BUCKET_NAME'],
-        file_location='filename.pdf',
+    mock_upload.assert_has_calls(
+        [
+            call(
+                filedata=mocker.ANY,
+                region=current_app.config['AWS_REGION'],
+                bucket_name=current_app.config['SANITISED_LETTER_BUCKET_NAME'],
+                file_location='filename.pdf',
+            ),
+            call(
+                filedata=valid_file,
+                region=current_app.config['AWS_REGION'],
+                bucket_name=current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'],
+                file_location='filename.pdf',
+            )
+        ]
     )
 
     encrypted_task_args = current_app.encryption_client.encrypt({


### PR DESCRIPTION
Those letters will be kept there for a week. We are doing this so that if we push risky updates to dependencies or there are any other problems with letter processing, or if we need to investigate why some letters cause trouble to DVLA, we have the originals as backup to either re-send or investigate any issues.