### PR TITLE
Only re-run bootstrap if it's likely necessary

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,11 +56,15 @@ RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/polic
 
 FROM parent as test
 
+# Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
+RUN mkdir -p app
+
+COPY Makefile requirements_for_test.txt ./
+RUN make bootstrap
+
 # Copy from the real world, one dir up (project root) into the environment's current working directory
 # Docker will rebuild from here down every time.
 COPY . .
-
-RUN make bootstrap
 
 ##### Production Image #######################################################
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178758588

Previously we rebuilt this "Python packages" layer of the image
whenever any file had changed, which made it slow to test before
/ after changes in other layers of the image, where we benefit
from Docker layer caching. This ensures we only rebuild the layer
containing Python packages when it's likely they have changes -
either because Makefile or requirements* have changed.