### PR TITLE
Validate and sanitise letter attachment

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -57,7 +57,6 @@ auth = HTTPTokenAuth(scheme="Token")
 
 def init_cache(application):
     def cache(*args, folder=None, extension="file"):
-
         cache_key = "{}/{}.{}".format(
             folder,
             sha1("".join(str(arg) for arg in args).encode("utf-8")).hexdigest(),
@@ -66,7 +65,6 @@ def init_cache(application):
 
         def wrapper(original_function):
             def new_function():
-
                 with suppress(S3ObjectNotFound):
                     return s3download(
                         application.config["LETTER_CACHE_BUCKET_NAME"],

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -168,11 +168,13 @@ def sanitise_precompiled_letter():
     if not encoded_string:
         raise InvalidRequest("no-encoded-string")
 
+    is_an_attachment = request.args.get("is_an_attachment") == "true"
+
     sanitise_json = sanitise_file_contents(
         encoded_string,
         allow_international_letters=allow_international_letters,
         filename=request.args.get("upload_id"),
-        is_an_attachment=request.args.get("is_an_attachment"),
+        is_an_attachment=is_an_attachment,
     )
     status_code = 400 if sanitise_json.get("message") else 200
 
@@ -486,7 +488,7 @@ def _overlay_printable_areas_with_white(src_pdf, is_an_attachment=False):
     of a full letter.
 
     :param BytesIO src_pdf: A file-like
-    :param is_an_attachment: a parameter that informs if the file-like is a full letter or a letter attachment
+    :param Boolean is_an_attachment: a parameter that informs if the file-like is a full letter or a letter attachment
     :return BytesIO: New file like containing the overlaid pdf
     """
 

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -486,6 +486,7 @@ def _overlay_printable_areas_with_white(src_pdf, is_an_attachment=False):
     of a full letter.
 
     :param BytesIO src_pdf: A file-like
+    :param is_an_attachment: a parameter that informs if the file-like is a full letter or a letter attachment
     :return BytesIO: New file like containing the overlaid pdf
     """
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -44,7 +44,6 @@ def _generate_png_page(
 ):
     output = BytesIO()
     with Image(width=pdf_width, height=pdf_height) as image:
-
         if pdf_colorspace == "cmyk":
             image.transform_colorspace("cmyk")
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -507,17 +507,17 @@ def test_precompiled_sanitise_pdf_with_notify_tag(client, auth_header):
 
 
 @pytest.mark.parametrize(
-    "is_an_attachment",
+    "query_string",
     (
         "",
         "?is_an_attachment=true",
     ),
 )
 def test_precompiled_sanitise_pdf_with_colour_outside_boundaries_returns_400(
-    client, auth_header, is_an_attachment
+    client, auth_header, query_string
 ):
     response = client.post(
-        url_for("precompiled_blueprint.sanitise_precompiled_letter") + is_an_attachment,
+        url_for("precompiled_blueprint.sanitise_precompiled_letter") + query_string,
         data=no_colour,
         headers={"Content-type": "application/json", **auth_header},
     )

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -190,7 +190,6 @@ def test_get_png_hits_cache_correct_number_of_times(
     number_of_cache_get_calls,
     number_of_cache_set_calls,
 ):
-
     mocked_cache_get.side_effect = side_effects
 
     resp = view_letter_template(filetype="png")
@@ -296,7 +295,6 @@ def test_blank_fields_okay(view_letter_template, preview_post_body, blank_item):
 
 
 def test_date_can_be_passed(view_letter_template, preview_post_body):
-
     preview_post_body["date"] = "2012-12-12T00:00:00"
 
     with patch("app.preview.HTML", wraps=HTML) as mock_html:


### PR DESCRIPTION
When we validate and sanitise an attachment, we don't have to do certain things:
- we don't have a first page with different boundaries, so all pages have same boundary validation
- we don't have an address block to rewrite
- we don't add any tags

Story ticket: https://trello.com/c/qJ82a3L9/292-validate-and-sanitise-letter-attachment-uploaded-by-user
Admin PR: https://github.com/alphagov/notifications-admin/pull/4664