### PR TITLE
Bump utils to bring in latest NotifyCelery code

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@48.1.0#egg=notifications-utils==48.1.0
+git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,9 @@ cairosvg==2.5.2
 celery[sqs]==5.0.5
     # via -r requirements.in
 certifi==2021.10.8
-    # via requests
+    # via
+    #   pyproj
+    #   requests
 cffi==1.15.0
     # via
     #   cairocffi
@@ -118,7 +120,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@48.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -154,6 +156,8 @@ pypdf2==1.26.0
     #   notifications-utils
 pyphen==0.11.0
     # via weasyprint
+pyproj==3.2.1
+    # via notifications-utils
 pyrsistent==0.18.0
     # via jsonschema
 python-dateutil==2.8.2


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180213914

The new version of the base class:

- Reenables Celery argument checking
- Removes redundant code

See here for more details [1]. This also brings in an additional
but irrelevant change, relating to broadcast polygons.

[1]: https://github.com/alphagov/notifications-utils/pull/921