### PR TITLE
Add back curl/deps for celery

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN echo "Install binary app dependencies" \
     && apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+        libcurl4 \
         libpango1.0-dev=1.46.2-3 \
         imagemagick=8:6.9.11.60+dfsg-1.3+deb11u1 \
         ghostscript=9.53.3~dfsg-7+deb11u5 \


### PR DESCRIPTION
Otherwise we get errors:

   2023-08-09T12:44:26.98+0100 [APP/PROC/WEB/0] ERR raise ImportError('The curl client requires the pycurl library.')
   2023-08-09T12:44:26.98+0100 [APP/PROC/WEB/0] ERR ImportError: The curl client requires the pycurl library.
   2023-08-09T12:44:29.26+0100 [APP/PROC/WEB/0] ERR scripts/run_app_paas.sh: line 45: kill: (62) - No such process