### PR TITLE
Set SERVER_NAME for local dev

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -105,6 +105,7 @@ class Preview(Config):
 
 
 class Development(Config):
+    SERVER_NAME = os.getenv("SERVER_NAME")
     NOTIFY_ENVIRONMENT = "development"
 
     STATSD_ENABLED = False


### PR DESCRIPTION
Adding this to all of our apps (for local/dev configuration) so that we can get URLs built on a .localhost domain when running via docker-compose.