### PR TITLE
Upgrade non-PDF-related dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,11 +1,11 @@
 #app requirements
 boto3==1.23.0
 celery[sqs]==5.2.6
-jsonschema==4.4.0
-Flask==2.1.1
+jsonschema==4.5.1
+Flask==2.1.2
 Flask-WeasyPrint==0.6
-Flask-HTTPAuth==4.5.0
-Werkzeug==2.1.1
+Flask-HTTPAuth==4.6.0
+Werkzeug==2.1.2
 
 # pdf libraries
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,14 +72,14 @@ deprecated==1.2.13
     # via redis
 docutils==0.15.2
     # via awscli
-flask==2.1.1
+flask==2.1.2
     # via
     #   -r requirements.in
     #   flask-httpauth
     #   flask-redis
     #   flask-weasyprint
     #   notifications-utils
-flask-httpauth==4.5.0
+flask-httpauth==4.6.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
@@ -111,7 +111,7 @@ jmespath==1.0.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.4.0
+jsonschema==4.5.1
     # via -r requirements.in
 kombu==5.2.4
     # via celery
@@ -224,7 +224,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==2.1.1
+werkzeug==2.1.2
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
These should be fine to upgrade without having to do any manual testing because they are not involved with generating or reading PDF files.