### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,7 +52,6 @@ class Config:
     if "NOTIFY_LOG_PATH" in os.environ:
         NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH")
 
-    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "ecs")
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     STATSD_ENABLED = True

--- a/app/config.py
+++ b/app/config.py
@@ -46,12 +46,6 @@ class Config:
         ],
     }
 
-    # if we use .get() for cases that it is not setup
-    # it will still create the config key with None value causing
-    # logging initialization in utils to fail
-    if "NOTIFY_LOG_PATH" in os.environ:
-        NOTIFY_LOG_PATH = os.environ.get("NOTIFY_LOG_PATH")
-
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
     STATSD_ENABLED = True

--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,6 @@ pdf2image==1.12.1
 PyMuPDF==1.22.5
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
 
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,7 +105,7 @@ markupsafe==2.1.1
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

~Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)~