### PR TITLE
Fix requirements (unable to freeze)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 #app requirements
-boto3==1.23.0
+boto3==1.28.5
 celery[sqs]==5.2.7
 jsonschema==4.15.0
 Flask==2.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ async-timeout==4.0.2
     # via redis
 attrs==21.4.0
     # via jsonschema
-awscli==1.24.3
+awscli==1.29.5
     # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
@@ -20,11 +20,12 @@ blinker==1.6.2
     # via
     #   flask
     #   sentry-sdk
-boto3==1.23.0
+boto3==1.28.5
     # via
     #   -r requirements.in
+    #   kombu
     #   notifications-utils
-botocore==1.26.3
+botocore==1.31.5
     # via
     #   awscli
     #   boto3
@@ -117,7 +118,7 @@ jmespath==1.0.0
     #   botocore
 jsonschema==4.15.0
     # via -r requirements.in
-kombu==5.2.4
+kombu[sqs]==5.2.4
     # via celery
 markupsafe==2.1.1
     # via
@@ -144,6 +145,8 @@ pyasn1==0.4.8
     # via rsa
 pycparser==2.21
     # via cffi
+pycurl==7.44.1
+    # via kombu
 pymupdf==1.22.5
     # via -r requirements.in
 pypdf2==2.10.9
@@ -166,7 +169,7 @@ pytz==2022.1
     # via
     #   celery
     #   notifications-utils
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   awscli
     #   notifications-utils
@@ -181,7 +184,7 @@ requests==2.31.0
     #   notifications-utils
 rsa==4.7.2
     # via awscli
-s3transfer==0.5.2
+s3transfer==0.6.1
     # via
     #   awscli
     #   boto3
@@ -209,6 +212,7 @@ typing-extensions==4.7.0
 urllib3==1.26.15
     # via
     #   botocore
+    #   kombu
     #   requests
     #   sentry-sdk
 vine==5.0.0


### PR DESCRIPTION
For the last few days we've been unable to run `make freeze-requirements`, getting errors like this:

```
...
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
...
pip._internal.exceptions.InstallationSubprocessError: Getting requirements to build wheel exited with 1

make: *** [freeze-requirements] Error 1
```

From some searches online this seems related to a release of cython3 that just came out, which PyYAML uses.

yaml/pyyaml#724

There is now a new release of PyYAML (6.0.1) that fixes the issue, so let's bump to that. In order to bump to that, we need to bump boto3, botocore and s3transfer as well.