### PR TITLE
add `choom-wrap-pkg`, use an OOM adjustment of 50 for imagemagick, ghostscript, poppler binaries

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ FROM python:3.9-slim-bullseye as base
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 
+COPY --chmod=0755 docker/choom-wrap-pkgs.sh /usr/local/bin/choom-wrap-pkgs
+
 RUN echo "Install binary app dependencies" \
     && apt-get update && \
     apt-get upgrade -y && \
@@ -17,6 +19,7 @@ RUN echo "Install binary app dependencies" \
         fonts-freefont-ttf=20120503-10 \
         fonts-wqy-zenhei \
         make \
+    && choom-wrap-pkgs 50 imagemagick-6.q16 ghostscript poppler-utils \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 

--- a/docker/choom-wrap-pkgs.sh
+++ b/docker/choom-wrap-pkgs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# usage: choom-wrap-pkgs <adjustment> <pkg_name> ...
+# wraps binaries belonging to listed debian packages
+# in a choom(1) call making adjustment <adjustment>
+# to the process's oom score when executed.
+
+function choom_wrap_bin() {
+  local adjustment="$1"; shift
+  local bin_path="$1"; shift
+  echo "choom-wrapping ${bin_path} with adjustment ${adjustment}" >&2
+
+  local bin_basename="$(basename ${bin_path})"
+  local bin_dirname="$(dirname ${bin_path})"
+  local bin_newpath="${bin_dirname}/.${bin_basename}-wrapped"
+
+  mv "${bin_path}" "${bin_newpath}"
+
+  cat > "${bin_path}" <<EOF
+#!/usr/bin/env bash
+exec choom -n '${adjustment}' -- '${bin_newpath}' "\$@"
+EOF
+  chmod --reference="${bin_newpath}" "${bin_path}"
+}
+
+function choom_wrap_deb_pkg() {
+  local adjustment="$1"; shift
+  local pkg_name="$1"; shift
+  echo "choom-wrapping binaries from debian package ${pkg_name}" >&2
+
+  dpkg -L "${pkg_name}" | while read -r filepath ; do
+    if [ -f "${filepath}" -a -x "${filepath}" ] ; then
+      choom_wrap_bin "${adjustment}" "${filepath}"
+    fi
+  done
+}
+
+function choom_wrap_deb_pkgs() {
+  local adjustment="$1"; shift
+  for pkg_name in "$@" ; do
+    choom_wrap_deb_pkg "${adjustment}" "${pkg_name}"
+  done
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  choom_wrap_deb_pkgs "$@"
+fi


### PR DESCRIPTION
When the oom-killer kicks in, it would be preferable for it to target the "leaf" processes that the python app is executing to service a task. These deaths should be comparatively recoverable, whereas if the oom-killer targets one of our python processes it is likely to bring the whole instance down, producing collateral damage to any other tasks that were being processed on the instance and potentially losing logs.

So rather than tracking down every place that the app (or, more likely, one of the libraries it uses) invokes an os binary, wrap those binaries in a script that will adjust the oom-score for every invocation.

I've only done cursory tests of this so far. Also I have no idea if 50 is a good number - picked it as a relatively conservative starter.