### PR TITLE
Bump utils to 68.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.1
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@66.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.1
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
68.0.1
---
* Fix a bug with some HTML getting injected into QR codes

68.0.0
---
* Update return value of `BaseLetterTemplate.has_qr_code_with_too_much_data` from `bool` to `Optional[QrCodeTooLong]`.

67.0.0
---
* Add `has_qr_code_with_too_much_data` property to letter templates.
* Update RecipientCSV to detect and throw errors when rows generate QR codes with too much data in them. Anything using RecipientCSV to process letters will need to check for and report on the row-level property `qr_code_too_long`.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/66.1.0...68.0.1