### PR TITLE
Change log level from error to exception

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -226,7 +226,7 @@ def sanitise_file_contents(encoded_string, *, allow_international_letters, filen
         }
     # Anything else is probably a bug but usually infrequent, so pretend it's invalid.
     except Exception as error:
-        current_app.logger.error(
+        current_app.logger.exception(
             f'Unexpected exception for precompiled pdf: {repr(error)} for file name: {filename}'
         )
 


### PR DESCRIPTION
These exceptions are unexpected and it is important to see the
strack trace when debugging however using `error` hides the
stack trace. Moving it to to `exception` means we include the
stack trace.

This will be helpful as at the moment I am seeing log lines of

```
Unexpected exception for precompiled pdf: IndexError('tuple index out of range') for file name: 70a42a07-7089-45b5-a135-7f6fd77ec673
```

however there is no stacktrace to give me context.