### PR TITLE
Dockerfile: increase `choom-wrap-packages` adjustment to 300

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "Install binary app dependencies" \
         fonts-freefont-ttf=20120503-10 \
         fonts-wqy-zenhei \
         make \
-    && choom-wrap-pkgs 150 imagemagick-6.q16 ghostscript poppler-utils \
+    && choom-wrap-pkgs 300 imagemagick-6.q16 ghostscript poppler-utils \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
When this starts to have an effect we should begin to see 500s resulting from `subprocess` calls being killed (perhaps with exit code 137).