### PR TITLE
Bump utils to version 56.0.0

### DIFF
--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -2,7 +2,7 @@ import subprocess
 from io import BytesIO
 
 from flask import current_app
-from PyPDF2 import PdfFileReader
+from PyPDF2 import PdfReader
 from PyPDF2.generic import IndirectObject
 
 
@@ -46,13 +46,13 @@ def contains_unembedded_fonts(pdf_data, filename=''):  # noqa: C901 (too complex
             for child in obj:
                 walk(child, fnt, emb)
         elif isinstance(obj, IndirectObject):
-            walk(obj.getObject(), fnt, emb)
+            walk(obj.get_object(), fnt, emb)
 
-    pdf = PdfFileReader(pdf_data)
+    pdf = PdfReader(pdf_data)
     fonts = set()
     embedded = set()
     for page in pdf.pages:
-        obj = page.getObject()
+        obj = page.get_object()
         walk(obj['/Resources'], fonts, embedded)
 
     unembedded = fonts - embedded

--- a/requirements.in
+++ b/requirements.in
@@ -10,13 +10,13 @@ Werkzeug==2.1.2
 # pdf libraries
 html5lib==1.1
 wand==0.5.9
-pypdf2==1.27.12
+pypdf2==2.0.0
 reportlab==3.6.3
 pdf2image==1.12.1
 PyMuPDF==1.19.6
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@55.1.4
+git+https://github.com/alphagov/notifications-utils.git@56.0.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ markupsafe==2.1.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@56.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -144,7 +144,7 @@ pymupdf==1.19.6
     # via -r requirements.in
 pyparsing==3.0.9
     # via packaging
-pypdf2==1.27.12
+pypdf2==2.0.0
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -201,6 +201,8 @@ tinycss2==1.1.1
     #   cairosvg
     #   cssselect2
     #   weasyprint
+typing-extensions==4.2.0
+    # via pypdf2
 urllib3==1.26.9
     # via
     #   botocore

--- a/tests/test_embedded_fonts.py
+++ b/tests/test_embedded_fonts.py
@@ -1,7 +1,7 @@
 from io import BytesIO
 
 import pytest
-from PyPDF2 import PdfFileReader
+from PyPDF2 import PdfReader
 from reportlab.lib.units import mm
 
 from app.embedded_fonts import contains_unembedded_fonts, embed_fonts
@@ -37,13 +37,13 @@ def test_embed_fonts():
 def test_embed_fonts_does_not_rotate_pages():
     file_with_rotated_text = BytesIO(portrait_rotated_page)
 
