### PR TITLE
Bump utils to 74.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 74.4.0

* Reverts the 'single session' change from 74.1.0, which may be causing us some connection errors.

 ## 74.3.0

* Add `decrby` method to the RedisClient

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.2.0...74.4.0