### PR TITLE
Update to Python 3.9

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -656,7 +656,7 @@ def _extract_text_from_page(page, *, x1, y1, x2, y2):
     :return: Any text found
     """
     rect = fitz.Rect(x1, y1, x2, y2)
-    words = page.getTextWords()
+    words = page.get_text_words()
     mywords = [w for w in words if fitz.Rect(w[:4]).intersects(rect)]
     mywords.sort(key=itemgetter(-3, -2, -1))
     group = groupby(mywords, key=itemgetter(3))

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -12,7 +12,7 @@ def _does_pdf_contain_colorspace(colourspace, data):
     doc = fitz.open(stream=data, filetype="pdf")
     for i in range(len(doc)):
         try:
-            page = doc.getPageImageList(i)
+            page = doc.get_page_images(i)
         except RuntimeError:
             current_app.logger.warning("Fitz couldn't read page info for page {}".format(i + 1))
             raise InvalidRequest("Invalid PDF on page {}".format(i + 1))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-buster as parent
+FROM python:3.9-slim-buster as parent
 
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 #app requirements
 boto3==1.18.6
-celery[sqs]==5.0.5
+celery[sqs]==5.0.5 # pyup: ignore
 Flask==1.1.4
 Flask-WeasyPrint==0.6
 Flask-HTTPAuth==4.2.0
-Werkzeug==1.0.1
+Werkzeug==1.0.1 # pyup: ignore 
 
 # pdf libraries
 html5lib==1.1
 wand==0.5.9
 jsonschema==3.2.0
 pypdf2==1.26.0
-Pillow==7.2.0
-reportlab==3.5.67
+Pillow==7.2.0 # pyup: ignore
+reportlab==3.5.67 # pyup: ignore
 pdf2image==1.12.1
 PyMuPDF==1.19.1
 pdfrw==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pypdf2==1.26.0
 Pillow==7.2.0
 reportlab==3.5.67
 pdf2image==1.12.1
-PyMuPDF==1.16.11
+PyMuPDF==1.19.1
 pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -80,11 +80,13 @@ def test_failure_queue_when_applied_synchronously(mocker, app, celery_task):
     logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')
 
 
-def test_call_exports_request_id_from_kwargs(mocker, celery_task):
-    g = mocker.patch('app.celery.celery.g')
-    # this would fail if the kwarg was passed through unexpectedly
-    celery_task(request_id='1234')
-    assert g.request_id == '1234'
+def test_call_exports_request_id_from_kwargs(mocker, app, celery_task):
+    with app.app_context():
+        g = mocker.patch('app.celery.celery.g')
+
+        # this would fail if the kwarg was passed through unexpectedly
+        celery_task(request_id='1234')
+        assert g.request_id == '1234'
 
 
 def test_send_task_injects_global_request_id_into_kwargs(mocker, app):

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -83,7 +83,7 @@ def test_convert_pdf_to_cmyk_preserves_black(client):
     pixmap = fitz.Pixmap(doc, image_object_number)
 
     assert 'CMYK' in str(pixmap.colorspace)
-    assert pixmap.pixel(100, 100) == [0, 0, 0, 255]  # [C,M,Y,K], where 'K' is black
+    assert pixmap.pixel(100, 100) == (0, 0, 0, 255)  # (C,M,Y,K), where 'K' is black
 
 
 # This test is intended to fail until we upgrade to a new version of

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -78,7 +78,7 @@ def test_convert_pdf_to_cmyk_preserves_black(client):
 
     result = convert_pdf_to_cmyk(data)
     doc = fitz.open(stream=result, filetype="pdf")
-    first_image = doc.getPageImageList(pno=0)[0]
+    first_image = doc.get_page_images(pno=0)[0]
     image_object_number = first_image[0]
     pixmap = fitz.Pixmap(doc, image_object_number)
 


### PR DESCRIPTION
Updates base container image to Python 3.9 based on Debian Buster.

Updates PyMuPDF to a later version. The previous version was fairly old and had no wheel distributions compatible with Python 3.9.

Updates deprecated method names in PyMuPDF fitz module. These were simply changed to `snake_case`.

Add `#pyup ignore` to various dependencies flagged on this PR. These do not block the upgrade to Python 3.9 and will be tackled in separate PRs. Various refactors are likely and out of scope of this update. Discussed with @quis.

🚨  **Accurate PDF rendering is untested. Don't merge until this has been checked by 👁️ **