### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-isort==5.12.0
-flake8==5.0.4
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
+flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
 flake8-print==5.0.0
 freezegun==1.2.2
 jinja2-cli[yaml]==0.8.2
@@ -11,4 +11,4 @@ pytest==7.1.3
 pytest-xdist==2.5.0
 requests-mock==1.10.0
 pdbpp==0.10.3
-black==22.8.0
+black==22.8.0  # Also update `.pre-commit-config.yaml` if this changes

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-isort==5.10.1
+isort==5.12.0
 flake8==5.0.4
 flake8-print==5.0.0
 freezegun==1.2.2


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.