### PR TITLE
Switch to using an exec in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,16 +4,16 @@ set -eu
 
 case "$@" in
   web)
-    gunicorn --error-logfile - -c /home/vcap/app/gunicorn_config.py wsgi
+    exec gunicorn --error-logfile - -c /home/vcap/app/gunicorn_config.py wsgi
     ;;
   web-local)
-    flask run --host=0.0.0.0 -p $PORT
+    exec flask run --host=0.0.0.0 -p $PORT
     ;;
   worker)
-    celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4
+    exec celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4
     ;;
   *)
     echo "Running custom command"
-    $@
+    exec $@
     ;;
 esac


### PR DESCRIPTION
What
----

Switch to using an exec in entrypoint.sh

The exec will replace the the entrypoint pid (usually 1) with the main gunicorn or flask one.

Why
----

Following guidance ['One PID to rule them all' from aws](https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/) we should use exec to prevent the shell script middleman from consuming SIGTERM signals and not passing them to child processes.


