### PR TITLE
Double memory for template preview to give it more CPU

### DIFF
--- a/manifest-celery.yml.j2
+++ b/manifest-celery.yml.j2
@@ -3,7 +3,7 @@ applications:
 - name: notify-template-preview-celery
 
   disk_quota: 2G
-  memory: 2G
+  memory: 4G
   health-check-type: process
   command: exec scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 2> /dev/null
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -14,7 +14,7 @@ applications:
       health-check-http-endpoint: /_status?simple=true
       health-check-type: http
       health-check-invocation-timeout: 10
-      memory: 2G
+      memory: 4G
       disk_quota: 2G
 
   env:


### PR DESCRIPTION
In production, the celery worker in particular, is spiking over 100% CPU very regularly. This is leading to the app crashing regularly.

There is no direct control for how much cpu to give a PaaS app but instead you increase the memory and this increases the available CPU.

https://grafana-notify.cloudapps.digital/d/_GlGBNbmk/notify-apps?orgId=1&var-space=production&var-app=notify-template-preview-celery&from=now-24h&to=now&refresh=1m&viewPanel=8

<img width="1736" alt="image" src="https://github.com/alphagov/notifications-template-preview/assets/7228605/16dca4de-dc40-4c30-8975-9c9f02628901">
