### PR TITLE
Fix branch deployments from M1 Macs to PaaS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,10 @@ test-with-docker: ## Run tests in Docker container
 
 .PHONY: upload-to-docker-registry
 upload-to-docker-registry: ## Upload the current version of the docker image to Docker registry
-	docker build -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker push ${DOCKER_IMAGE_NAME}
+	docker buildx build --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- PAAS COMMANDS ---- #
 


### PR DESCRIPTION
An image built on a Mac M1 machine won't run on a PaaS AMD instance,
so we need to use Docker's new buildx feature [^1].

Note: you may need to run "docker buildx create --use" first, but the
command will prompt you to do so if necessary.

[^1]: https://docs.docker.com/buildx/working-with-buildx/