### PR TITLE
Remove unnecessary re-check of unembedded fonts

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -226,9 +226,6 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
 
     if contains_unembedded_fonts(file_data, filename):
         file_data = embed_fonts(file_data)
-        if contains_unembedded_fonts(file_data, filename):
-            current_app.logger.info(
-                f"File still contains unembedded fonts after embed_fonts for file name {filename}")
 
     # during switchover, DWP and CYSP will still be sending the notify tag. Only add it if it's not already there
     if not is_notify_tag_present(file_data):


### PR DESCRIPTION
Follows on from: https://github.com/alphagov/notifications-template-preview/pull/553

Since we fixed the method to detect these, we've not seen any logs
about them, which indicates it's not an issue. We can always put
the log back if we believe it might be.
