### PR TITLE
Fix image build due to broken GhostScript version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN echo "Install base packages" && apt-get update \
         libpango1.0-dev \
         libmagickwand-dev \
         imagemagick \
-        ghostscript=9.53.3~dfsg-7+deb11u1 \
+        ghostscript=9.53.3~dfsg-7+deb11u2 \
         poppler-utils=20.09.0-3.1 \
         xfonts-utils \
         gsfonts \


### PR DESCRIPTION
To fix this error:

      21.53 The following packages have unmet dependencies:
      21.67  ghostscript : Depends: libgs9 (= 9.53.3~dfsg-7+deb11u1) but 9.53.3~dfsg-7+deb11u2 is to be installed
      21.69 E: Unable to correct problems, you have held broken packages.

Changelog: https://www.mail-archive.com/debian-changes@lists.debian.org/msg23791.html

I think this is happening because deb11u1 refers to the specific OS
version, which has changed in the base image (although I can't work
out how to get the full OS version to confirm this).

Bumping the package version will fix the issue for now, although we
should consider locking the base image to a specific tag, if we want
to avoid this happening again. Arguably we should continue as we are
until we have a security upgrade policy for our images.

Given this is a security update, I'm not concerned about the deploy
and don't think we need to do any further testing.