### PR TITLE
Bump utils to 53.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ pdfrw==0.4
 defusedxml==0.6.0
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0
+git+https://github.com/alphagov/notifications-utils.git@53.0.0#egg=notifications-utils==53.0.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@53.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
Changes (none directly affect this app):

53.0.0
---

* `notifications_utils.columns.Columns` has moved to `notifications_utils.insensitive_dict.InsensitiveDict`
* `notifications_utils.columns.Rows` has moved to `notifications_utils.recipients.Rows`
* `notifications_utils.columns.Cell` has moved to `notifications_utils.recipients.Cell`

52.0.0
---

* Deprecate the following unused `redis_client` functions:
  - `redis_client.increment_hash_value`
  - `redis_client.decrement_hash_value`
  - `redis_client.get_all_from_hash`
  - `redis_client.set_hash_and_expire`
  - `redis_client.expire`

51.3.1
---

* Bump govuk-bank-holidays to cache holidays for next year.