### PR TITLE
Start tracking versions in Sentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,14 @@ generate-version-file:
 	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
-bootstrap:
+bootstrap: generate-version-file
 	mkdir -p log # manually create directory to avoid permission issues
 	pip install -r requirements_for_test.txt
 
 # ---- DOCKER COMMANDS ---- #
 
 .PHONY: bootstrap
-bootstrap-with-docker: ## Setup environment to run app commands
+bootstrap-with-docker: generate-version-file ## Setup environment to run app commands
 	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bump-utils:  # Bump notifications-utils package to latest version
 
 .PHONY: generate-version-file
 generate-version-file:
-	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
+	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
 bootstrap:

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,1 @@
+version.py

--- a/app/performance.py
+++ b/app/performance.py
@@ -27,9 +27,9 @@ def init_performance_monitoring():
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
         try:
-            from app.version import __commit__
+            from app.version import __git_commit__
 
-            release = __commit__
+            release = __git_commit__
         except ImportError:
             release = None
 

--- a/app/performance.py
+++ b/app/performance.py
@@ -26,6 +26,13 @@ def init_performance_monitoring():
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
+        try:
+            from app.version import __commit__
+
+            release = __commit__
+        except ImportError:
+            release = None
+
         sentry_sdk.init(
             dsn=sentry_dsn,
             environment=environment,
@@ -33,4 +40,5 @@ def init_performance_monitoring():
             send_default_pii=send_pii,
             request_bodies=send_request_bodies,
             traces_sampler=traces_sampler,
+            release=release,
         )

--- a/app/status.py
+++ b/app/status.py
@@ -15,7 +15,7 @@ def _status():
     return (
         jsonify(
             status="ok",
-            commit=version.__commit__,
+            commit=version.__git_commit__,
             build_time=version.__time__,
             ghostscript_version=get_ghostscript_version(),
             imagemagick_version=get_imagemagick_version(),

--- a/app/version.py
+++ b/app/version.py
@@ -1,2 +1,0 @@
-__commit__ = "fake-local-dev-sha"
-__time__ = "2022-03-10T13:49:50"

--- a/app/version.py.dist
+++ b/app/version.py.dist
@@ -1,2 +1,2 @@
-__commit__ = ""
+__git_commit__ = ""
 __time__ = ""


### PR DESCRIPTION
Send the current git commit as a release version to sentry when initialised, which will let us track when errors are introduced and mark errors resolved as of a specific commit/release.

Renames the variable from __commit__ to __git_commit__ to match the other apps.