### PR TITLE
Refactor the docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ bootstrap: generate-version-file
 
 .PHONY: bootstrap
 bootstrap-with-docker: generate-version-file ## Setup environment to run app commands
-	docker build --build-arg BASE_IMAGE=app_base -f docker/Dockerfile --target test -t notifications-template-preview .
+	docker build --build-arg BASE_IMAGE=base -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask in Docker container
@@ -75,7 +75,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=app_base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- PAAS COMMANDS ---- #
 

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} --target=production .
 
 # ---- PAAS COMMANDS ---- #
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ bootstrap: generate-version-file
 
 .PHONY: bootstrap
 bootstrap-with-docker: generate-version-file ## Setup environment to run app commands
-	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-template-preview .
+	docker build --build-arg BASE_IMAGE=app_base -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask in Docker container
@@ -75,7 +75,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=parent --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=app_base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- PAAS COMMANDS ---- #
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,15 +49,18 @@ USER notify
 
 RUN mkdir /home/vcap/logs
 
-COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
+COPY --from=python_build --chown=root:root /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY --chown=notify:notify entrypoint.sh .
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################
-
 FROM ${BASE_IMAGE} as test
+
+USER root
+RUN chown -R notify:notify /opt/venv
+USER notify
 
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-template-preview:base
-FROM python:3.9-slim-bullseye as parent
+FROM python:3.9-slim-bullseye as base
 
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
@@ -26,21 +26,31 @@ RUN echo "Install base packages" && apt-get update \
 
 COPY docker/Arial.ttf /usr/share/fonts/truetype/msttcorefonts/
 
-WORKDIR /home/vcap/app
-
-COPY policy.xml entrypoint.sh ./
+COPY policy.xml .
 
 # Overwrite the default ImageMagick policy which doesn't allow reading or writing PDFs
 RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/policy.xml
+WORKDIR /home/vcap/app
+
+# Build/Install python dependencies
+FROM base AS python_build
 
 COPY requirements.txt .
 
-RUN \
-	echo "Installing python dependencies" \
-	&& pip install -r requirements.txt
+RUN echo "Installing python dependencies" && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install -r requirements.txt
 
-RUN useradd celeryuser
+#### Shared App Base Image ####################################################
+FROM base AS app_base
 
+RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap/app && useradd celeryuser
+USER notify
+
+COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+
+COPY --chown=notify:notify entrypoint.sh .
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################
@@ -50,22 +60,22 @@ FROM ${BASE_IMAGE} as test
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app
 
-COPY Makefile requirements.txt requirements_for_test.txt ./
+COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./
 RUN make bootstrap
 
 # Copy from the real world, one dir up (project root) into the environment's current working directory
 # Docker will rebuild from here down every time.
-COPY . .
+COPY --chown=notify:notify . .
 
 ##### Production Image #######################################################
 
 FROM ${BASE_IMAGE} as production
 
-COPY app app
-COPY wsgi.py gunicorn_config.py Makefile run_celery.py ./
-COPY scripts/run_app_paas.sh scripts/
+COPY --chown=notify:notify app app
+COPY --chown=notify:notify wsgi.py gunicorn_config.py Makefile run_celery.py ./
+COPY --chown=notify:notify scripts/run_app_paas.sh scripts/
 
 # .git folder used only for make generate-version-file but we don't wish to include it in our final production build
-COPY .git .git
+COPY --chown=notify:notify .git .git
 RUN make generate-version-file
 RUN rm -rf .git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,8 +44,10 @@ RUN echo "Installing python dependencies" && \
 #### Shared App Base Image ####################################################
 FROM base AS app_base
 
-RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap/app && useradd celeryuser
+RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap && useradd celeryuser
 USER notify
+
+RUN mkdir /home/vcap/logs
 
 COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,10 +27,8 @@ COPY policy.xml .
 RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/policy.xml
 WORKDIR /home/vcap/app
 
-# Build/Install python dependencies
+##### Python Build Image #####################################################
 FROM ${BASE_IMAGE} AS python_build
-
-COPY requirements.txt .
 
 RUN echo "Install OS dependencies for python app requirements" && apt-get update && \
     apt-get upgrade -y && \
