### PR TITLE
Upgrade poppler-utils from `20.09.0-3.1` to `20.09.0-3.1+deb11u1`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install base packages" && apt-get update \
         libmagickwand-dev=8:6.9.11.60+dfsg-1.3 \
         imagemagick=8:6.9.11.60+dfsg-1.3 \
         ghostscript=9.53.3~dfsg-7+deb11u2 \
-        poppler-utils=20.09.0-3.1 \
+        poppler-utils=20.09.0-3.1+deb11u1 \
         gsfonts=1:8.11+urwcyr1.0.7~pre44-4.5 \
         fonts-freefont-ttf=20120503-10 \
     && apt-get -y clean \


### PR DESCRIPTION
This upgrades poppler-utils in the Dockerfile to fix two vulnerabilities: https://www.debian.org/security/2022/dsa-5224