### PR TITLE
Bump utils to 74.9.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
To stop logging some sensitive information.

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/74.9.0...74.9.1