### PR TITLE
Chown /opt/venv faster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,6 @@ ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 FROM production as test
 
 USER root
-RUN chown -R notify:notify /opt/venv
 RUN echo "Install OS dependencies for test build" && apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
@@ -85,6 +84,9 @@ USER notify
 
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app
+
+# Copying to overwrite is faster than RUN chown notify:notify ...
+COPY --from=python_build --chown=notify:notify /opt/venv /opt/venv
 
 # Install dev/test requirements
 COPY --chown=notify:notify requirements.txt requirements_for_test.txt ./


### PR DESCRIPTION
Copying the directory via a Dockerfile command is faster than running a command inside the build container to update ownership