### PR TITLE
Copy original precompiled letter to backup bucket

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,6 +90,12 @@ def load_config(application):
         )
     )
 
+    application.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'] = (
+        '{}-letters-precompiled-originals-backup'.format(
+            application.config['NOTIFY_ENVIRONMENT']
+        )
+    )
+
     application.config['LETTER_LOGO_URL'] = 'https://static-logos.{}/letters'.format({
         'test': 'notify.tools',
         'development': 'notify.tools',


### PR DESCRIPTION
Copy it straight from scan bucket to the backup bucket.

Those letters will be kept there for a week. We are doing this so that if we push risky updates to dependencies or there are any other problems with letter processing, or if we need to investigate why some letters cause trouble to DVLA, we have the originals as backup to either re-send or investigate any issues.

In this PR we only do it for precompiled letters we get via API integration.

For letters uploaded via Notify interface, at the time when we sanitise those letters we don’t have the official filename for them yet, so replaying them would be very tricky, even if we had originals.
We would need to give them a temporary identifier and then rename them once they become a notification, or something to that effect.