### PR TITLE
Error on incomplete content streams

### DIFF
--- a/app/transformation.py
+++ b/app/transformation.py
@@ -61,6 +61,14 @@ def convert_pdf_to_cmyk(input_data):
         stderr=subprocess.PIPE,
     )
     stdout, stderr = gs_process.communicate(input=input_data.read())
+
+    # See: https://github.com/alphagov/notifications-template-preview/pull/713
+    error_in_stream = b"**** Error" in stdout and b"Output may be incorrect." in stdout
+    if error_in_stream:
+        raise Exception(
+            "ghostscript cmyk transformation failed to read all content streams"
+        )
+
     if gs_process.returncode != 0:
         raise Exception(
             "ghostscript cmyk transformation failed with return code: {}\nstdout: {}\nstderr:{}".format(


### PR DESCRIPTION
We had reports from our print provider of a precompiled PDF causing print issues and needing manual intervention. On manual inspection of the PDF we sent compared to the original PDF uploaded by the service, we can see that page (notification 2451bf05-a7ad-4457-86f4-472370cbaa3f, see also original precompiled upload in S3) 2 has been blanked out by template-preview sanitising.

When going through CMYK processing in GhostScript, we see part-way through the PDF an inline error about failing to read the full content stream and the output potentially being incorrect. This is actually written into the PDF rather than being emitted on stderr, so the PDF itself contains the error marker and suspect this is what caused the print issue at DVLA.

Let's scan the PDF for this error marker and, if present, throw a proper exception. This will filter back to the admin frontend and prevent the user proceeding with the upload and require them to reformat/save it their end.

----

We have a PDF that can be used to reproduce the error, let me know if you need it.

Although we only noticed/were told about this problem because of the error "Error reading a content stream. The page may be incomplete. Output may be incorrect." we can also see in Kibana an error for "**** Error: Some elements of Mask array are out of range. Output may be incorrect." so I think we should catch all "Errors" followed by "Output may be incorrect"