### PR TITLE
Bump utils to 71.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@71.0.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@70.0.6
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@71.0.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
 ## 71.0.0

* Remove support for Markdown-style links in letters `[label](https://example.url)`

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/70.0.6...71.0.0