### PR TITLE
Fix log format to avoid double interpolation

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -243,7 +243,7 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
         file_data = convert_pdf_to_cmyk(file_data)
 
     if unembedded := contains_unembedded_fonts(file_data, filename):
-        current_app.logger.info(f'PDF contains unembedded fonts: {unembedded}')
+        current_app.logger.info(f'PDF contains unembedded fonts: {", ".join(unembedded)}')
         file_data = embed_fonts(file_data)
 
     # during switchover, DWP and CYSP will still be sending the notify tag. Only add it if it's not already there


### PR DESCRIPTION
This was trying to log the set of unembedded fonts, which has the
same form as a format string - e.g. {'/Helvetica'} - and was being
picked up by an old, magical bit of handler code in utils [1].

Although the log gets through, this stops the excess of error logs
that don't make it to Kibana, but do make it to Sentry.

[1]: https://github.com/alphagov/notifications-utils/blob/aa3b918e6c6c6d8b94b5aaf3c47d69680e7f1611/notifications_utils/logging.py#L159