### PR TITLE
Use stable secure version of imagemagick

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "Install base packages" && apt-get update \
     && echo "Install binary app dependencies" \
     && apt-get install -y --no-install-recommends \
         libpango1.0-dev=1.46.2-3 \
-        imagemagick=8:6.9.11.60+dfsg-1.3 \
+        imagemagick=8:6.9.11.60+dfsg-1.3+deb11u1 \
         ghostscript=9.53.3~dfsg-7+deb11u4 \
         poppler-utils=20.09.0-3.1+deb11u1 \
         gsfonts=1:8.11+urwcyr1.0.7~pre44-4.5 \


### PR DESCRIPTION
When building the Docker image we were getting errors that `Version '8:6.9.11.60+dfsg-1.3' for 'imagemagick' was not found`. Version `8:6.9.11.60+dfsg-1.3+deb11u1` has been created to fix a security vulnerabiltiy, so this changes the version in the Dockerfile.