### PR TITLE
Bump Flask and Werkzeug dependencies

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -266,7 +266,7 @@ def overlay_template_png_for_page():
         raise InvalidRequest(f'page_number or is_first_page must be specified in request params {request.args}')
 
     return send_file(
-        filename_or_fp=png_from_pdf(
+        path_or_file=png_from_pdf(
             _colour_no_print_areas_of_single_page_pdf_in_red(file_data, is_first_page=is_first_page),
             # the pdf is only one page, so this is always 1.
             page_number=1
@@ -297,7 +297,7 @@ def overlay_template_pdf():
     for i in range(pdf.numPages):
         _colour_no_print_areas_of_page_in_red(pdf.getPage(i), is_first_page=(i == 0))
 
-    return send_file(filename_or_fp=bytesio_from_pdf(pdf), mimetype='application/pdf')
+    return send_file(path_or_file=bytesio_from_pdf(pdf), mimetype='application/pdf')
 
 
 def log_metadata_for_letter(src_pdf, filename):

--- a/app/preview.py
+++ b/app/preview.py
@@ -98,12 +98,12 @@ def view_letter_template(filetype):
 
         if filetype == 'pdf':
             return send_file(
-                filename_or_fp=get_pdf(html),
+                path_or_file=get_pdf(html),
                 mimetype='application/pdf',
             )
         elif filetype == 'png':
             return send_file(
-                filename_or_fp=get_png(
+                path_or_file=get_png(
                     html,
                     int(request.args.get('page', 1)),
                 ),
@@ -177,7 +177,7 @@ def view_precompiled_letter():
             abort(400)
 
         return send_file(
-            filename_or_fp=get_png_from_precompiled(
+            path_or_file=get_png_from_precompiled(
                 encoded_string,
                 int(request.args.get('page', 1)),
                 hide_notify=request.args.get('hide_notify', '') == 'true',
@@ -224,7 +224,7 @@ def print_letter_template():
     response = send_file(
         cmyk_pdf,
         as_attachment=True,
-        attachment_filename='print.pdf'
+        download_name='print.pdf'
     )
     response.headers['X-pdf-page-count'] = get_page_count(cmyk_pdf.read())
     cmyk_pdf.seek(0)

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 #app requirements
 boto3==1.20.5
 celery[sqs]==5.0.5 # pyup: ignore
-Flask==1.1.4
+Flask==2.0.2
 Flask-WeasyPrint==0.6
 Flask-HTTPAuth==4.2.0
-Werkzeug==1.0.1 # pyup: ignore
+Werkzeug==2.0.2
 
 # pdf libraries
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ deprecated==1.2.13
     # via redis
 docutils==0.15.2
     # via awscli
-flask==1.1.4
+flask==2.0.2
     # via
     #   -r requirements.in
     #   flask-httpauth
@@ -100,11 +100,11 @@ html5lib==1.1
     #   weasyprint
 idna==3.3
     # via requests
-itsdangerous==1.1.0
+itsdangerous==2.0.1
     # via
     #   flask
     #   notifications-utils
-jinja2==2.11.3
+jinja2==3.0.3
     # via
     #   flask
     #   notifications-utils
@@ -231,7 +231,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==1.0.1
+werkzeug==2.0.2
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
PyUp is complaining about vulnerabilities in Werkzeug version 1.0.1, specifically

> Werkzeug version 2.0.2 improves the security of the debugger cookies. "SameSite" attribute is set to "Strict" instead of "None", and the secure flag is added when on HTTPS.

This doesn’t affect this app in production since it doesn’t serve public traffic.

This also means bumping Flask to version 2 (or downgrading to 1.1.2) since Flask 1.1.4 specifically requires Werkzeug less than version 2.

Flask 2 changes some argument names, but otherwise the tests seem to pass OK.