### PR TITLE
Set `HOME` in Dockerfile test build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,11 +81,15 @@ RUN echo "Install OS dependencies for test build" && apt-get update && \
     apt-get install -y --no-install-recommends \
       sudo \
       git \
+      libcurl4-openssl-dev \
+      libssl-dev \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* /tmp/*
 RUN usermod -aG sudo notify
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER notify
+
+ENV HOME=/home/vcap
 
 # Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
 RUN mkdir -p app


### PR DESCRIPTION
If `HOME` is not set it defaults to `/home/notify` which gives an error when trying to run `make freeze-requirements` of "The directory '/home/notify/.cache/pip' or its parent directory is not owned or is not writable by the current user."