### PR TITLE
Make bootstrap consistent with Ruby API Client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+environment*.sh

--- a/Makefile
+++ b/Makefile
@@ -34,11 +34,15 @@ help:
 generate-version-file:
 	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
+.PHONY: bootstrap
+bootstrap: generate-version-file
+	mkdir -p log # manually create directory to avoid permission issues
+	pip install -r requirements_for_test.txt
+
 # ---- DOCKER COMMANDS ---- #
 
 .PHONY: bootstrap
-bootstrap: generate-version-file ## Setup environment to run app commands
-	mkdir -p log # manually create directory to avoid permission issues
+bootstrap-with-docker: ## Setup environment to run app commands
 	docker build -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Generates PNG and PDF previews of letter templates created in the [GOV.UK Notify
 This app uses dependencies that are difficult to install locally. In order to make local development easy, we run app commands through a Docker container. Run the following to set this up:
 
 ```shell
-  make bootstrap
+  make bootstrap-with-docker
 ```
 
 Because the container caches things like Python packages, you will need to run this again if you change things like "requirements.txt".
@@ -31,7 +31,6 @@ export NOTIFICATION_QUEUE_PREFIX='YOUR_OWN_PREFIX'
 Things to change:
 
 - Replace YOUR_OWN_PREFIX with local_dev_\<first name\>.
-
 
 ## To test the application
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,17 +56,11 @@ RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/polic
 
 FROM parent as test
 
-COPY requirements_for_test.txt .
-
-RUN \
-	echo "Installing python dependencies" \
-	&& pip install -r requirements_for_test.txt
-
 # Copy from the real world, one dir up (project root) into the environment's current working directory
 # Docker will rebuild from here down every time.
 COPY . .
 
-RUN make generate-version-file
+RUN make bootstrap
 
 ##### Production Image #######################################################
 


### PR DESCRIPTION
It's taken a few attempts to standardise the way we do local setup
for repos that run through Docker. The final repos to standardise
were the API clients, where we agreed on a slightly different way
of doing local setup [1]. This change is to be consistent with that.

Note that the Dockerfile already had a "COPY . ." statement, which
supersedes "COPY requirements_for_test.txt ." since it copies all
files. Since we no longer need to rebuild the image every time we
run the tests, the previous comment [2] no longer applies.

[1]: https://github.com/alphagov/notifications-ruby-client/pull/122
[2]: https://github.com/alphagov/notifications-template-preview/blob/f9df02478683896a38b66f4f77d50775729905da/docker/Dockerfile#L66