### PR TITLE
Bump Celery to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 #app requirements
 boto3==1.20.5
-celery[sqs]==5.0.5 # pyup: ignore
+celery[sqs]==5.2.1
 Flask==2.0.2
 Flask-WeasyPrint==0.6
 Flask-HTTPAuth==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ bleach==4.1.0
 boto3==1.20.5
     # via
     #   -r requirements.in
-    #   celery
     #   notifications-utils
 botocore==1.23.5
     # via
@@ -36,7 +35,7 @@ cairocffi==1.3.0
     #   weasyprint
 cairosvg==2.5.2
     # via weasyprint
-celery[sqs]==5.0.5
+celery[sqs]==5.2.1
     # via -r requirements.in
 certifi==2021.10.8
     # via
@@ -48,7 +47,7 @@ cffi==1.15.0
     #   weasyprint
 charset-normalizer==2.0.7
     # via requests
-click==7.1.2
+click==8.0.3
     # via
     #   celery
     #   click-didyoumean
@@ -114,7 +113,7 @@ jmespath==0.10.0
     #   botocore
 jsonschema==3.2.0
     # via -r requirements.in
-kombu==5.2.1
+kombu==5.2.2
     # via celery
 markupsafe==2.0.1
     # via jinja2
@@ -144,8 +143,6 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
-pycurl==7.43.0.5
-    # via celery
 pymupdf==1.19.1
     # via -r requirements.in
 pyparsing==2.4.7


### PR DESCRIPTION
This brings in the version 5.2.1 of Kombu, which fixes a security vulnerability:
> Celery 5.2.0 includes 'kombu' v5.2.1, which includes dependencies
> updates that resolve security issues.
— https://pyup.io/repos/github/alphagov/notifications-api/commits/?page=1#b654c27699a5164cbbe50e042d5d34141f560255

This is the commit from Kombu: celery/kombu@f3b0455

I believe the dependency of Kombu which has issues is urllib3, which has two open advisories for versions less than 1.26.5:
- GHSA-q2q7-5pp4-w6pg
- GHSA-5phf-pp7p-vc2r