### PR TITLE
Bump utils to 66.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -96,7 +96,7 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/7d14402ff8ea09a258158be3814834b1a744cc93.pdf"
+    expected_cache_key = "templated/40b85fca8e41c89a213779ffcab99a714cbacd65.pdf"
     resp = view_letter_template(filetype="pdf")
 
     assert resp.status_code == 200
@@ -119,7 +119,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/7d14402ff8ea09a258158be3814834b1a744cc93.page01.png"
+    expected_cache_key = "templated/40b85fca8e41c89a213779ffcab99a714cbacd65.page01.png"
     resp = view_letter_template(filetype="png")
 
     assert resp.status_code == 200
@@ -561,7 +561,7 @@ def test_page_count_from_cache(client, auth_header, mocker, mocked_cache_get):
         headers={"Content-type": "application/json", **auth_header},
     )
     assert mocked_cache_get.call_args[0][0] == "test-template-preview-cache"
-    assert mocked_cache_get.call_args[0][1] == "templated/15688a062cf73a562f82bd5d5ca3d4458bac5c89.pdf"
+    assert mocked_cache_get.call_args[0][1] == "templated/1112c8ea52b0b9e9eab2bb65c3fb54a30fe467f8.pdf"
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {"count": 10, "attachment_page_count": 0}
 


### PR DESCRIPTION
66.1.0
---

* Add a simpler syntax for QR codes in letters (QR: http://example.com)

66.0.2
---

* Style the QR code placeholder so it looks better when the placeholder text is long

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/66.0.1...66.1.0