### PR TITLE
Bump pypdf back down to 3.13 to fix bug

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,9 @@ sentry-sdk[flask,celery]>=1.0.0,<2.0.0
 # pdf libraries
 html5lib==1.1
 wand==0.5.9
-pypdf==3.17.0
+# pypdf can't be bumped past 3.13 until we figure out why it caused
+# https://govuk.zendesk.com/agent/tickets/5555290
+pypdf==3.13.0
 reportlab==3.6.13
 pdf2image==1.12.1
 PyMuPDF==1.22.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ cachetools==5.2.0
 celery[sqs]==5.2.7
     # via
     #   -r requirements.in
+    #   celery
     #   sentry-sdk
 certifi==2023.7.22
     # via
@@ -81,7 +82,9 @@ flask-redis==0.4.0
 flask-weasyprint==1.0.0
     # via -r requirements.in
 fonttools[woff]==4.41.0
-    # via weasyprint
+    # via
+    #   fonttools
+    #   weasyprint
 geojson==2.5.0
     # via notifications-utils
 govuk-bank-holidays==0.11
@@ -146,7 +149,7 @@ pydyf==0.7.0
     # via weasyprint
 pymupdf==1.22.5
     # via -r requirements.in
-pypdf==3.17.0
+pypdf==3.13.0
     # via
     #   -r requirements.in
     #   notifications-utils
@@ -188,7 +191,9 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[celery,flask]==1.32.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
 shapely==1.8.2
     # via notifications-utils
 six==1.16.0


### PR DESCRIPTION
We are seeing in our logs:
'**** Error: File did not complete the page properly and may be damaged.' and a small number of letters when uploaded are coming back as invalid due to content outside the printable area with the red box for invalid content in the wrong place.

I've replicated the issue locally, and dropping this back down to 3.13 fixes the issue for one of the PDFs in question.