### PR TITLE
Fix not detecting Type 0 (composite) fonts

### DIFF
--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -1,11 +1,12 @@
 import subprocess
 from io import BytesIO
 
+from flask import current_app
 from PyPDF2 import PdfFileReader
 from PyPDF2.generic import IndirectObject
 
 
-def contains_unembedded_fonts(pdf_data):  # noqa: C901 (too complex)
+def contains_unembedded_fonts(pdf_data, filename=''):  # noqa: C901 (too complex)
     """
     Code adapted from https://gist.github.com/tiarno/8a2995e70cee42f01e79
 
@@ -23,11 +24,21 @@ def contains_unembedded_fonts(pdf_data):  # noqa: C901 (too complex)
         '''
         if hasattr(obj, 'keys'):
             fontkeys = {'/FontFile', '/FontFile2', '/FontFile3'}
+
             if '/BaseFont' in obj:
                 fnt.add(obj['/BaseFont'])
+
             if '/FontName' in obj:
                 if any(x in obj for x in fontkeys):  # test to see if there is FontFile
                     emb.add(obj['/FontName'])
+
+            # DVLA have been having problem printing these. We want to
+            # see if it's viable to reject them. We can remove this, the
+            # "filename" parameter and the "client" fixture in the tests
+            # when we have an answer.
+            if '/Subtype' in obj and 'Type3' in obj['/Subtype']:
+                current_app.logger.info(
+                    f"File contains Type3 fonts for file name {filename}")
 
             for k in obj.keys():
                 walk(obj[k], fnt, emb)

--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -2,9 +2,10 @@ import subprocess
 from io import BytesIO
 
 from PyPDF2 import PdfFileReader
+from PyPDF2.generic import IndirectObject
 
 
-def contains_unembedded_fonts(pdf_data):
+def contains_unembedded_fonts(pdf_data):  # noqa: C901 (too complex)
     """
     Code adapted from https://gist.github.com/tiarno/8a2995e70cee42f01e79
 
@@ -30,6 +31,11 @@ def contains_unembedded_fonts(pdf_data):
 
             for k in obj.keys():
                 walk(obj[k], fnt, emb)
+        elif isinstance(obj, list):
+            for child in obj:
+                walk(child, fnt, emb)
+        elif isinstance(obj, IndirectObject):
+            walk(obj.getObject(), fnt, emb)
 
     pdf = PdfFileReader(pdf_data)
     fonts = set()

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -221,9 +221,9 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
     if not does_pdf_contain_cmyk(file_data) or does_pdf_contain_rgb(file_data):
         file_data = convert_pdf_to_cmyk(file_data)
 
-    if contains_unembedded_fonts(file_data):
+    if contains_unembedded_fonts(file_data, filename):
         file_data = embed_fonts(file_data)
-        if contains_unembedded_fonts(file_data):
+        if contains_unembedded_fonts(file_data, filename):
             current_app.logger.info(
                 f"File still contains unembedded fonts after embed_fonts for file name {filename}")
 

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -16,10 +16,10 @@ from tests.pdf_consts import (
 
 
 @pytest.mark.parametrize(['pdf_file', 'has_unembedded_fonts'], [
-    (BytesIO(blank_with_address), True),  # false positive, I think, or maybe because created through Google sheets?
+    (BytesIO(blank_with_address), False),
     (BytesIO(example_dwp_pdf), False),
     (BytesIO(multi_page_pdf), True),
-    (BytesIO(valid_letter), True),   # false positive, I think, or maybe because created through Google sheets?
+    (BytesIO(valid_letter), False)
 ], ids=['blank_with_address', 'example_dwp_pdf', 'multi_page_pdf', 'valid_letter'])
 def test_contains_unembedded_fonts(pdf_file, has_unembedded_fonts):
     assert bool(contains_unembedded_fonts(pdf_file)) == has_unembedded_fonts

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -21,7 +21,7 @@ from tests.pdf_consts import (
     (BytesIO(multi_page_pdf), True),
     (BytesIO(valid_letter), False)
 ], ids=['blank_with_address', 'example_dwp_pdf', 'multi_page_pdf', 'valid_letter'])
-def test_contains_unembedded_fonts(pdf_file, has_unembedded_fonts):
+def test_contains_unembedded_fonts(client, pdf_file, has_unembedded_fonts):
     assert bool(contains_unembedded_fonts(pdf_file)) == has_unembedded_fonts
 
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177985853

Previously the function to gather used fonts would only walk certain
parts of the PDF object tree. This worked for PDFs which had TrueType
fonts embedded, since the tree looks like this:

```
(parents)
  BaseFont: AAABQG+ArialMT
  ...
  FontDescriptor:
    FontFile2: ...
    FontName: AAABQG+ArialMT
    ...
```

Some PDFs have composite fonts, which look like this:

```
(parents)
  BaseFont: MUFUZY+ArialMT
  ...
  DescendantFonts: # AN ARRAY!
    - BaseFont: MUFUZY+ArialMT
      FontDescriptor:
        FontFile2: ...
        FontName: MUFUZY+ArialMT
        ...
```

In addition, the FontDescriptor is actually an indirect reference,
which means it doesn't (directly) have a "keys" attribute.

This fixes the false positives for detecting unembedded fonts, by
adding support to walk the tree for arrays and indirect objects.

Note, I found this article helpful [1].

[1]: https://www.prepressure.com/pdf/basics/fonts