### PR TITLE
Fix test ordering bug for `setFont` which causes Concourse to fail

### DIFF
--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -229,8 +229,9 @@ def test_get_invalid_pages_second_page(x, y, expected_failed, client):
         assert get_invalid_pages_with_message(packet) == ("", [])
 
 
-def test_get_invalid_pages_black_text(client):
-    for x, y, page, expected_message in [
+@pytest.mark.parametrize(
+    "x, y, page, expected_message",
+    [
         (0, 0, 1, ("content-outside-printable-area", [1])),
         (200, 200, 1, ("", [])),
         (590, 830, 1, ("content-outside-printable-area", [1])),
@@ -257,23 +258,25 @@ def test_get_invalid_pages_black_text(client):
         (200, 0, 2, ("content-outside-printable-area", [2])),
         (590, 0, 2, ("content-outside-printable-area", [2])),
         (590, 200, 2, ("content-outside-printable-area", [2])),
-    ]:
-        packet = io.BytesIO()
-        cv = canvas.Canvas(packet, pagesize=A4)
-        cv.setStrokeColor(white)
-        cv.setFillColor(white)
-        cv.rect(0, 0, 1000, 1000, stroke=1, fill=1)
+    ],
+)
+def test_get_invalid_pages_black_text(client, x, y, page, expected_message):
+    packet = io.BytesIO()
+    cv = canvas.Canvas(packet, pagesize=A4)
+    cv.setStrokeColor(white)
+    cv.setFillColor(white)
+    cv.rect(0, 0, 1000, 1000, stroke=1, fill=1)
 
-        if page > 1:
-            cv.showPage()
+    if page > 1:
+        cv.showPage()
 
-        cv.setStrokeColor(black)
-        cv.setFillColor(black)
-        cv.drawString(x, y, "This is a test string used to detect non white on a page")
+    cv.setStrokeColor(black)
+    cv.setFillColor(black)
+    cv.drawString(x, y, "This is a test string used to detect non white on a page")
 
-        cv.save()
-        packet.seek(0)
-        assert get_invalid_pages_with_message(packet) == expected_message
+    cv.save()
+    packet.seek(0)
+    assert get_invalid_pages_with_message(packet) == expected_message
 
 
 def test_get_invalid_pages_address_margin(client):

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -269,8 +269,6 @@ def test_get_invalid_pages_black_text(client):
 
         cv.setStrokeColor(black)
         cv.setFillColor(black)
-        # This line can’t be used in a test with the @pytest.mark.parametrize decorator
-        cv.setFont("Arial", 6)
         cv.drawString(x, y, "This is a test string used to detect non white on a page")
 
         cv.save()


### PR DESCRIPTION
## The bug
This `test_get_invalid_pages_second_page` test was passing when `make test` was run but would fail if run individually. This is because in `test_get_invalid_pages_second_page` it calls `setFont`, and `setFont` relies on `registerFont` to be called before it, otherwise it can not find the Arial font and will raise an exception.

Tests further up in the file were calling `add_notify_tag_to_letter` which calls `registerFont` with the `Arial` font. As long as one of the tests that called `add_notify_tag_to_letter` was run before this one, this test would pass.

The behaviour appears to have been that `registerFont` persisted the font registration to a single run of pytest. So if you ran `make test` (which would pass and register Arial) then running the single test after would still fail because Arial was no longer registered.

The way we fixed this is by deciding that we do not need to call `setFont` in this test. This test is creating a custom PDF and putting some content in it that will be outside of the allowed precompiled letter standard. It doesn't matter which font is used for the content on the template, in the same way that our users might provide any font, so we can just use the default rather than forcing it to use Arial.

## Why did this cause an issue when it had been passing nicely for so long
Running `make test` on Concourse had been passing for many years with this test ordering bug. Why did it start causing problems last week?

The answer is that we upgraded the Concourse workers from `t3.xlarge` to `t3.2xlarge` instances. `t3.2xlarge` has twice as many CPU cores available. When we run `make test` it actually runs `pytest -n auto` under the hood. 

```
-n numprocesses, --numprocesses=numprocesses
                        Shortcut for '--dist=load --tx=NUM*popen'. With 'auto', attempt to detect physical CPU count. With 'logical', detect logical CPU count. If physical CPU count cannot be found, falls back to logical count. This will
                        be 0 when used with --pdb.
```

We have chosen `auto` for `numprocesses` meaning that it will attempt to detect physical CPU count to determine how many processes to run.

Before our concourse instances were upgraded, this would result in 4 processes to run the tests

<img width="907" alt="image" src="https://user-images.githubusercontent.com/7228605/209329288-6d693295-d0ad-483f-bdab-d916fb001a98.png">

After our concourse instances were upgraded, this would result in 8 processes to run the tests
<img width="925" alt="image" src="https://user-images.githubusercontent.com/7228605/209329435-c070f406-b19f-4d15-9899-fe13f7fe83b8.png">

It appears that by moving from 4 to 8 processes broke the tests. `test_get_invalid_pages_second_page` is about the 9th test in the file. My guess is that using 4 processes, one of the tests that calls `add_notify_tag_to_letter` was successfully running before any of the processes got round to running `test_get_invalid_pages_second_page`. With the change to 8 processes, I reckon that now `test_get_invalid_pages_second_page` was running before there had been a successful call to 
`add_notify_tag_to_letter` and so `test_get_invalid_pages_second_page` would fail.

## How to review
The simplest way to confirm the test no longer relies on context from other tests is to
- pull the latest copy of the main branch and run `pytest -k test_get_invalid_pages_second_page` to confirm you see a test failure
- then pull this branch and run `pytest -k test_get_invalid_pages_second_page` to confirm the test is fixed

You may want to review commit by commit as the first commit fixes the bug, the second commit does a small refactor.
