### PR TITLE
Prepare to switch to Redis on PaaS

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,8 @@
-import json
-import os
 from contextlib import suppress
 from hashlib import sha1
 
 from flask import Flask, jsonify
 from flask_httpauth import HTTPTokenAuth
-from kombu import Exchange, Queue
 from notifications_utils import logging as utils_logging
 from notifications_utils import request_helper
 from notifications_utils.celery import NotifyCelery
@@ -18,103 +15,13 @@ from app import weasyprint_hack
 notify_celery = NotifyCelery()
 
 
-def load_config(application):
-    application.config['AWS_REGION'] = 'eu-west-1'
-    application.config['TEMPLATE_PREVIEW_INTERNAL_SECRETS'] = json.loads(
-        os.environ.get('TEMPLATE_PREVIEW_INTERNAL_SECRETS', '[]')
-    )
-    application.config['NOTIFY_ENVIRONMENT'] = os.environ['NOTIFY_ENVIRONMENT']
-    application.config['NOTIFY_APP_NAME'] = 'template-preview'
-    application.config['DANGEROUS_SALT'] = os.environ['DANGEROUS_SALT']
-    application.config['SECRET_KEY'] = os.environ['SECRET_KEY']
-
-    application.config['CELERY'] = {
-        'broker_url': 'sqs://',
-        'broker_transport_options': {
-            'region': application.config['AWS_REGION'],
-            'visibility_timeout': 310,
-            'queue_name_prefix': queue_prefix[application.config['NOTIFY_ENVIRONMENT']],
-            'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
-        },
-        'timezone': 'Europe/London',
-        'worker_max_memory_per_child': 50,
-        'imports': ['app.celery.tasks'],
-        'task_queues': [
-            Queue(QueueNames.SANITISE_LETTERS, Exchange('default'), routing_key=QueueNames.SANITISE_LETTERS)
-        ],
-    }
-
-    # if we use .get() for cases that it is not setup
-    # it will still create the config key with None value causing
-    # logging initialization in utils to fail
-    if 'NOTIFY_LOG_PATH' in os.environ:
-        application.config['NOTIFY_LOG_PATH'] = os.environ['NOTIFY_LOG_PATH']
-
-    application.config['EXPIRE_CACHE_IN_SECONDS'] = 600
-
-    if os.environ['STATSD_ENABLED'] == "1":
-        application.config['STATSD_ENABLED'] = True
-        application.config['STATSD_HOST'] = os.environ['STATSD_HOST']
-        application.config['STATSD_PORT'] = 8125
-    else:
-        application.config['STATSD_ENABLED'] = False
-
-    application.config['LETTERS_SCAN_BUCKET_NAME'] = (
-        '{}-letters-scan'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-    application.config['LETTER_CACHE_BUCKET_NAME'] = (
-        '{}-template-preview-cache'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['LETTERS_PDF_BUCKET_NAME'] = (
-        '{}-letters-pdf'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['TEST_LETTERS_BUCKET_NAME'] = (
-        '{}-test-letters'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['INVALID_PDF_BUCKET_NAME'] = (
-        '{}-letters-invalid-pdf'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['SANITISED_LETTER_BUCKET_NAME'] = (
-        '{}-letters-sanitise'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME'] = (
-        '{}-letters-precompiled-originals-backup'.format(
-            application.config['NOTIFY_ENVIRONMENT']
-        )
-    )
-
-    application.config['LETTER_LOGO_URL'] = 'https://static-logos.{}/letters'.format({
-        'test': 'notify.tools',
-        'development': 'notify.tools',
-        'preview': 'notify.works',
-        'staging': 'staging-notify.works',
-        'production': 'notifications.service.gov.uk'
-    }[application.config['NOTIFY_ENVIRONMENT']])
-
-
 def create_app():
     application = Flask(__name__)
 
-    init_app(application)
+    from app.config import Config
+    application.config.from_object(Config)
 
-    load_config(application)
+    init_app(application)
 
     from app.precompiled import precompiled_blueprint
     from app.preview import preview_blueprint
@@ -229,23 +136,3 @@ class ValidationFailed(Exception):
         self.invalid_pages = invalid_pages
         self.code = code
         self.page_count = page_count
-
-
-class QueueNames:
-    LETTERS = 'letter-tasks'
-    SANITISE_LETTERS = 'sanitise-letter-tasks'
-
-
-class TaskNames:
-    PROCESS_SANITISED_LETTER = 'process-sanitised-letter'
-    UPDATE_BILLABLE_UNITS_FOR_LETTER = 'update-billable-units-for-letter'
-    UPDATE_VALIDATION_FAILED_FOR_TEMPLATED_LETTER = 'update-validation-failed-for-templated-letter'
-
-
-queue_prefix = {
-    'test': 'test',
-    'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX', 'development'),
-    'preview': 'preview',
-    'staging': 'staging',
-    'production': 'live',
-}

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -9,7 +9,8 @@ from notifications_utils import LETTER_MAX_PAGE_COUNT
 from notifications_utils.s3 import s3download, s3upload
 from notifications_utils.template import LetterPrintTemplate
 
-from app import QueueNames, TaskNames, notify_celery
+from app import notify_celery
+from app.config import QueueNames, TaskNames
 from app.precompiled import sanitise_file_contents
 from app.preview import get_page_count
 from app.transformation import convert_pdf_to_cmyk

--- a/app/cloudfoundry_config.py
+++ b/app/cloudfoundry_config.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+
+def extract_cloudfoundry_config():
+    vcap_services = json.loads(os.environ['VCAP_SERVICES'])
+
+    # Redis config
+    if 'redis' in vcap_services:
+        os.environ['REDIS_URL'] = vcap_services['redis'][0]['credentials']['uri']

--- a/app/config.py
+++ b/app/config.py
@@ -16,14 +16,15 @@ class TaskNames:
 
 
 class Config:
+    NOTIFY_ENVIRONMENT = os.environ['NOTIFY_ENVIRONMENT']
+
     AWS_REGION = 'eu-west-1'
     TEMPLATE_PREVIEW_INTERNAL_SECRETS = json.loads(
         os.environ.get('TEMPLATE_PREVIEW_INTERNAL_SECRETS', '[]')
     )
-    NOTIFY_ENVIRONMENT = os.environ['NOTIFY_ENVIRONMENT']
     NOTIFY_APP_NAME = 'template-preview'
-    DANGEROUS_SALT = os.environ['DANGEROUS_SALT']
-    SECRET_KEY = os.environ['SECRET_KEY']
+    DANGEROUS_SALT = os.environ.get('DANGEROUS_SALT')
+    SECRET_KEY = os.environ.get('SECRET_KEY')
 
     CELERY = {
         'broker_url': 'sqs://',
@@ -51,13 +52,13 @@ class Config:
     # it will still create the config key with None value causing
     # logging initialization in utils to fail
     if 'NOTIFY_LOG_PATH' in os.environ:
-        NOTIFY_LOG_PATH = os.environ['NOTIFY_LOG_PATH']
+        NOTIFY_LOG_PATH = os.environ.get('NOTIFY_LOG_PATH')
 
     EXPIRE_CACHE_IN_SECONDS = 600
 
-    if os.environ['STATSD_ENABLED'] == "1":
+    if os.environ.get('STATSD_ENABLED') == "1":
         STATSD_ENABLED = True
-        STATSD_HOST = os.environ['STATSD_HOST']
+        STATSD_HOST = os.environ.get('STATSD_HOST')
         STATSD_PORT = 8125
     else:
         STATSD_ENABLED = False

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,114 @@
+import json
+import os
+
+from kombu import Exchange, Queue
+
+queue_prefix = {
+    'test': 'test',
+    'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX', 'development'),
+    'preview': 'preview',
+    'staging': 'staging',
+    'production': 'live',
+}
+
+
+class QueueNames:
+    LETTERS = 'letter-tasks'
+    SANITISE_LETTERS = 'sanitise-letter-tasks'
+
+
+class TaskNames:
+    PROCESS_SANITISED_LETTER = 'process-sanitised-letter'
+    UPDATE_BILLABLE_UNITS_FOR_LETTER = 'update-billable-units-for-letter'
+    UPDATE_VALIDATION_FAILED_FOR_TEMPLATED_LETTER = 'update-validation-failed-for-templated-letter'
+
+
+class Config:
+    AWS_REGION = 'eu-west-1'
+    TEMPLATE_PREVIEW_INTERNAL_SECRETS = json.loads(
+        os.environ.get('TEMPLATE_PREVIEW_INTERNAL_SECRETS', '[]')
+    )
+    NOTIFY_ENVIRONMENT = os.environ['NOTIFY_ENVIRONMENT']
+    NOTIFY_APP_NAME = 'template-preview'
+    DANGEROUS_SALT = os.environ['DANGEROUS_SALT']
+    SECRET_KEY = os.environ['SECRET_KEY']
+
+    CELERY = {
+        'broker_url': 'sqs://',
+        'broker_transport_options': {
+            'region': AWS_REGION,
+            'visibility_timeout': 310,
+            'queue_name_prefix': queue_prefix[NOTIFY_ENVIRONMENT],
+            'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
+        },
+        'timezone': 'Europe/London',
+        'worker_max_memory_per_child': 50,
+        'imports': ['app.celery.tasks'],
+        'task_queues': [
+            Queue(QueueNames.SANITISE_LETTERS, Exchange('default'), routing_key=QueueNames.SANITISE_LETTERS)
+        ],
+    }
+
+    # if we use .get() for cases that it is not setup
+    # it will still create the config key with None value causing
+    # logging initialization in utils to fail
+    if 'NOTIFY_LOG_PATH' in os.environ:
+        NOTIFY_LOG_PATH = os.environ['NOTIFY_LOG_PATH']
+
+    EXPIRE_CACHE_IN_SECONDS = 600
+
+    if os.environ['STATSD_ENABLED'] == "1":
+        STATSD_ENABLED = True
+        STATSD_HOST = os.environ['STATSD_HOST']
+        STATSD_PORT = 8125
+    else:
+        STATSD_ENABLED = False
+
+    LETTERS_SCAN_BUCKET_NAME = (
+        '{}-letters-scan'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+    LETTER_CACHE_BUCKET_NAME = (
+        '{}-template-preview-cache'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    LETTERS_PDF_BUCKET_NAME = (
+        '{}-letters-pdf'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    TEST_LETTERS_BUCKET_NAME = (
+        '{}-test-letters'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    INVALID_PDF_BUCKET_NAME = (
+        '{}-letters-invalid-pdf'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    SANITISED_LETTER_BUCKET_NAME = (
+        '{}-letters-sanitise'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = (
+        '{}-letters-precompiled-originals-backup'.format(
+            NOTIFY_ENVIRONMENT
+        )
+    )
+
+    LETTER_LOGO_URL = 'https://static-logos.{}/letters'.format({
+        'test': 'notify.tools',
+        'development': 'notify.tools',
+        'preview': 'notify.works',
+        'staging': 'staging-notify.works',
+        'production': 'notifications.service.gov.uk'
+    }[NOTIFY_ENVIRONMENT])

--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,12 @@ import os
 
 from kombu import Exchange, Queue
 
+if os.environ.get('VCAP_APPLICATION'):
+    # CloudFoundry config is in JSON blobs called VCAP_APPLICATION
+    # and VCAP_SERVICES, which we can unpack into standard env vars
+    from app.cloudfoundry_config import extract_cloudfoundry_config
+    extract_cloudfoundry_config()
+
 
 class QueueNames:
     LETTERS = 'letter-tasks'

--- a/app/config.py
+++ b/app/config.py
@@ -3,14 +3,6 @@ import os
 
 from kombu import Exchange, Queue
 
-queue_prefix = {
-    'test': 'test',
-    'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX', 'development'),
-    'preview': 'preview',
-    'staging': 'staging',
-    'production': 'live',
-}
-
 
 class QueueNames:
     LETTERS = 'letter-tasks'
@@ -38,8 +30,14 @@ class Config:
         'broker_transport_options': {
             'region': AWS_REGION,
             'visibility_timeout': 310,
-            'queue_name_prefix': queue_prefix[NOTIFY_ENVIRONMENT],
-            'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
+            'wait_time_seconds': 20,  # enable long polling, with a wait time of 20 seconds
+            'queue_name_prefix': ({
+                'test': 'test',
+                'development': os.environ.get('NOTIFICATION_QUEUE_PREFIX', 'development'),
+                'preview': 'preview',
+                'staging': 'staging',
+                'production': 'live',
+            }[NOTIFY_ENVIRONMENT]),
         },
         'timezone': 'Europe/London',
         'worker_max_memory_per_child': 50,
@@ -64,46 +62,13 @@ class Config:
     else:
         STATSD_ENABLED = False
 
-    LETTERS_SCAN_BUCKET_NAME = (
-        '{}-letters-scan'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-    LETTER_CACHE_BUCKET_NAME = (
-        '{}-template-preview-cache'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-
-    LETTERS_PDF_BUCKET_NAME = (
-        '{}-letters-pdf'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-
-    TEST_LETTERS_BUCKET_NAME = (
-        '{}-test-letters'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-
-    INVALID_PDF_BUCKET_NAME = (
-        '{}-letters-invalid-pdf'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-
-    SANITISED_LETTER_BUCKET_NAME = (
-        '{}-letters-sanitise'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
-
-    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = (
-        '{}-letters-precompiled-originals-backup'.format(
-            NOTIFY_ENVIRONMENT
-        )
-    )
+    LETTERS_SCAN_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-letters-scan'
+    LETTER_CACHE_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-template-preview-cache'
+    LETTERS_PDF_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-letters-pdf'
+    TEST_LETTERS_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-test-letters'
+    INVALID_PDF_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-letters-invalid-pdf'
+    SANITISED_LETTER_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-letters-sanitise'
+    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = f'{NOTIFY_ENVIRONMENT}-letters-precompiled-originals-backup'
 
     LETTER_LOGO_URL = 'https://static-logos.{}/letters'.format({
         'test': 'notify.tools',

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ env =
     STATSD_ENABLED=0
     DANGEROUS_SALT='test-notify-salt'
     SECRET_KEY='test-notify-secret-key'
+    TEMPLATE_PREVIEW_INTERNAL_SECRETS=["my-secret-key", "my-secret-key2"]

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -10,13 +10,13 @@ from flask import current_app
 from moto import mock_s3
 
 import app.celery.tasks
-from app import QueueNames
 from app.celery.tasks import (
     _remove_folder_from_filename,
     create_pdf_for_templated_letter,
     recreate_pdf_for_precompiled_letter,
     sanitise_and_upload_letter,
 )
+from app.config import QueueNames
 from app.weasyprint_hack import WeasyprintError
 from tests.pdf_consts import bad_postcode, blank_with_address, no_colour
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 
 import pytest
@@ -9,7 +8,6 @@ from app import create_app
 
 @pytest.fixture(scope='session')
 def app():
-    os.environ['TEMPLATE_PREVIEW_INTERNAL_SECRETS'] = '["my-secret-key", "my-secret-key2"]'
     yield create_app()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 
 import pytest
@@ -78,3 +79,16 @@ def set_config(app, name, value):
     app.config[name] = value
     yield
     app.config[name] = old_val
+
+
+@pytest.fixture
+def os_environ():
+    # for use whenever you expect code to edit environment variables
+    old_env = os.environ.copy()
+    os.environ.clear()
+
+    yield
+
+    os.environ.clear()
+    for k, v in old_env.items():
+        os.environ[k] = v

--- a/tests/test_cloudfoundry_config.py
+++ b/tests/test_cloudfoundry_config.py
@@ -1,0 +1,31 @@
+import json
+import os
+
+import pytest
+
+from app.cloudfoundry_config import extract_cloudfoundry_config
+
+
+@pytest.fixture
+def vcap_services():
+    return {
+        'redis': [{
+            'credentials': {
+                'uri': 'redis uri'
+            }
+        }],
+    }
+
+
+def test_extract_cloudfoundry_config_populates_other_vars(os_environ, vcap_services):
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
+    extract_cloudfoundry_config()
+    assert os.environ['REDIS_URL'] == 'redis uri'
+
+
+def test_set_config_env_vars_copes_if_redis_not_set(os_environ, vcap_services):
+    del vcap_services['redis']
+    os.environ['VCAP_SERVICES'] = json.dumps(vcap_services)
+
+    extract_cloudfoundry_config()
+    assert 'REDIS_URL' not in os.environ

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+
+import pytest
+
+from app import config
+
+
+@pytest.fixture
+def reload_config(os_environ):
+    # Needs to be set again due to os_environ
+    os.environ['NOTIFY_ENVIRONMENT'] = 'test'
+
+    yield
+    importlib.reload(config)
+
+
+def test_load_config(reload_config):
+    os.environ['SECRET_KEY'] = 'env'
+    importlib.reload(config)
+
+    assert os.environ['SECRET_KEY'] == 'env'
+    assert config.Config.SECRET_KEY == 'env'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,10 @@ import pytest
 from app import config
 
 
+def cf_conf():
+    os.environ['SECRET_KEY'] = 'abc'
+
+
 @pytest.fixture
 def reload_config(os_environ):
     # Needs to be set again due to os_environ
@@ -15,9 +19,35 @@ def reload_config(os_environ):
     importlib.reload(config)
 
 
-def test_load_config(reload_config):
+def test_load_cloudfoundry_config_if_available(reload_config, mocker):
     os.environ['SECRET_KEY'] = 'env'
+    os.environ['VCAP_APPLICATION'] = 'some json blob'
+
+    cf_extract = mocker.patch(
+        'app.cloudfoundry_config.extract_cloudfoundry_config',
+        side_effect=cf_conf
+    )
+
+    # reload config so that its module level code (ie: all of it) is re-instantiated
     importlib.reload(config)
+    assert cf_extract.called
+
+    assert os.environ['SECRET_KEY'] == 'abc'
+    assert config.Config.SECRET_KEY == 'abc'
+
+
+def test_load_config_if_cloudfoundry_not_available(reload_config, mocker):
+    os.environ['SECRET_KEY'] = 'env'
+    os.environ.pop('VCAP_SERVICES', None)
+
+    cf_extract = mocker.patch(
+        'app.cloudfoundry_config.extract_cloudfoundry_config',
+        side_effect=cf_conf
+    )
+
+    # reload config so that its module level code (ie: all of it) is re-instantiated
+    importlib.reload(config)
+    assert not cf_extract.called
 
     assert os.environ['SECRET_KEY'] == 'env'
     assert config.Config.SECRET_KEY == 'env'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181796569

This adds similar code to [^1]. Since this app didn't
previously load CloudFoundry config - and the config
code was also very different to other apps - there are
some initial commits to lay a foundation first.

The config module is still different to other repos due 
to the heavy use of NOTIFY_ENVIRONMENT to avoid 
duplication. I think it would be too subjective to change 
the approach in this PR - leaving as-is for now.

[^1]: https://github.com/alphagov/notifications-admin/pull/4210