@@ -39,15 +37,18 @@ RUN echo "Install OS dependencies for python app requirements" && apt-get update
         git \
         libcurl4-openssl-dev \
         curl \
-        libssl-dev && \
-    echo "Installing python requirements" && \
-    python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install -r requirements.txt \
+        libssl-dev \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
-#### Shared App Base Image ####################################################
-FROM ${BASE_IMAGE} AS app_base
+COPY requirements.txt .
+
+RUN echo "Installing python requirements" && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install -r requirements.txt
+
+##### Production Image #######################################################
+FROM ${BASE_IMAGE} as production
 
 RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap
 USER notify
@@ -57,35 +58,38 @@ RUN mkdir /home/vcap/logs
 COPY --from=python_build --chown=root:root /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
-COPY --chown=notify:notify entrypoint.sh .
-ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
-
-##### Test Image ##############################################################
-FROM app_base as test
-
-USER root
-RUN chown -R notify:notify /opt/venv
-USER notify
-
-# Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
-RUN mkdir -p app
-
-COPY --chown=notify:notify Makefile requirements.txt requirements_for_test.txt ./
-RUN make bootstrap
-
-# Copy from the real world, one dir up (project root) into the environment's current working directory
-# Docker will rebuild from here down every time.
-COPY --chown=notify:notify . .
-
-##### Production Image #######################################################
-
-FROM app_base as production
-
 COPY --chown=notify:notify app app
-COPY --chown=notify:notify wsgi.py gunicorn_config.py Makefile run_celery.py ./
 COPY --chown=notify:notify scripts/run_app_paas.sh scripts/
+COPY --chown=notify:notify entrypoint.sh wsgi.py gunicorn_config.py Makefile run_celery.py ./
 
 # .git folder used only for make generate-version-file but we don't wish to include it in our final production build
 COPY --chown=notify:notify .git .git
 RUN make generate-version-file
 RUN rm -rf .git
+
+ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
+
+##### Test Image ##############################################################
+FROM production as test
+
+USER root
+RUN chown -R notify:notify /opt/venv
+RUN echo "Install OS dependencies for test build" && apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+			curl \
+			git \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+USER notify
+
+# Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
+RUN mkdir -p app
+
+# Install dev/test requirements
+COPY --chown=notify:notify requirements.txt requirements_for_test.txt ./
+RUN make bootstrap
+
+# Copy from the real world, one dir up (project root) into the environment's current working directory
+# Docker will rebuild from here down every time.
+COPY --chown=notify:notify . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "Installing python dependencies" && \
 #### Shared App Base Image ####################################################
 FROM ${BASE_IMAGE} AS app_base
 
-RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap && useradd celeryuser
+RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap && (useradd celeryuser || true)
 USER notify
 
 RUN mkdir /home/vcap/logs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/polic
 WORKDIR /home/vcap/app
 
 # Build/Install python dependencies
-FROM base AS python_build
+FROM ${BASE_IMAGE} AS python_build
 
 COPY requirements.txt .
 
@@ -42,7 +42,7 @@ RUN echo "Installing python dependencies" && \
     /opt/venv/bin/pip install -r requirements.txt
 
 #### Shared App Base Image ####################################################
-FROM base AS app_base
+FROM ${BASE_IMAGE} AS app_base
 
 RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap && useradd celeryuser
 USER notify
@@ -56,7 +56,7 @@ COPY --chown=notify:notify entrypoint.sh .
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################
-FROM ${BASE_IMAGE} as test
+FROM app_base as test
 
 USER root
 RUN chown -R notify:notify /opt/venv
@@ -74,7 +74,7 @@ COPY --chown=notify:notify . .
 
 ##### Production Image #######################################################
 
-FROM ${BASE_IMAGE} as production
+FROM app_base as production
 
 COPY --chown=notify:notify app app
 COPY --chown=notify:notify wsgi.py gunicorn_config.py Makefile run_celery.py ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN echo "Installing python dependencies" && \
 #### Shared App Base Image ####################################################
 FROM ${BASE_IMAGE} AS app_base
 
-RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap && (useradd celeryuser || true)
+RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap
 USER notify
 
 RUN mkdir /home/vcap/logs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,16 +4,10 @@ FROM python:3.9-slim-bullseye as base
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN echo "Install base packages" && apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y --no-install-recommends \
-        build-essential \
-        git \
-        libcurl4-openssl-dev \
-        curl \
-        libssl-dev \
-    && echo "Install binary app dependencies" \
-    && apt-get install -y --no-install-recommends \
+RUN echo "Install binary app dependencies" \
+    && apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
         libpango1.0-dev=1.46.2-3 \
         imagemagick=8:6.9.11.60+dfsg-1.3+deb11u1 \
         ghostscript=9.53.3~dfsg-7+deb11u5 \
@@ -21,6 +15,7 @@ RUN echo "Install base packages" && apt-get update \
         gsfonts=1:8.11+urwcyr1.0.7~pre44-4.5 \
         fonts-freefont-ttf=20120503-10 \
         fonts-wqy-zenhei \
+        make \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 
@@ -37,9 +32,19 @@ FROM ${BASE_IMAGE} AS python_build
 
 COPY requirements.txt .
 
-RUN echo "Installing python dependencies" && \
+RUN echo "Install OS dependencies for python app requirements" && apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libcurl4-openssl-dev \
+        curl \
+        libssl-dev && \
+    echo "Installing python requirements" && \
     python3 -m venv /opt/venv && \
-    /opt/venv/bin/pip install -r requirements.txt
+    /opt/venv/bin/pip install -r requirements.txt \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 #### Shared App Base Image ####################################################
 FROM ${BASE_IMAGE} AS app_base

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ case "$@" in
     flask run --host=0.0.0.0 -p $PORT
     ;;
   worker)
-    celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 --uid=`id -u celeryuser`
+    celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4
     ;;
   *)
     echo "Running custom command"

--- a/manifest-celery.yml.j2
+++ b/manifest-celery.yml.j2
@@ -5,7 +5,7 @@ applications:
   disk_quota: 2G
   memory: 2G
   health-check-type: process
-  command: exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 --uid=`id -u celeryuser` 2> /dev/null
+  command: exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 2> /dev/null
 
   services:
     - logit-ssl-syslog-drain
@@ -19,7 +19,7 @@ applications:
 
     NOTIFY_APP_NAME: template-preview-celery
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log
-    
+
     NOTIFICATION_QUEUE_PREFIX: {{ NOTIFICATION_QUEUE_PREFIX }}
 
     AWS_ACCESS_KEY_ID: {{ AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
An initial dockerfile update. If/when this goes in, I'd like to make sure we're following a similar/consistent approach in all of our other dockerfiles.

---

Headlines:
* Production image size from 1030MB -> 780MB.
* Fewer dependencies installed and available in production image; smaller attack surface.
* App no longer running as `root` user
* venv is readonly in production image (read-write in test/dev image)

We do a number of things here:

A `notify` user
---------------

Create and switch to a `notify` user, rather than running the app as `root` user. There are various obvious security improvements that flow out of not using the root user.

Additional build stages
-----------------------

Add some extra stages to the build process. We split out the `parent` step into separate `base` and `python_build` stages.

The `base` step takes care of everything that needs to be run as the `root` user and are about installing OS-level dependencies, fonts, config etc. (**note**: if we go ahead with renaming this step we'll need to update the `base_image_build_for_docker_app` ci pipeline. Maybe it's not worth changing the name here?)

The `python_build` step handles creating the virtual environment, which means we can just copy the `venv` directory to a different clean stage. There can be space improvements here if things required to build/install the dependencies aren't actually needed post-build. This approach is recommended as best practice by various parties, including Snyk, a security-tooling company
(https://snyk.io/blog/best-practices-containerizing-python-docker/). There are a number of OS-level dependencies that we are only installing for the python requirements build/install, so by separating those out into a different stage we can exclude them from our production image.

Use a venv
----------

Finally, we install python dependencies into a virtual environment rather than to the default directory (/usr/local/bin). We make this venv readonly for the production image, but readwrite by the `notify` user for the test image (which will be used for local dev).