### PR TITLE
Bump utils to 69.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@68.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
69.0.0
---

* Remove old syntax for QR codes in letters (only `QR: http://example.com` will work now)

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/68.0.1...69.0.0