### PR TITLE
Bump utils to 51.3.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@49.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This app has nothing to do with broadcasts or CSVs - this upgrade
is to pull in new logging for the NotifyCelery base class [1].

[1]: https://github.com/alphagov/notifications-utils/blob/master/CHANGELOG.md#5130