### PR TITLE
Adding a comment about the page count being cached in admin

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -72,6 +72,7 @@ def _preview_and_get_page_count(letter_json, language="english"):
 @preview_blueprint.route("/get-page-count", methods=["POST"])
 @auth.login_required
 def page_count():
+    # This endpoint is called from all_page_counts in admin and is cached there.
     json = get_and_validate_json_from_request(request, preview_schema)
 
     counts = {


### PR DESCRIPTION
So when/if caching should be added to getting page counts we know where is already caching