### PR TITLE
Fix bug in add_redact_annot() by pulling newest PyMuPDF

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ wand==0.5.9
 pypdf==3.13.0
 reportlab==3.6.13
 pdf2image==1.12.1
-PyMuPDF==1.22.5
+PyMuPDF==1.24.4
 WeasyPrint==59
 
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,8 +130,10 @@ pycurl==7.44.1
     # via kombu
 pydyf==0.7.0
     # via weasyprint
-pymupdf==1.22.5
+pymupdf==1.24.4
     # via -r requirements.in
+pymupdfb==1.24.3
+    # via pymupdf
 pypdf==3.13.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
A user wrote to us with an issue - they tried to upload a PDF letter, but the letter content on the first page got mangled - symbols replaced the actual letter content on the first page.

Debugging the issue, I realised the text gets mangled during the address block redaction process. I looked that we use PyMuPDF to redact the address block, and that [they have fixed a couple issues](https://github.com/pymupdf/PyMuPDF/blob/8ec240783f66a227446d38d1afe732663d44b555/changes.txt) with `add_redact_annot()` in newer releases.

So I pulled in the newest release and upon testing it fixed the issue.