### PR TITLE
Fix Docker environment breaking without version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## application-specific
 
+## A placeholder version of this file is still committed to avoid having to generate it for local
+## development. The committed file will get overwritten as part of building the Docker image.
 app/version.py
+
 .envrc
 
 ## We don’t allow committing certain file types that risk containing users’ personal information

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ generate-version-file:
 	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
-bootstrap: generate-version-file
+bootstrap:
 	mkdir -p log # manually create directory to avoid permission issues
 	pip install -r requirements_for_test.txt
 

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,2 @@
+__commit__ = "fake-local-dev-sha"
+__time__ = "2022-03-10T13:49:50"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

We could also fix this by making "bootstrap-with-docker" depend on
"generate-version-file", but generating the file has no value for
local development, so I think this approach is better.

We should also apply this change the Antivirus repo, which is built
in the same way as this one.