### PR TITLE
When previewing attachment with overlay, don't apply address page overlay

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -302,11 +302,13 @@ def overlay_template_png_for_page():
 
     file_data = BytesIO(encoded_string)
 
-    if "is_first_page" in request.args:
+    is_an_attachment = request.args.get("is_an_attachment", "").lower() == "true"
+
+    if "is_first_page" in request.args and not is_an_attachment:
         is_first_page = request.args.get("is_first_page", "").lower() == "true"
     elif "page_number" in request.args:
         page = int(request.args.get("page_number"))
-        is_first_page = page == 1  # page_number arg is one-indexed
+        is_first_page = page == 1 and not is_an_attachment  # page_number arg is one-indexed
     else:
         raise InvalidRequest(f"page_number or is_first_page must be specified in request params {request.args}")
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -346,10 +346,8 @@ def test_overlay_template_png_for_page_not_encoded(client, auth_header):
         ({"is_first_page": "true"}, True),
         ({"is_first_page": "anything_else"}, False),
         ({"is_first_page": ""}, False),
-        (
-            {"page_number": 1, "is_first_page": "true"},
-            True,
-        ),  # is_first_page takes priority
+        ({"page_number": 1, "is_first_page": "true"}, True),  # is_first_page takes priority
+        ({"page_number": "1", "is_an_attachment": True}, False),  # attachment doesn't mandate address block
     ],
 )
 def test_overlay_template_png_for_page_checks_if_first_page(client, auth_header, mocker, params, expected_first_page):


### PR DESCRIPTION
Because letter attachments do not mandate address block.

PR that needs this: https://github.com/alphagov/notifications-admin/pull/4780/files