### PR TITLE
Fix incorrect / misleading name for function

### DIFF
--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -45,7 +45,7 @@ def contains_unembedded_fonts(pdf_data):
     return unembedded
 
 
-def remove_embedded_fonts(pdf_data):
+def embed_fonts(pdf_data):
     """
     Recreate the following
     gs \

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -224,12 +224,8 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
     if contains_unembedded_fonts(file_data):
         file_data = embed_fonts(file_data)
         if contains_unembedded_fonts(file_data):
-            # To start with log this is happening, later mark file as validation-failed
             current_app.logger.info(
                 f"File still contains unembedded fonts after embed_fonts for file name {filename}")
-        else:
-            current_app.logger.info(
-                f"File no longer contains unembedded fonts for file name {filename}")
 
     # during switchover, DWP and CYSP will still be sending the notify tag. Only add it if it's not already there
     if not is_notify_tag_present(file_data):

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -21,7 +21,7 @@ from reportlab.pdfgen import canvas
 
 import app.pdf_redactor as pdf_redactor
 from app import InvalidRequest, ValidationFailed, auth
-from app.embedded_fonts import contains_unembedded_fonts, remove_embedded_fonts
+from app.embedded_fonts import contains_unembedded_fonts, embed_fonts
 from app.preview import png_from_pdf
 from app.transformation import (
     convert_pdf_to_cmyk,
@@ -222,14 +222,14 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
         file_data = convert_pdf_to_cmyk(file_data)
 
     if contains_unembedded_fonts(file_data):
-        file_data = remove_embedded_fonts(file_data)
+        file_data = embed_fonts(file_data)
         if contains_unembedded_fonts(file_data):
             # To start with log this is happening, later mark file as validation-failed
             current_app.logger.info(
-                f"File still contains embedded fonts after remove_embedded_fonts for file name {filename}")
+                f"File still contains unembedded fonts after embed_fonts for file name {filename}")
         else:
             current_app.logger.info(
-                f"File no longer contains embedded fonts for file name {filename}")
+                f"File no longer contains unembedded fonts for file name {filename}")
 
     # during switchover, DWP and CYSP will still be sending the notify tag. Only add it if it's not already there
     if not is_notify_tag_present(file_data):

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -4,7 +4,7 @@ import pytest
 from PyPDF2 import PdfFileReader
 from reportlab.lib.units import mm
 
-from app.embedded_fonts import contains_unembedded_fonts, remove_embedded_fonts
+from app.embedded_fonts import contains_unembedded_fonts, embed_fonts
 from app.precompiled import _is_page_A4_portrait
 from tests.pdf_consts import (
     blank_with_address,
@@ -25,20 +25,20 @@ def test_contains_unembedded_fonts(pdf_file, has_unembedded_fonts):
     assert bool(contains_unembedded_fonts(pdf_file)) == has_unembedded_fonts
 
 
-def test_remove_embedded_fonts():
+def test_embed_fonts():
     input_pdf = BytesIO(multi_page_pdf)
     assert contains_unembedded_fonts(input_pdf)
 
-    new_pdf = remove_embedded_fonts(BytesIO(multi_page_pdf))
+    new_pdf = embed_fonts(BytesIO(multi_page_pdf))
 
     assert not contains_unembedded_fonts(new_pdf)
 
 
-def test_remove_embedded_fonts_does_not_rotate_pages():
+def test_embed_fonts_does_not_rotate_pages():
     file_with_rotated_text = BytesIO(portrait_rotated_page)
 
     new_pdf = PdfFileReader(
-        remove_embedded_fonts(file_with_rotated_text)
+        embed_fonts(file_with_rotated_text)
     )
     page = new_pdf.getPage(0)
 


### PR DESCRIPTION
Previously this was saying the opposite of what the method does: embed all
fonts, so that the output PDF is self-contained for the printer. This
renames the method to match what it does.