### PR TITLE
Create/preview templated letter pdfs with attachment

### DIFF
--- a/app/letter_attachments.py
+++ b/app/letter_attachments.py
@@ -19,6 +19,9 @@ def add_attachment_to_letter(service_id, templated_letter_pdf: StreamingBody, at
 
     # templated letters are cached in s3, where a StreamingBody is returned which does not have a seek function,
     # so we need to read the `bytes` and then wrap that in a `BytesIO` as a buffer
-    stitched_pdf = stitch_pdfs(first_pdf=BytesIO(templated_letter_pdf.read()), second_pdf=BytesIO(attachment_pdf))
+    stitched_pdf = stitch_pdfs(
+        first_pdf=BytesIO(templated_letter_pdf.read()),
+        second_pdf=BytesIO(attachment_pdf),
+    )
 
     return stitched_pdf

--- a/app/letter_attachments.py
+++ b/app/letter_attachments.py
@@ -1,0 +1,24 @@
+from io import BytesIO
+
+from botocore.response import StreamingBody
+from flask import current_app
+from notifications_utils.s3 import s3download
+
+
+def get_attachment_pdf(service_id, attachment_id) -> bytes:
+    return s3download(
+        current_app.config["LETTER_ATTACHMENT_BUCKET_NAME"],
+        f"service-{service_id}/{attachment_id}.pdf",
+    ).read()
+
+
+def add_attachment_to_letter(service_id, templated_letter_pdf: StreamingBody, attachment_object: dict) -> BytesIO:
+    from app.precompiled import stitch_pdfs
+
+    attachment_pdf = get_attachment_pdf(service_id, attachment_object["id"])
+
+    # templated letters are cached in s3, where a StreamingBody is returned which does not have a seek function,
+    # so we need to read the `bytes` and then wrap that in a `BytesIO` as a buffer
+    stitched_pdf = stitch_pdfs(first_pdf=BytesIO(templated_letter_pdf.read()), second_pdf=BytesIO(attachment_pdf))
+
+    return stitched_pdf

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -830,3 +830,14 @@ def bytesio_from_pdf(pdf):
     output.write(pdf_bytes)
     pdf_bytes.seek(0)
     return pdf_bytes
+
+
+def stitch_pdfs(first_pdf: BytesIO, second_pdf: BytesIO) -> BytesIO:
+    output = PdfWriter()
+    output.append_pages_from_reader(PdfReader(first_pdf))
+    output.append_pages_from_reader(PdfReader(second_pdf))
+
+    pdf_bytes = BytesIO()
+    output.write(pdf_bytes)
+    pdf_bytes.seek(0)
+    return pdf_bytes

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -21,6 +21,7 @@ preview_schema = {
         "template": {
             "type": "object",
             "properties": {
+                "service": {"type": "string"},
                 "subject": {"type": "string"},
                 "content": {"type": "string"},
                 "letter_attachment": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
+from io import BytesIO
 
 import pytest
+from botocore.response import StreamingBody
 from notifications_utils.s3 import S3ObjectNotFound
 
 from app import create_app
@@ -31,6 +33,7 @@ def preview_post_body():
             "content": "letter content with ((placeholder))",
             "updated_at": "2017-08-01",
             "version": 1,
+            "service": "1234",
         },
         "values": {"placeholder": "abc"},
         "filename": "hm-government",
@@ -48,6 +51,7 @@ def data_for_create_pdf_for_templated_letter_task():
             "content": "letter content with ((placeholder))",
             "updated_at": "2017-08-01",
             "version": 1,
+            "service": "1234",
         },
         "values": {"placeholder": "abc"},
         "logo_filename": None,
@@ -78,3 +82,7 @@ def set_config(app, name, value):
     app.config[name] = value
     yield
     app.config[name] = old_val
+
+
+def s3_response_body(data: bytes = b"\x00"):
+    return StreamingBody(BytesIO(data), len(data))

--- a/tests/pdf_consts.py
+++ b/tests/pdf_consts.py
@@ -38,7 +38,7 @@ notify_tag_on_first_page = file("tests/test_pdfs/notify_tag_on_first_page.pdf")
 notify_tags_on_page_2_and_4 = file("tests/test_pdfs/notify_tags_on_page_2_and_4.pdf")
 
 # address-is-empty
-multi_page_pdf = file("tests/test_pdfs/multi_page_pdf.pdf")
+multi_page_pdf = file("tests/test_pdfs/multi_page_pdf.pdf")  # (10 pages long)
 blank_page = file("tests/test_pdfs/blank_page.pdf")
 # bad postcode
 bad_postcode = file("tests/test_pdfs/bad_postcode.pdf")

--- a/tests/test_letter_attachments.py
+++ b/tests/test_letter_attachments.py
@@ -1,0 +1,13 @@
+from app.letter_attachments import add_attachment_to_letter
+from app.preview import get_page_count
+from tests.conftest import s3_response_body
+from tests.pdf_consts import blank_page, valid_letter
+
+
+def test_add_attachment_to_letter(mocker):
+    mock_get_attachment = mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=blank_page)
+    response = add_attachment_to_letter("1234", (s3_response_body(valid_letter)), {"page_count": 1, "id": "5678"})
+
+    assert mock_get_attachment.called_once_with("1234", {"page_count": 1, "id": "5678"})
+
+    assert get_page_count(response) == 2


### PR DESCRIPTION
If a letter attachment json blob is passed through when either previewing via `POST /preview.pdf` or creating via the `create_pdf_for_templated_letter` task, append that PDF to the generated letter PDF. Note that the two generated letter PDFs are different when previewing and creating (since the preview has fake QR codes and the print version has the white NOTIFY text).

This code needs the API to send over the new fields before we can merge it.

- [x] https://github.com/alphagov/notifications-api/pull/3818

Once we've merged this PR, we then need to update admin/api when they call `/preview.pdf` to pass through the `letter_attachment` json blob. We already pass it through when you download a pdf from the check page before sending[^1], but not when you download a pdf of a created notification[^2]

[^1]: https://github.com/alphagov/notifications-admin/blob/main/app/main/views/send.py#L740
[^2]: https://github.com/alphagov/notifications-admin/blob/main/app/main/views/notifications.py#L215