### PR TITLE
Remove environment knowledge from application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,10 +21,13 @@ notify_celery = NotifyCelery()
 def create_app():
     application = Flask(__name__)
 
-    from app.config import configs
+    from app.config import Config, configs
 
     notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
-    application.config.from_object(configs[notify_environment])
+    if notify_environment in configs:
+        application.config.from_object(configs[notify_environment])
+    else:
+        application.config.from_object(Config)
 
     init_app(application)
 

--- a/app/config.py
+++ b/app/config.py
@@ -52,50 +52,16 @@ class Config:
     STATSD_HOST = os.environ.get("STATSD_HOST")
     STATSD_PORT = 8125
 
-
-class Production(Config):
-    NOTIFY_ENVIRONMENT = "production"
-
-    LETTERS_SCAN_BUCKET_NAME = "production-letters-scan"
-    LETTER_CACHE_BUCKET_NAME = "production-template-preview-cache"
-    LETTERS_PDF_BUCKET_NAME = "production-letters-pdf"
-    TEST_LETTERS_BUCKET_NAME = "production-test-letters"
-    INVALID_PDF_BUCKET_NAME = "production-letters-invalid-pdf"
-    SANITISED_LETTER_BUCKET_NAME = "production-letters-sanitise"
-    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = "production-letters-precompiled-originals-backup"
-    LETTER_ATTACHMENT_BUCKET_NAME = "production-letter-attachments"
-
-    LETTER_LOGO_URL = "https://static-logos.notifications.service.gov.uk/letters"
-
-
-class Staging(Config):
-    NOTIFY_ENVIRONMENT = "staging"
-
-    LETTERS_SCAN_BUCKET_NAME = "staging-letters-scan"
-    LETTER_CACHE_BUCKET_NAME = "staging-template-preview-cache"
-    LETTERS_PDF_BUCKET_NAME = "staging-letters-pdf"
-    TEST_LETTERS_BUCKET_NAME = "staging-test-letters"
-    INVALID_PDF_BUCKET_NAME = "staging-letters-invalid-pdf"
-    SANITISED_LETTER_BUCKET_NAME = "staging-letters-sanitise"
-    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = "staging-letters-precompiled-originals-backup"
-    LETTER_ATTACHMENT_BUCKET_NAME = "staging-letter-attachments"
-
-    LETTER_LOGO_URL = "https://static-logos.staging-notify.works/letters"
-
-
-class Preview(Config):
-    NOTIFY_ENVIRONMENT = "preview"
-
-    LETTERS_SCAN_BUCKET_NAME = "preview-letters-scan"
-    LETTER_CACHE_BUCKET_NAME = "preview-template-preview-cache"
-    LETTERS_PDF_BUCKET_NAME = "preview-letters-pdf"
-    TEST_LETTERS_BUCKET_NAME = "preview-test-letters"
-    INVALID_PDF_BUCKET_NAME = "preview-letters-invalid-pdf"
-    SANITISED_LETTER_BUCKET_NAME = "preview-letters-sanitise"
-    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = "preview-letters-precompiled-originals-backup"
-    LETTER_ATTACHMENT_BUCKET_NAME = "preview-letter-attachments"
-
-    LETTER_LOGO_URL = "https://static-logos.notify.works/letters"
+    NOTIFY_ENVIRONMENT = os.environ.get("NOTIFY_ENVIRONMENT")
+    LETTERS_SCAN_BUCKET_NAME = os.environ.get("LETTERS_SCAN_BUCKET_NAME")
+    LETTER_CACHE_BUCKET_NAME = os.environ.get("LETTER_CACHE_BUCKET_NAME")
+    LETTERS_PDF_BUCKET_NAME = os.environ.get("LETTERS_PDF_BUCKET_NAME")
+    TEST_LETTERS_BUCKET_NAME = os.environ.get("TEST_LETTERS_BUCKET_NAME")
+    INVALID_PDF_BUCKET_NAME = os.environ.get("INVALID_PDF_BUCKET_NAME")
+    SANITISED_LETTER_BUCKET_NAME = os.environ.get("SANITISED_LETTER_BUCKET_NAME")
+    PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = os.environ.get("PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME")
+    LETTER_ATTACHMENT_BUCKET_NAME = os.environ.get("LETTER_ATTACHMENT_BUCKET_NAME")
+    LETTER_LOGO_URL = os.environ.get("LETTER_LOGO_URL")
 
 
 class Development(Config):
@@ -132,7 +98,4 @@ class Test(Development):
 configs = {
     "development": Development,
     "test": Test,
-    "production": Production,
-    "staging": Staging,
-    "preview": Preview,
 }

--- a/app/performance.py
+++ b/app/performance.py
@@ -11,7 +11,7 @@ def sentry_sampler(sampling_context, sample_rate: float = 0.0):
 
 def init_performance_monitoring():
     environment = os.getenv("NOTIFY_ENVIRONMENT").lower()
-    not_production = environment in {"development", "preview", "staging"}
+    allow_pii = os.getenv("SENTRY_ALLOW_PII", "0") == "1"
     sentry_enabled = bool(int(os.getenv("SENTRY_ENABLED", "0")))
     sentry_dsn = os.getenv("SENTRY_DSN")
 
@@ -25,8 +25,8 @@ def init_performance_monitoring():
         # 10% of traced requests will be profiled.
         profiles_sample_rate = float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", 0.0))
 
-        send_pii = True if not_production else False
-        send_request_bodies = "medium" if not_production else "never"
+        send_pii = True if allow_pii else False
+        send_request_bodies = "medium" if allow_pii else "never"
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 


### PR DESCRIPTION
What
----

Remove environment knowledge from application. Environment configuration will be passed in during deployments.

Replace environment name checks with feature flags.

Why
----

We are updating our notify deployment model to allow for many more environments. As such environment settings will be kept in as few places as possible (eventually just one place).

The main benefit of this is to be able to add new environments without having to modify source code

Note
----

This change should not be merged until the deployment configuration has been updated. See [the following pr](https://github.com/alphagov/notifications-aws/pull/2207)
