### PR TITLE
Update weasyprint to render QR codes in letter

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ pypdf2==2.10.9
 reportlab==3.6.3
 pdf2image==1.12.1
 PyMuPDF==1.22.5
-WeasyPrint==51
+WeasyPrint==59
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
 

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.3.0
 
 # PaaS requirements
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,14 +30,10 @@ botocore==1.31.5
     #   awscli
     #   boto3
     #   s3transfer
+brotli==1.0.9
+    # via fonttools
 cachetools==5.2.0
     # via notifications-utils
-cairocffi==1.3.0
-    # via
-    #   cairosvg
-    #   weasyprint
-cairosvg==2.7.0
-    # via weasyprint
 celery[sqs]==5.2.7
     # via
     #   -r requirements.in
@@ -48,9 +44,7 @@ certifi==2022.12.7
     #   requests
     #   sentry-sdk
 cffi==1.15.0
-    # via
-    #   cairocffi
-    #   weasyprint
+    # via weasyprint
 charset-normalizer==2.0.12
     # via requests
 click==8.1.3
@@ -69,11 +63,7 @@ click-repl==0.2.0
 colorama==0.4.4
     # via awscli
 cssselect2==0.6.0
-    # via
-    #   cairosvg
-    #   weasyprint
-defusedxml==0.7.1
-    # via cairosvg
+    # via weasyprint
 docutils==0.15.2
     # via awscli
 flask==2.3.2
@@ -90,6 +80,8 @@ flask-redis==0.4.0
     # via notifications-utils
 flask-weasyprint==1.0.0
     # via -r requirements.in
+fonttools[woff]==4.41.0
+    # via weasyprint
 geojson==2.5.0
     # via notifications-utils
 govuk-bank-holidays==0.11
@@ -126,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@65.3.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -136,9 +128,9 @@ phonenumbers==8.12.49
     # via notifications-utils
 pillow==9.3.0
     # via
-    #   cairosvg
     #   pdf2image
     #   reportlab
+    #   weasyprint
 prompt-toolkit==3.0.29
     # via click-repl
 pyasn1==0.4.8
@@ -147,6 +139,8 @@ pycparser==2.21
     # via cffi
 pycurl==7.44.1
     # via kombu
+pydyf==0.7.0
+    # via weasyprint
 pymupdf==1.22.5
     # via -r requirements.in
 pypdf2==2.10.9
@@ -188,6 +182,8 @@ s3transfer==0.6.1
     # via
     #   awscli
     #   boto3
+segno==1.5.2
+    # via notifications-utils
 sentry-sdk[celery,flask]==1.21.1
     # via -r requirements.in
 shapely==1.8.2
@@ -204,7 +200,6 @@ statsd==3.3.0
     # via notifications-utils
 tinycss2==1.1.1
     # via
-    #   cairosvg
     #   cssselect2
     #   weasyprint
 typing-extensions==4.7.0
@@ -224,7 +219,7 @@ wand==0.5.9
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit
-weasyprint==59
+weasyprint==59.0
     # via
     #   -r requirements.in
     #   flask-weasyprint
@@ -239,6 +234,8 @@ werkzeug==2.3.3
     #   flask
 zipp==3.15.0
     # via importlib-metadata
+zopfli==0.2.2
+    # via fonttools
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -224,7 +224,7 @@ wand==0.5.9
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit
-weasyprint==51
+weasyprint==59
     # via
     #   -r requirements.in
     #   flask-weasyprint

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -96,12 +96,12 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/e3db50ff186b2d0fc0112075986e51499ccf2e22.pdf"
+    expected_cache_key = "templated/7d14402ff8ea09a258158be3814834b1a744cc93.pdf"
     resp = view_letter_template(filetype="pdf")
 
     assert resp.status_code == 200
     assert resp.headers["Content-Type"] == "application/pdf"
-    assert resp.get_data().startswith(b"%PDF-1.5")
+    assert resp.get_data().startswith(b"%PDF-1.7")
     mocked_cache_get.assert_called_once_with("test-template-preview-cache", expected_cache_key)
     assert mocked_cache_set.call_count == 1
     mocked_cache_set.call_args[0][0].seek(0)
@@ -119,7 +119,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/e3db50ff186b2d0fc0112075986e51499ccf2e22.page01.png"
+    expected_cache_key = "templated/7d14402ff8ea09a258158be3814834b1a744cc93.page01.png"
     resp = view_letter_template(filetype="png")
 
     assert resp.status_code == 200
@@ -561,7 +561,7 @@ def test_page_count_from_cache(client, auth_header, mocker, mocked_cache_get):
         headers={"Content-type": "application/json", **auth_header},
     )
     assert mocked_cache_get.call_args[0][0] == "test-template-preview-cache"
-    assert mocked_cache_get.call_args[0][1] == "templated/90216d9477b54c42f2b123c9ef0035742cc0d57d.pdf"
+    assert mocked_cache_get.call_args[0][1] == "templated/15688a062cf73a562f82bd5d5ca3d4458bac5c89.pdf"
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {"count": 10, "attachment_page_count": 0}
 


### PR DESCRIPTION
Weasyprint only started SVGs since version 53, and at first it was a bit buggy, so I updated to the latest version.

See this issue: https://github.com/Kozea/WeasyPrint/issues/75