### PR TITLE
Bump utils to 74.8.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
 ## 74.8.0

* NotifyRequest: generate own span_id if none provided in headers

 ## 74.7.0

* Include onwards request headers in AntivirusClient requests

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.6.0...74.8.0