### PR TITLE
Change filename for back up PDF letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -49,7 +49,7 @@ def sanitise_and_upload_letter(notification_id, filename, allow_international_le
             # upload a backup copy of the original PDF that will be held in the bucket for a week
             copy_s3_object(
                 current_app.config['LETTERS_SCAN_BUCKET_NAME'], filename,
-                current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], filename
+                current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], f'{notification_id}.pdf'
             )
 
         current_app.logger.info('Notification {} sanitisation: {}'.format(validation_status, notification_id))

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -60,7 +60,7 @@ def test_sanitise_and_upload_valid_letter(mocker, client):
 
     mock_backup_original.assert_called_once_with(
         current_app.config['LETTERS_SCAN_BUCKET_NAME'], 'filename.pdf',
-        current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], 'filename.pdf'
+        current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], 'abc-123.pdf'
     )
 
 
@@ -155,7 +155,7 @@ def test_sanitise_letter_which_fails_redaction(mocker, client):
     )
     mock_backup_original.assert_called_once_with(
         current_app.config['LETTERS_SCAN_BUCKET_NAME'], 'filename.pdf',
-        current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], 'filename.pdf'
+        current_app.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'], 'abc-123.pdf'
     )
 
 


### PR DESCRIPTION
We back up PDF letters that are uploaded (done in notifications-admin) and PDFs that are sent via the API (done in this repo). The filenames for both are in a different format, which makes trying to use these back ups more complicated than if they were the same.

This changes the filenames of PDFs sent via the API to be the notification ID so that all filenames have the same format. It is not possible to do this the other way round - we have no way of generating a `NOTIFY.<reference>.D.2.C.<datetime>.PDF` style filename in admin.

Part of this work for this [Pivotal story](https://www.pivotaltracker.com/story/show/178746435)