### PR TITLE
Double template preview disk space as we are currently at 100%

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -2,7 +2,7 @@
 applications:
 - name: notify-template-preview
 
-  disk_quota: 2G
+  disk_quota: 4G
 
   services:
     - logit-ssl-syslog-drain


### PR DESCRIPTION
Haven't given too much thought to what is causing this or how to reduce the amount of disk space needed. This can be a quick fix at least.

Note, the template preview celery worker appears happier at around 50% disk space in production so no equivalent change made.