### PR TITLE
Add a make command to bump utils, using the tooling from utils version 59.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ freeze-requirements: ## create static requirements.txt
 	pip install --upgrade pip-tools
 	pip-compile requirements.in
 
+.PHONY: bump-utils
+bump-utils:  # Bump notifications-utils package to latest version
+	python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"
+
 .PHONY: generate-version-file
 generate-version-file:
 	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ pdf2image==1.12.1
 PyMuPDF==1.19.6
 WeasyPrint==51
 
-git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -117,7 +117,7 @@ markupsafe==2.1.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@59.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
59.3.0
---
* Add tooling to bump utils version in apps (and use it in the Makefile)

59.2.0
---
* Add support for creating redis cache keys for a specific notification type.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/59.1.1...59.3.0