### PR TITLE
Remove redundant log for reraised exception

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -85,34 +85,29 @@ def view_letter_template(filetype):
         "filename": {"type": "string"}
     }
     """
-    try:
-        if filetype not in ('pdf', 'png'):
-            abort(404)
+    if filetype not in ('pdf', 'png'):
+        abort(404)
 
-        if filetype == 'pdf' and request.args.get('page') is not None:
-            abort(400)
+    if filetype == 'pdf' and request.args.get('page') is not None:
+        abort(400)
 
-        html = get_html(
-            get_and_validate_json_from_request(request, preview_schema)
+    html = get_html(
+        get_and_validate_json_from_request(request, preview_schema)
+    )
+
+    if filetype == 'pdf':
+        return send_file(
+            path_or_file=get_pdf(html),
+            mimetype='application/pdf',
         )
-
-        if filetype == 'pdf':
-            return send_file(
-                path_or_file=get_pdf(html),
-                mimetype='application/pdf',
-            )
-        elif filetype == 'png':
-            return send_file(
-                path_or_file=get_png(
-                    html,
-                    int(request.args.get('page', 1)),
-                ),
-                mimetype='image/png',
-            )
-
-    except Exception as e:
-        current_app.logger.error(str(e))
-        raise e
+    elif filetype == 'png':
+        return send_file(
+            path_or_file=get_png(
+                html,
+                int(request.args.get('page', 1)),
+            ),
+            mimetype='image/png',
+        )
 
 
 def get_html(json):


### PR DESCRIPTION
Exceptions are logged automatically if they go unhandled. If they
are handled, then we should leave it up to the handler to make a
decision about whether to log or not.

Currently this is leading to unactionable logs for 4xx errors e.g.

    Traceback (most recent call last):
      File "/home/vcap/app/app/preview.py", line 35, in png_from_pdf
        page = pdf.sequence[page_number - 1]
      File "/usr/local/lib/python3.9/site-packages/wand/sequence.py", line 111, in __getitem__
        index = self.validate_position(index)
      File "/usr/local/lib/python3.9/site-packages/wand/sequence.py", line 80, in validate_position
        raise IndexError(
    IndexError: out of index: 3 (total: 3)

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1516, in full_dispatch_request
        rv = self.dispatch_request()
      File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 1502, in dispatch_request
        return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
      File "/usr/local/lib/python3.9/site-packages/flask_httpauth.py", line 164, in decorated
        return f(*args, **kwargs)
      File "/home/vcap/app/app/preview.py", line 115, in view_letter_template
        raise e
      File "/home/vcap/app/app/preview.py", line 106, in view_letter_template
        path_or_file=get_png(
      File "/home/vcap/app/app/preview.py", line 150, in get_png
        return _get()
      File "/home/vcap/app/app/__init__.py", line 169, in new_function
        data = original_function()
      File "/home/vcap/app/app/preview.py", line 145, in _get
        return png_from_pdf(
      File "/home/vcap/app/app/preview.py", line 37, in png_from_pdf
        abort(400, 'Letter does not have a page {}'.format(page_number))
      File "/usr/local/lib/python3.9/site-packages/werkzeug/exceptions.py", line 940, in abort
        _aborter(status, *args, **kwargs)
      File "/usr/local/lib/python3.9/site-packages/werkzeug/exceptions.py", line 923, in __call__
        raise self.mapping[code](*args, **kwargs)
    werkzeug.exceptions.BadRequest: 400 Bad Request: Letter does not have a page 4