### PR TITLE
Fix failing install of PyMuPDF in Docker

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ jsonschema==3.2.0
 pypdf2==1.26.0
 reportlab==3.6.3
 pdf2image==1.12.1
-PyMuPDF==1.19.1
+PyMuPDF==1.19.6
 defusedxml==0.6.0
 WeasyPrint==51
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -140,7 +140,7 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
-pymupdf==1.19.1
+pymupdf==1.19.6
     # via -r requirements.in
 pyparsing==2.4.7
     # via packaging


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

This has been failing since 1.19.1 and seems to have started working
again since 1.19.5, so we may as well upgrade to the latest version.

        fitz/fitz_wrap.c:2755:10: fatal error: fitz.h: No such file or directory

It's unclear from the changelog [^1] why it broke and why the install
is now working. It's unclear if this is related to building the image
on top of Mac M1 - while online discussions corroborate the problem
[^2], the versions that work for us are different e.g. 1.19.4 breaks.

We use the "fitz" module from PyMuPDF in several critcal parts of the
code, including address extraction / redaction and colour detection.
We should therefore deploy this upgrade with caution.

[^1]: https://github.com/pymupdf/PyMuPDF/blob/master/changes.txt
[^2]: https://github.com/pymupdf/PyMuPDF/discussions/1563#discussioncomment-2317416