### PR TITLE
Make the location of the parent image configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ bootstrap:
 
 .PHONY: bootstrap
 bootstrap-with-docker: ## Setup environment to run app commands
-	docker build -f docker/Dockerfile --target test -t notifications-template-preview .
+	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask in Docker container
@@ -74,7 +74,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=parent --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- PAAS COMMANDS ---- #
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-template-preview:base
 FROM python:3.9-slim-bullseye as parent
 
 ENV PYTHONUNBUFFERED=1
@@ -39,7 +40,7 @@ RUN \
 
 ##### Test Image ##############################################################
 
-FROM ghcr.io/alphagov/notify/notifications-template-preview:base as test
+FROM ${BASE_IMAGE} as test
 
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app
@@ -53,7 +54,7 @@ COPY . .
 
 ##### Production Image #######################################################
 
-FROM ghcr.io/alphagov/notify/notifications-template-preview:base as production
+FROM ${BASE_IMAGE} as production
 
 RUN useradd celeryuser
 


### PR DESCRIPTION
This allows people to develop and test locally without having to
overwrite the base image in ghcr in order for the local build to work