### PR TITLE
Remove libmagickwand-dev package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,6 @@ RUN echo "Install base packages" && apt-get update \
     && echo "Install binary app dependencies" \
     && apt-get install -y --no-install-recommends \
         libpango1.0-dev=1.46.2-3 \
-        libmagickwand-dev=8:6.9.11.60+dfsg-1.3 \
         imagemagick=8:6.9.11.60+dfsg-1.3 \
         ghostscript=9.53.3~dfsg-7+deb11u2 \
         poppler-utils=20.09.0-3.1+deb11u1 \


### PR DESCRIPTION
We started seeing errors when trying to build template preview:

I looked at the package information for libmagickwand-dev at https://packages.debian.org/bullseye/libmagickwand-dev and it states that this package is a dummy package and you can safely remove it.

I could find a bit of information on dummy packages at https://forums.debian.net/viewtopic.php?t=33370
but removing the package allows the image to be built successfully again and the unit tests pass.