### PR TITLE
Make resanitise logs distinct from normal ones

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -197,7 +197,7 @@ def recreate_pdf_for_precompiled_letter(notification_id, file_location, allow_in
         # Only files that have failed sanitisation have 'message' in the sanitisation_details dict
         if sanitisation_details.get('message'):
             # The file previously passed sanitisation, so we need to manually investigate why it's now failing
-            current_app.logger.error(f'Notification failed sanitisation: {notification_id}')
+            current_app.logger.error(f'Notification failed resanitisation: {notification_id}')
             return
 
         file_data = base64.b64decode(sanitisation_details['file'].encode())
@@ -211,7 +211,7 @@ def recreate_pdf_for_precompiled_letter(notification_id, file_location, allow_in
             file_location=file_location,
         )
 
-        current_app.logger.info(f'Notification passed sanitisation: {notification_id}')
+        current_app.logger.info(f'Notification passed resanitisation: {notification_id}')
 
     except BotoClientError:
         current_app.logger.exception(

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -366,4 +366,4 @@ def test_recreate_pdf_for_precompiled_letter_that_fails_validation(mocker, clien
     assert [o.key for o in backup_bucket.objects.all()] == ['1234-abcd.pdf']
     assert len([x for x in final_letters_bucket.objects.all()]) == 0
 
-    mock_logger_error.assert_called_once_with("Notification failed sanitisation: 1234-abcd")
+    mock_logger_error.assert_called_once_with("Notification failed resanitisation: 1234-abcd")


### PR DESCRIPTION
After trying the recovery process for the first time I ended up
having to manually search for the logs for each notification, as
they were all mixed up with the normal PDF processing logs.