### PR TITLE
Hide second notify tag on letters for print

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -114,14 +114,16 @@ def view_letter_template(filetype):
         abort(400)
 
     json = get_and_validate_json_from_request(request, preview_schema)
-    pdf = _get_pdf_from_letter_json(json)
 
     if json["template"].get("letter_languages", None) == "welsh_then_english":
+        english_pdf = _get_pdf_from_letter_json(json)
         welsh_pdf = _get_pdf_from_letter_json(json, language="welsh")
         pdf = stitch_pdfs(
             first_pdf=BytesIO(welsh_pdf.read()),
-            second_pdf=BytesIO(pdf.read()),
+            second_pdf=BytesIO(english_pdf.read()),
         )
+    else:
+        pdf = _get_pdf_from_letter_json(json)
 
     letter_attachment = json["template"].get("letter_attachment", {})
     if letter_attachment:

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.2.1
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,9 +119,9 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.2.1
     # via -r requirements.in
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 packaging==23.1
     # via gunicorn

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -202,6 +202,7 @@ def test_create_pdf_for_templated_letter_happy_path(
     )
 
     assert not any(r.levelname == "ERROR" for r in caplog.records)
+    assert "NOTIFY" in PdfReader(mock_upload.call_args_list[0][1]["filedata"]).pages[0].extract_text()
 
 
 def test_create_pdf_for_templated_letter_includes_welsh_pages_if_provided(

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -8,6 +8,7 @@ from botocore.exceptions import ClientError as BotoClientError
 from celery.exceptions import Retry
 from flask import current_app
 from moto import mock_s3
+from pypdf import PdfReader
 
 import app.celery.tasks
 from app.celery.tasks import (
@@ -240,8 +241,8 @@ def test_create_pdf_for_templated_letter_includes_welsh_pages_if_provided(
     )
 
     assert mock_create_pdf.call_args_list == [
-        mocker.call(mocker.ANY, mocker.ANY, language="english"),
-        mocker.call(mocker.ANY, mocker.ANY, language="welsh"),
+        mocker.call(mocker.ANY, mocker.ANY, language="welsh", include_notify_tag=True),
+        mocker.call(mocker.ANY, mocker.ANY, language="english", include_notify_tag=False),
     ]
 
     assert not any(r.levelname == "ERROR" for r in caplog.records)
@@ -486,3 +487,20 @@ def test_recreate_pdf_for_precompiled_letter_that_fails_validation(client, caplo
 def test_remove_folder_from_filename(filename, expected_filename):
     actual_filename = _remove_folder_from_filename(filename)
     assert actual_filename == expected_filename
+
+
+@pytest.mark.parametrize("include_notify_tag", (True, False))
+def test_create_pdf_for_letter_notify_tagging(client, include_notify_tag):
+    pdf = _create_pdf_for_letter(
+        task=None,  # noqa
+        letter_details={
+            "template": {"template_type": "letter", "subject": "subject", "content": "content"},
+            "values": {},
+            "letter_contact_block": "",
+            "logo_filename": "",
+        },
+        language="english",
+        include_notify_tag=include_notify_tag,
+    )
+
+    assert ("NOTIFY" in PdfReader(pdf).pages[0].extract_text()) is include_notify_tag


### PR DESCRIPTION
When we print letters, we insert a NOTIFY tag on the first page in the top-left, which helps DVLA printers recognise our workload.

We've been accidentally including this twice in bilingual letters, on the first page of Welsh and the first page of English content.

This patch hides the tag on the English pages.