-    new_pdf = PdfFileReader(
+    new_pdf = PdfReader(
         embed_fonts(file_with_rotated_text)
     )
-    page = new_pdf.getPage(0)
+    page = new_pdf.pages[0]
 
-    page_height = float(page.mediaBox.getHeight()) / mm
-    page_width = float(page.mediaBox.getWidth()) / mm
+    page_height = float(page.mediabox.height) / mm
+    page_width = float(page.mediabox.width) / mm
     rotation = page.get('/Rotate')
 
     assert rotation is None

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -7,7 +7,7 @@ import fitz
 import PyPDF2
 import pytest
 from flask import url_for
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 from reportlab.lib.colors import black, grey, white
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
@@ -69,24 +69,24 @@ def test_endpoints_rejects_if_not_authenticated(client, headers, endpoint, kwarg
 
 
 def test_add_notify_tag_to_letter(mocker):
-    pdf_original = PyPDF2.PdfFileReader(BytesIO(multi_page_pdf))
+    pdf_original = PyPDF2.PdfReader(BytesIO(multi_page_pdf))
 
-    assert 'NOTIFY' not in pdf_original.getPage(0).extractText()
+    assert 'NOTIFY' not in pdf_original.pages[0].extract_text()
 
     pdf_page = add_notify_tag_to_letter(BytesIO(multi_page_pdf))
 
-    pdf_new = PyPDF2.PdfFileReader(BytesIO(pdf_page.read()))
+    pdf_new = PyPDF2.PdfReader(BytesIO(pdf_page.read()))
 
-    assert pdf_new.numPages == pdf_original.numPages
-    assert pdf_new.getPage(0).extractText() != pdf_original.getPage(0).extractText()
-    assert 'NOTIFY' in pdf_new.getPage(0).extractText()
-    assert pdf_new.getPage(1).extractText() == pdf_original.getPage(1).extractText()
-    assert pdf_new.getPage(2).extractText() == pdf_original.getPage(2).extractText()
-    assert pdf_new.getPage(3).extractText() == pdf_original.getPage(3).extractText()
+    assert len(pdf_new.pages) == len(pdf_original.pages)
+    assert pdf_new.pages[0].extract_text() != pdf_original.pages[0].extract_text()
+    assert 'NOTIFY' in pdf_new.pages[0].extract_text()
+    assert pdf_new.pages[1].extract_text() == pdf_original.pages[1].extract_text()
+    assert pdf_new.pages[2].extract_text() == pdf_original.pages[2].extract_text()
+    assert pdf_new.pages[3].extract_text() == pdf_original.pages[3].extract_text()
 
 
 def test_add_notify_tag_to_letter_correct_margins(mocker):
-    pdf_original = PyPDF2.PdfFileReader(BytesIO(multi_page_pdf))
+    pdf_original = PyPDF2.PdfReader(BytesIO(multi_page_pdf))
 
     can = NotifyCanvas(white)
     can.drawString = MagicMock(return_value=3)
@@ -105,7 +105,7 @@ def test_add_notify_tag_to_letter_correct_margins(mocker):
 
     x = mm_from_left_of_page * mm
 
-    y = float(pdf_original.getPage(0).mediaBox[3]) - (
+    y = float(pdf_original.pages[0].mediabox[3]) - (
         float(mm_from_top_of_the_page * mm + font_size)
     )
 

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -2,7 +2,7 @@ from io import BytesIO
 
 import fitz
 import pytest
-from PyPDF2 import PdfFileReader
+from PyPDF2 import PdfReader
 from reportlab.lib.units import mm
 from weasyprint import HTML
 
@@ -47,13 +47,13 @@ def test_subprocess_fails(client, mocker):
 def test_convert_pdf_to_cmyk_does_not_rotate_pages():
     file_with_rotated_text = BytesIO(portrait_rotated_page)
 
-    transformed_pdf = PdfFileReader(
+    transformed_pdf = PdfReader(
         convert_pdf_to_cmyk(file_with_rotated_text)
     )
-    page = transformed_pdf.getPage(0)
+    page = transformed_pdf.pages[0]
 
-    page_height = float(page.mediaBox.getHeight()) / mm
-    page_width = float(page.mediaBox.getWidth()) / mm
+    page_height = float(page.mediabox.height) / mm
+    page_width = float(page.mediabox.width) / mm
     rotation = page.get('/Rotate')
 
     assert rotation is None
@@ -95,10 +95,10 @@ def test_convert_pdf_to_cmyk_preserves_black(client):
 # prompt you to go and manually check the output still looks OK.
 def test_convert_pdf_to_cmyk_does_not_strip_images():
     result = convert_pdf_to_cmyk(BytesIO(public_guardian_sample))
-    first_page = PdfFileReader(result).getPage(0)
+    first_page = PdfReader(result).pages[0]
 
     image_refs = first_page['/Resources']['/XObject'].values()
-    images = [image_ref.getObject() for image_ref in image_refs]
+    images = [image_ref.get_object() for image_ref in image_refs]
     assert not any(['/Matte' in image for image in images])
 
 


### PR DESCRIPTION
The only impactful change is the major version itself, where I've
fixed the breaking changes due to the upgrade of PyPDF2 [^1] and
fixed all the deprecation warnings I saw when I ran the tests -
the warnings contain the alternate code to use.

[^1]: https://github.com/alphagov/notifications-utils/pull/973