### PR TITLE
Bump utils to 70.0.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@69.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
 ## 70.0.6

* Fix QR code rendering for old-style syntax `[QR]()`

 ## 70.0.5

* Ensure UUIDs in Redis cache keys are always lowercase

 ## 70.0.4

* Update the commit message auto-generated by `make bump-utils` (in app repos) to be copy/pastable via eg vim commit message editing.

 ## 70.0.3

* Remove empty table cell from 'branding only' branding HTML to fix bug with JAWS screen reader

 ## 70.0.2

* Update sanitising of SMS content to include more obscure whitespace

 ## 70.0.0

* InvalidPhoneError messages have been updated. The new error messages are more user friendly.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/69.0.0...70.0.6