### PR TITLE
Bump Flask to 2.3.2 to fix security vulnerability

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,10 +2,10 @@
 boto3==1.23.0
 celery[sqs]==5.2.7
 jsonschema==4.15.0
-Flask==2.1.2
+Flask==2.3.2
 Flask-WeasyPrint==1.0.0
-Flask-HTTPAuth==4.7.0
-Werkzeug==2.2.3
+Flask-HTTPAuth==4.8.0
+Werkzeug==2.3.3
 
 # pdf libraries
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ awscli-cwlogs==1.4.6
     # via -r requirements.in
 billiard==3.6.4.0
     # via celery
+blinker==1.6.2
+    # via flask
 boto3==1.23.0
     # via
     #   -r requirements.in
@@ -68,14 +70,14 @@ defusedxml==0.7.1
     # via cairosvg
 docutils==0.15.2
     # via awscli
-flask==2.1.2
+flask==2.3.2
     # via
     #   -r requirements.in
     #   flask-httpauth
     #   flask-redis
     #   flask-weasyprint
     #   notifications-utils
-flask-httpauth==4.7.0
+flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
@@ -93,6 +95,8 @@ html5lib==1.1
     #   weasyprint
 idna==3.3
     # via requests
+importlib-metadata==6.6.0
+    # via flask
 itsdangerous==2.1.2
     # via
     #   flask
@@ -192,6 +196,8 @@ tinycss2==1.1.1
     #   cairosvg
     #   cssselect2
     #   weasyprint
+typing-extensions==4.5.0
+    # via pypdf2
 urllib3==1.26.9
     # via
     #   botocore
@@ -214,10 +220,12 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==2.2.3
+werkzeug==2.3.3
     # via
     #   -r requirements.in
     #   flask
+zipp==3.15.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
This bumps Flask to version 2.3.2 to fix a security vulnerability (https://github.com/alphagov/notifications-template-preview/security/dependabot/37).

This change also requires Werkzeug and and Flask-HTTPAuth to be bumped to the lastest version.