### PR TITLE
requirements: notifications-utils: 72.2.0 -> 73.1.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,7 +119,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@72.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils
@@ -188,9 +188,7 @@ s3transfer==0.6.1
 segno==1.5.2
     # via notifications-utils
 sentry-sdk[celery,flask]==1.35.0
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 shapely==1.8.2
     # via notifications-utils
 six==1.16.0


### PR DESCRIPTION
https://trello.com/c/Q5S5m4ge/446-add-http-logging-to-all-of-our-ecs-apps

See https://github.com/alphagov/notifications-utils/pull/1077, this should bring flask request logging to apps in desired circumstances.