### PR TITLE
Upgrade imagemagick for security vulnerability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "Install binary app dependencies" \
         libcurl4 \
         curl \
         libpango1.0-dev=1.46.2-3 \
-        imagemagick=8:6.9.11.60+dfsg-1.3+deb11u1 \
+        imagemagick=8:6.9.11.60+dfsg-1.3+deb11u2 \
         ghostscript=9.53.3~dfsg-7+deb11u6 \
         poppler-utils=20.09.0-3.1+deb11u1 \
         gsfonts=1:8.11+urwcyr1.0.7~pre44-4.5 \


### PR DESCRIPTION
This upgrades imagemagick to the version that has a fix for CVE-2021-20309 as identified by our security scan.