### PR TITLE
manifest generation: handle celery `-ecs-fixup` suffixed app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD)
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
 CF_APP ?= notify-template-preview
-CF_MANIFEST_TEMPLATE_PATH ?= manifest$(subst notify-template-preview,,${CF_APP}).yml.j2
+CF_MANIFEST_TEMPLATE_PATH ?= manifest$(subst -ecs-fixup,,$(subst notify-template-preview,,${CF_APP})).yml.j2
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
 CF_API ?= api.cloud.service.gov.uk
@@ -110,7 +110,9 @@ generate-manifest:
 	$(if ${GPG_PASSPHRASE_TXT}, $(eval export DECRYPT_CMD=echo -n $$$${GPG_PASSPHRASE_TXT} | ${GPG} --quiet --batch --passphrase-fd 0 --pinentry-mode loopback -d), $(eval export DECRYPT_CMD=${GPG} --quiet --batch -d))
 
 	@jinja2 --strict ${CF_MANIFEST_TEMPLATE_PATH} \
-	    -D environment=${CF_SPACE} --format=yaml \
+	    -D environment=${CF_SPACE} \
+	    -D CF_APP=${CF_APP} \
+	    --format=yaml \
 	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/paas/environment-variables.gpg) 2>&1
 
 .PHONY: cf-deploy

--- a/manifest-celery.yml.j2
+++ b/manifest-celery.yml.j2
@@ -1,6 +1,26 @@
+{%- set app_vars = {
+  'notify-template-preview-celery': {},
+  'notify-template-preview-celery-ecs-fixup': {
+    'additional_env_vars': {
+      'NOTIFICATION_QUEUE_PREFIX': ('production-' if environment == 'production' else (NOTIFICATION_QUEUE_PREFIX + '-ecs')),
+    },
+    'instances': {
+      'preview': 0,
+      'staging': 0,
+      'production': 0,
+    },
+  },
+} -%}
+
+{%- set app = app_vars[CF_APP] -%}
+{%- set instance_count = app.get('instances', {}).get(environment) -%}
 ---
 applications:
-- name: notify-template-preview-celery
+- name: {{ CF_APP }}
+
+  {% if instance_count is not none %}
+  instances: {{ instance_count }}
+  {%- endif %}
 
   disk_quota: 2G
   memory: 4G
@@ -11,13 +31,13 @@ applications:
     - logit-ssl-syslog-drain
 
   routes:
-    - route: {{ environment }}-notify-template-preview-celery.cloudapps.digital
+    - route: {{ environment }}-{{ CF_APP }}.cloudapps.digital
 
 
   env:
     NOTIFY_ENVIRONMENT: {{ environment }}
 
-    NOTIFY_APP_NAME: template-preview-celery
+    NOTIFY_APP_NAME: {{ app.get('NOTIFY_APP_NAME', CF_APP.replace('notify-', '')) }}
     NOTIFY_LOG_PATH: /home/vcap/logs/app.log
 
     NOTIFICATION_QUEUE_PREFIX: {{ NOTIFICATION_QUEUE_PREFIX }}
@@ -38,3 +58,7 @@ applications:
     SENTRY_ERRORS_SAMPLE_RATE: '{{ TEMPLATE_PREVIEW_SENTRY_ERRORS_SAMPLE_RATE }}'
     SENTRY_TRACES_SAMPLE_RATE: '{{ TEMPLATE_PREVIEW_SENTRY_TRACES_SAMPLE_RATE }}'
     SENTRY_PROFILES_SAMPLE_RATE: '{{ TEMPLATE_PREVIEW_SENTRY_PROFILES_SAMPLE_RATE }}'
+
+    {% for key, value in app.get('additional_env_vars', {}).items() %}
+    {{key}}: '{{value}}'
+    {% endfor %}


### PR DESCRIPTION
https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa

Apply the same mechanism for generating more than one app's
manifest from a single template as in the api's manifest template (adapted in https://github.com/alphagov/notifications-api/pull/4002 and https://github.com/alphagov/notifications-api/pull/4012)