### PR TITLE
Mark letters as validation-failed if the templated letter is too long.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -84,6 +84,12 @@ def load_config(application):
         )
     )
 
+    application.config['INVALID_PDF_BUCKET_NAME'] = (
+        '{}-letters-invalid-pdf'.format(
+            application.config['NOTIFY_ENVIRONMENT']
+        )
+    )
+
     application.config['SANITISED_LETTER_BUCKET_NAME'] = (
         '{}-letters-sanitise'.format(
             application.config['NOTIFY_ENVIRONMENT']
@@ -239,6 +245,7 @@ class QueueNames:
 class TaskNames:
     PROCESS_SANITISED_LETTER = 'process-sanitised-letter'
     UPDATE_BILLABLE_UNITS_FOR_LETTER = 'update-billable-units-for-letter'
+    UPDATE_VALIDATION_FAILED_FOR_TEMPLATED_LETTER = 'update-validation-failed-for-templated-letter'
 
 
 queue_prefix = {

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -12,6 +12,7 @@ from moto import mock_s3
 import app.celery.tasks
 from app import QueueNames
 from app.celery.tasks import (
+    _remove_folder_from_filename,
     copy_redaction_failed_pdf,
     create_pdf_for_templated_letter,
     recreate_pdf_for_precompiled_letter,
@@ -224,6 +225,7 @@ def test_create_pdf_for_templated_letter_happy_path(
         region=current_app.config['AWS_REGION'],
         bucket_name=current_app.config[bucket_name],
         file_location='MY_LETTER.PDF',
+        metadata=None
     )
 
     mock_celery.assert_called_once_with(
@@ -237,6 +239,47 @@ def test_create_pdf_for_templated_letter_happy_path(
     mock_logger.assert_has_calls([
         call("Creating a pdf for notification with id abc-123"),
         call(f"Uploaded letters PDF MY_LETTER.PDF to {current_app.config[bucket_name]} for notification id abc-123")
+    ])
+    mock_logger_exception.assert_not_called()
+
+
+def test_create_pdf_for_templated_letter_when_letter_is_too_long(
+    mocker, client, data_for_create_pdf_for_templated_letter_task
+):
+    # create a pdf for templated letter using data from API, upload the pdf to the final S3 bucket,
+    # and send data back to API so that it can update notification status and billable units.
+    mock_upload = mocker.patch('app.celery.tasks.s3upload')
+    mock_celery = mocker.patch('app.celery.tasks.notify_celery.send_task')
+    mock_logger = mocker.patch('app.celery.tasks.current_app.logger.info')
+    mock_logger_exception = mocker.patch('app.celery.tasks.current_app.logger.exception')
+    mocker.patch('app.celery.tasks.get_page_count', return_value=11)
+
+    data_for_create_pdf_for_templated_letter_task["logo_filename"] = 'hm-government'
+    data_for_create_pdf_for_templated_letter_task["key_type"] = 'normal'
+
+    encrypted_data = current_app.encryption_client.encrypt(data_for_create_pdf_for_templated_letter_task)
+
+    create_pdf_for_templated_letter(encrypted_data)
+    mock_upload.assert_called_once_with(
+        filedata=mocker.ANY,
+        region=current_app.config['AWS_REGION'],
+        bucket_name=current_app.config['INVALID_PDF_BUCKET_NAME'],
+        file_location='MY_LETTER.PDF',
+        metadata={'validation_status': 'failed', 'message': 'letter-too-long', 'page_count': '11'}
+    )
+
+    mock_celery.assert_called_once_with(
+        kwargs={
+            "notification_id": 'abc-123',
+            "page_count": 11
+        },
+        name='update-validation-failed-for-templated-letter',
+        queue='letter-tasks'
+    )
+    mock_logger.assert_has_calls([
+        call("Creating a pdf for notification with id abc-123"),
+        call(f"Uploaded letters PDF MY_LETTER.PDF to {current_app.config['INVALID_PDF_BUCKET_NAME']} "
+             f"for notification id abc-123")
     ])
     mock_logger_exception.assert_not_called()
 
@@ -367,3 +410,14 @@ def test_recreate_pdf_for_precompiled_letter_that_fails_validation(mocker, clien
     assert len([x for x in final_letters_bucket.objects.all()]) == 0
 
     mock_logger_error.assert_called_once_with("Notification failed resanitisation: 1234-abcd")
+
+
+@pytest.mark.parametrize("filename, expected_filename",
+                         [('2018-01-13/NOTIFY.ABCDEF1234567890.PDF',
+                           'NOTIFY.ABCDEF1234567890.PDF'),
+                          ('NOTIFY.ABCDEF1234567890.PDF',
+                           'NOTIFY.ABCDEF1234567890.PDF'),
+                          ])
+def test_remove_folder_from_filename(filename, expected_filename):
+    actual_filename = _remove_folder_from_filename(filename)
+    assert actual_filename == expected_filename


### PR DESCRIPTION
It is possible that the personalisation for a templated letter can make the letter exceed 10 pages or 5 sheets. We are not validating the letters posted via the API for this validation error. It is only possible to validate the letter once we create the PDF in notifications-template-preview. This means that the letter can only get a validation-failed status after the client has received a 201 from the POST to /v2/notifications.
NOTE: we only validate the preview row of a CSV for this validation error, this change will mean that it is possible for a letter to be marked as validation-failed after a successful file upload.

A new task to update the notification to `validation-failed` has been added to the API. If we find that the letter is too long once we have created the PDF we call the `update-validation-failed-for-templated-letter` task rather than `update-billable-units-for-letter` task. 

New work flow for a letter in brief:
API - receives POST /v2/notifications
:: save to db
:: put CREATE_LETTERS_PDF task on queue for template preview to consume
TEMPLATE-PREVIEW - consumes task CREATE_LETTERS_PDF
:: create PDF
:: count pages of PDF
:: IF page count exceeds 10 pages
	 put in the letters-invalid-pdf S3 bucket with metadata (similar to the precompiled letters)
	 put `update-validation-failed-for-templated-letter` task on the queue for the API to consume
   ELSE
     put PDF in the `letters-pdf` bucket
     put `update-billable-units-for-letter` task on the queue
API - consumes `update-billable-units-for-letter` OR `update-validation-failed-for-templated-letter` task 
:: IF `update-billable-units-for-letter` task: 
   	update billable units for notification as usual
:: ELSE `update-validation-failed-for-templated-letter`:
   	update notification_status = `validation-failed`
ADMIN - view notification page for letter
:: show validation letter for templated letter

There will be 3 PRs in order to make this change, one for the API, template-preview and the admin app.

#### Deployment plan

Deploy Admin first
Deploy API
Deploy template-preview

Related PRs:
https://github.com/alphagov/notifications-api/pull/3418
https://github.com/alphagov/notifications-admin/pull/4107

https://www.pivotaltracker.com/story/show/169209742