### PR TITLE
Log filename when letter redaction fails

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -239,6 +239,7 @@ def rewrite_pdf(file_data, *, page_count, allow_international_letters, filename)
         file_data,
         page_count=page_count,
         allow_international_letters=allow_international_letters,
+        filename=filename,
     )
 
     if not does_pdf_contain_cmyk(file_data):
@@ -628,7 +629,7 @@ def handle_irregular_whitespace_characters(string):
     return also_handle_irregular_spacing
 
 
-def rewrite_address_block(pdf, *, page_count, allow_international_letters):
+def rewrite_address_block(pdf, *, page_count, allow_international_letters, filename):
     address = extract_address_block(pdf)
     address.allow_international_letters = allow_international_letters
 
@@ -640,7 +641,7 @@ def rewrite_address_block(pdf, *, page_count, allow_international_letters):
         pdf = add_address_to_precompiled_letter(pdf, address.normalised)
         return pdf, address.normalised, None
     except pdf_redactor.RedactionException as e:
-        current_app.logger.warning(f'Could not redact address block for letter: "{e}" ')
+        current_app.logger.warning(f'Could not redact address for {filename}: "{e}"')
         pdf.seek(0)
         return pdf, address.raw_address, str(e)
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -644,6 +644,7 @@ def test_rewrite_address_block_end_to_end(pdf_data, address_snippet):
         BytesIO(pdf_data),
         page_count=1,
         allow_international_letters=False,
+        filename='file'
     )
     assert not message
     assert address == extract_address_block(new_pdf).raw_address
@@ -658,6 +659,7 @@ def test_rewrite_address_block_doesnt_overwrite_if_it_cant_redact_address(client
         old_pdf,
         page_count=1,
         allow_international_letters=False,
+        filename='file'
     )
 
     # assert that the pdf is unchanged. Specifically we haven't written the new address over the old one


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180900091

This will allow us to investigate the scale of the issue. We see
thousands of these logs every week, but:

- It's unclear how many services are affected.
- We can't investigate individual failures.

Having the letter filename will allow us to gather more data to fix
the bug, which may actually be several bugs.