### PR TITLE
config: set `NOTIFY_RUNTIME_PLATFORM` and `NOTIFY_REQUEST_LOG_LEVEL`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,9 @@ class Config:
     if "NOTIFY_LOG_PATH" in os.environ:
         NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH")
 
+    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "paas")
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
+
     STATSD_ENABLED = True
     STATSD_HOST = os.environ.get("STATSD_HOST")
     STATSD_PORT = 8125


### PR DESCRIPTION
For some reason this was never set for this app, so on PaaS the app just has an empty value.

This configuration should continue to produce `app.request` post-request log messages on PaaS.

See also https://github.com/alphagov/notifications-api/pull/4016