### PR TITLE
Bump sentry to 1.35.0 and add some interesting spans

### DIFF
--- a/app/embedded_fonts.py
+++ b/app/embedded_fonts.py
@@ -1,6 +1,7 @@
 import subprocess
 from io import BytesIO
 
+import sentry_sdk
 from flask import current_app
 from pypdf import PdfReader
 from pypdf.generic import IndirectObject
@@ -62,6 +63,7 @@ def contains_unembedded_fonts(pdf_data, filename=""):  # noqa: C901 (too complex
     return unembedded
 
 
+@sentry_sdk.trace
 def embed_fonts(pdf_data):
     """
     Recreate the following

--- a/app/performance.py
+++ b/app/performance.py
@@ -42,7 +42,7 @@ def init_performance_monitoring():
             environment=environment,
             sample_rate=error_sample_rate,
             send_default_pii=send_pii,
-            request_bodies=send_request_bodies,
+            max_request_body_size=send_request_bodies,
             traces_sampler=traces_sampler,
             profiles_sample_rate=profiles_sample_rate,
             release=release,

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -3,6 +3,7 @@ import subprocess
 from io import BytesIO
 
 import fitz
+import sentry_sdk
 from flask import current_app
 
 from app import InvalidRequest
@@ -34,6 +35,7 @@ def does_pdf_contain_rgb(data):
     return _does_pdf_contain_colorspace("RGB", data)
 
 
+@sentry_sdk.trace
 def convert_pdf_to_cmyk(input_data):
     gs_process = subprocess.Popen(
         [

--- a/requirements.txt
+++ b/requirements.txt
@@ -190,7 +190,7 @@ s3transfer==0.6.1
     #   boto3
 segno==1.5.2
     # via notifications-utils
-sentry-sdk[celery,flask]==1.32.0
+sentry-sdk[celery,flask]==1.35.0
     # via
     #   -r requirements.in
     #   sentry-sdk


### PR DESCRIPTION
[Add spans in interesting places](https://github.com/alphagov/notifications-template-preview/commit/bebbd95c140de40383c2eb1951a31fab4ea12e1b)

Add some tracing around blocks of code that are key to the performance
of template-preview:

* Creating PDFs
* Modifying PDFs via GhostScript (embedding fonts or converting to CMYK)
* Create PNG from PDF