### PR TITLE
attempt to remove celery worker logging

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ case "$@" in
     exec flask run --host=0.0.0.0 -p $PORT
     ;;
   worker)
-    exec celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4
+    exec celery --quiet -A run_celery.notify_celery worker --logfile=/dev/null --concurrency=4
     ;;
   *)
     echo "Running custom command"

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.0
 
 # PaaS requirements
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -114,7 +114,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.9.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
These changes should quieten celery's own attempts at logging/ stdout output and stop us outputting celery logs in structured format too.

We can bring them back (hopefully in structured format) when we can be more certain that they cannot contain sensitive values.