### PR TITLE
Run integration tests on multiple CPU cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ run-celery-with-docker: ## Run celery in Docker container
 test: ## Run tests (used by Concourse)
 	flake8 .
 	isort --check-only ./app ./tests
-	pytest --maxfail=10
+	pytest -n auto --maxfail=10
 
 .PHONY: test-with-docker
 test-with-docker: ## Run tests in Docker container

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,5 +8,6 @@ moto[s3]==3.1.4
 pytest-env==0.6.2
 pytest-mock==3.7.0
 pytest==7.1.1
+pytest-xdist==2.5.0
 requests-mock==1.9.3
 pdbpp==0.10.3

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -209,47 +209,48 @@ def test_get_invalid_pages_second_page(x, y, expected_failed, client):
         assert get_invalid_pages_with_message(packet) == ('', [])
 
 
-@pytest.mark.parametrize('x, y, page, expected_message', [
-    (0, 0, 1, ('content-outside-printable-area', [1])),
-    (200, 200, 1, ('', [])),
-    (590, 830, 1, ('content-outside-printable-area', [1])),
-    (0, 200, 1, ('content-outside-printable-area', [1])),
-    (0, 830, 1, ('content-outside-printable-area', [1])),
-    (200, 0, 1, ('content-outside-printable-area', [1])),
-    (590, 0, 1, ('content-outside-printable-area', [1])),
-    (590, 200, 1, ('content-outside-printable-area', [1])),
-    # under the citizen address block:
-    (24.6 * mm, (297 - 90) * mm, 1, ('content-outside-printable-area', [1])),
-    (24.6 * mm, (297 - 90) * mm, 2, ('', [])),  # Same place on page 2 should be ok
-    (24.6 * mm, (297 - 39) * mm, 1, ('content-outside-printable-area', [1])),  # under the logo
-    (24.6 * mm, (297 - 39) * mm, 2, ('', [])),  # Same place on page 2 should be ok
-    (0, 0, 2, ('content-outside-printable-area', [2])),
-    (200, 200, 2, ('', [])),
-    (590, 830, 2, ('content-outside-printable-area', [2])),
-    (0, 200, 2, ('content-outside-printable-area', [2])),
-    (0, 830, 2, ('content-outside-printable-area', [2])),
-    (200, 0, 2, ('content-outside-printable-area', [2])),
-    (590, 0, 2, ('content-outside-printable-area', [2])),
-    (590, 200, 2, ('content-outside-printable-area', [2])),
-])
-def test_get_invalid_pages_black_text(x, y, page, expected_message, client):
-    packet = io.BytesIO()
-    cv = canvas.Canvas(packet, pagesize=A4)
-    cv.setStrokeColor(white)
-    cv.setFillColor(white)
-    cv.rect(0, 0, 1000, 1000, stroke=1, fill=1)
+def test_get_invalid_pages_black_text(client):
+    for x, y, page, expected_message in [
+        (0, 0, 1, ('content-outside-printable-area', [1])),
+        (200, 200, 1, ('', [])),
+        (590, 830, 1, ('content-outside-printable-area', [1])),
+        (0, 200, 1, ('content-outside-printable-area', [1])),
+        (0, 830, 1, ('content-outside-printable-area', [1])),
+        (200, 0, 1, ('content-outside-printable-area', [1])),
+        (590, 0, 1, ('content-outside-printable-area', [1])),
+        (590, 200, 1, ('content-outside-printable-area', [1])),
+        # under the citizen address block:
+        (24.6 * mm, (297 - 90) * mm, 1, ('content-outside-printable-area', [1])),
+        (24.6 * mm, (297 - 90) * mm, 2, ('', [])),  # Same place on page 2 should be ok
+        (24.6 * mm, (297 - 39) * mm, 1, ('content-outside-printable-area', [1])),  # under the logo
+        (24.6 * mm, (297 - 39) * mm, 2, ('', [])),  # Same place on page 2 should be ok
+        (0, 0, 2, ('content-outside-printable-area', [2])),
+        (200, 200, 2, ('', [])),
+        (590, 830, 2, ('content-outside-printable-area', [2])),
+        (0, 200, 2, ('content-outside-printable-area', [2])),
+        (0, 830, 2, ('content-outside-printable-area', [2])),
+        (200, 0, 2, ('content-outside-printable-area', [2])),
+        (590, 0, 2, ('content-outside-printable-area', [2])),
+        (590, 200, 2, ('content-outside-printable-area', [2])),
+    ]:
+        packet = io.BytesIO()
+        cv = canvas.Canvas(packet, pagesize=A4)
+        cv.setStrokeColor(white)
+        cv.setFillColor(white)
+        cv.rect(0, 0, 1000, 1000, stroke=1, fill=1)
 
-    if page > 1:
-        cv.showPage()
+        if page > 1:
+            cv.showPage()
 
-    cv.setStrokeColor(black)
-    cv.setFillColor(black)
-    cv.setFont('Arial', 6)
-    cv.drawString(x, y, 'This is a test string used to detect non white on a page')
+        cv.setStrokeColor(black)
+        cv.setFillColor(black)
+        # This line can’t be used in a test with the @pytest.mark.parametrize decorator
+        cv.setFont('Arial', 6)
+        cv.drawString(x, y, 'This is a test string used to detect non white on a page')
 
-    cv.save()
-    packet.seek(0)
-    assert get_invalid_pages_with_message(packet) == expected_message
+        cv.save()
+        packet.seek(0)
+        assert get_invalid_pages_with_message(packet) == expected_message
 
 
 def test_get_invalid_pages_address_margin(client):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -266,9 +266,9 @@ def test_invalid_filetype_404s(view_letter_template):
     assert resp.status_code == 404
 
 
-@pytest.mark.parametrize('missing_item', {
+@pytest.mark.parametrize('missing_item', (
     'letter_contact_block', 'values', 'template', 'filename'
-})
+))
 def test_missing_field_400s(view_letter_template, preview_post_body, missing_item):
     preview_post_body.pop(missing_item)
 


### PR DESCRIPTION
As we do in other apps<sup>1 2</sup> we can make the tests run faster by executing them across multiple worker processes in parallel.

`-n auto` tells `pytest-xdist` to spawn the same number of worker processes as the machine has CPUs.

***

Before | After
---|---
<img width="270" alt="image" src="https://user-images.githubusercontent.com/355079/168627246-4d67ba00-2ed0-4f6c-9787-967b8a01f651.png"> | <img width="194" alt="image" src="https://user-images.githubusercontent.com/355079/168632890-3fdf2476-5432-4f5d-ac08-33f5c1e9a59b.png">


***

1. https://github.com/alphagov/notifications-admin/blob/e467167c62ac4ba5d599e26570b1e01290f2ca1b/Makefile#L64
2. https://github.com/alphagov/notifications-api/blob/318cc1284aefa6f8e30928c1a0f703d5e5cc3a59/Makefile#L72