### PR TITLE
Bump PyMuPDF version and replace deprecated pageCount property

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -729,7 +729,7 @@ def _get_pages_with_notify_tag(src_pdf_bytes, is_an_attachment=False):
     starting_page_index = 1
     if is_an_attachment:
         starting_page_index = 0
-    if doc.pageCount == starting_page_index:
+    if doc.page_count == starting_page_index:
         # if no extra pages we dont need to do anything
         src_pdf_bytes.seek(0)
         return []

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ wand==0.5.9
 pypdf2==2.10.9
 reportlab==3.6.3
 pdf2image==1.12.1
-PyMuPDF==1.19.6
+PyMuPDF==1.22.5
 WeasyPrint==51
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@62.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -101,6 +101,8 @@ html5lib==1.1
     #   weasyprint
 idna==3.3
     # via requests
+importlib-metadata==6.7.0
+    # via flask
 itsdangerous==2.1.2
     # via
     #   flask
@@ -142,7 +144,7 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
-pymupdf==1.19.6
+pymupdf==1.22.5
     # via -r requirements.in
 pypdf2==2.10.9
     # via
@@ -202,6 +204,8 @@ tinycss2==1.1.1
     #   cairosvg
     #   cssselect2
     #   weasyprint
+typing-extensions==4.7.0
+    # via pypdf2
 urllib3==1.26.15
     # via
     #   botocore
@@ -229,6 +233,8 @@ werkzeug==2.3.3
     # via
     #   -r requirements.in
     #   flask
+zipp==3.15.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
PyMuPDF now makes wheels for MacOS available on pypi.org and automatically
 downloads the required MuPDF source and builds it into PyMuPDF.
This solves previous installation problems where the `setup.py` file could not find specific terms (`build,bdist`, `bdist`_`wheel`) in `sys.argv` to initiate
 downloading and building MuPDF locally.
 The `pageCount` property name is now deprecated and the new version is `page_count`.