### PR TITLE
Bump utils to 79.0.0

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -56,7 +56,7 @@ def sanitise_and_upload_letter(notification_id, filename, allow_international_le
             )
 
         current_app.logger.info(
-            "Notification %(status)s sanitisation: %(id)s", dict(status=validation_status, id=notification_id)
+            "Notification %(status)s sanitisation: %(id)s", {"status": validation_status, "id": notification_id}
         )
 
     except BotoClientError:
@@ -103,12 +103,12 @@ def copy_s3_object(source_bucket, source_filename, target_bucket, target_filenam
 
     current_app.logger.info(
         "Copied PDF letter: %(source_bucket)s/%(source_filename)s to %(target_bucket)s/%(target_filename)s",
-        dict(
-            source_bucket=source_bucket,
-            source_filename=source_filename,
-            target_bucket=target_bucket,
-            target_filename=target_filename,
-        ),
+        {
+            "source_bucket": source_bucket,
+            "source_filename": source_filename,
+            "target_bucket": target_bucket,
+            "target_filename": target_filename,
+        },
     )
 
 
@@ -181,17 +181,17 @@ def create_pdf_for_templated_letter(self: Task, encoded_letter_data):
 
         current_app.logger.info(
             "Uploaded letters PDF %(filename)s to %(bucket_name)s for notification id %(id)s",
-            dict(
-                filename=letter_details["letter_filename"],
-                bucket_name=bucket_name,
-                id=letter_details["notification_id"],
-            ),
+            {
+                "filename": letter_details["letter_filename"],
+                "bucket_name": bucket_name,
+                "id": letter_details["notification_id"],
+            },
         )
 
     except BotoClientError:
         current_app.logger.exception(
             "Error uploading %(filename)s to pdf bucket for notification %(id)s",
-            dict(filename=letter_details["letter_filename"], id=letter_details["notification_id"]),
+            {"filename": letter_details["letter_filename"], "id": letter_details["notification_id"]},
         )
         return
 

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -365,7 +365,7 @@ def log_metadata_for_letter(src_pdf, filename):
     else:
         current_app.logger.info(
             'Processing letter "%(filename)s" with creator "%(creator)s" and producer "%(producer)s"',
-            dict(filename=filename, creator=info.creator, producer=info.producer),
+            {"filename": filename, "creator": info.creator, "producer": info.producer},
         )
 
 
@@ -449,7 +449,7 @@ def _get_pages_with_invalid_orientation_or_size(src_pdf):
                     "Letter is not A4 portrait size on page %(page)s. "
                     "Rotate: %(rotate)s, height: %(height)smm, width: %(width)smm"
                 ),
-                dict(page=page_num + 1, rotate=rotation, height=int(page_height), width=int(page_width)),
+                {"page": page_num + 1, "rotate": rotation, "height": int(page_height), "width": int(page_width)},
             )
     return invalid_pages
 

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -435,7 +435,7 @@ def _is_page_A4_portrait(page_height, page_width, rotation):
 def _get_pages_with_invalid_orientation_or_size(src_pdf):
     pdf = PdfReader(src_pdf)
     invalid_pages = []
-    for page_num in range(0, len(pdf.pages)):
+    for page_num in range(len(pdf.pages)):
         page = pdf.pages[page_num]
 
         page_height = float(page.mediabox.height) / mm
@@ -557,7 +557,7 @@ def _colour_no_print_areas_of_single_page_pdf_in_red(src_pdf, is_first_page):
     try:
         pdf = PdfReader(src_pdf)
     except PdfReadError as e:
-        raise InvalidRequest("Unable to read the PDF data: {}".format(e)) from e
+        raise InvalidRequest(f"Unable to read the PDF data: {e}") from e
 
     if len(pdf.pages) != 1:
         # this function is used to render images, which call template-preview separately for each page. This function

--- a/app/preview.py
+++ b/app/preview.py
@@ -37,7 +37,7 @@ def png_from_pdf(data, page_number, hide_notify=False):
         try:
             page = pdf.sequence[page_number - 1]
         except IndexError:
-            abort(400, "Letter does not have a page {}".format(page_number))
+            abort(400, f"Letter does not have a page {page_number}")
         pdf_colorspace = pdf.colorspace
     return _generate_png_page(page, pdf_width, pdf_height, pdf_colorspace, hide_notify)
 
@@ -228,7 +228,7 @@ def get_pdf(html) -> BytesIO:
 
 
 def get_png(pdf, page_number):
-    @current_app.cache(pdf.read(), folder="templated", extension="page{0:02d}.png".format(page_number))
+    @current_app.cache(pdf.read(), folder="templated", extension=f"page{page_number:02d}.png")
     def _get():
         pdf.seek(0)
         return png_from_pdf(
@@ -244,7 +244,7 @@ def get_png_from_precompiled(encoded_string: bytes, page_number, hide_notify):
         encoded_string.decode("ascii"),
         hide_notify,
         folder="precompiled",
-        extension="page{0:02d}.png".format(page_number),
+        extension=f"page{page_number:02d}.png",
     )
     def _get():
         return png_from_pdf(

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -69,6 +69,7 @@ def convert_pdf_to_cmyk(input_data):
 
     if gs_process.returncode != 0:
         raise Exception(
-            f"ghostscript cmyk transformation failed with return code: {gs_process.returncode}\nstdout: {stdout}\nstderr:{stderr}"
+            f"ghostscript cmyk transformation failed with return code: "
+            f"{gs_process.returncode}\nstdout: {stdout}\nstderr:{stderr}"
         )
     return BytesIO(stdout)

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -16,7 +16,7 @@ def _does_pdf_contain_colorspace(colourspace, data):
             page = doc.get_page_images(i)
         except RuntimeError as e:
             current_app.logger.warning("Fitz couldn't read page info for page %s", i + 1)
-            raise InvalidRequest("Invalid PDF on page {}".format(i + 1)) from e
+            raise InvalidRequest(f"Invalid PDF on page {i + 1}") from e
         for img in page:
             xref = img[0]
             pix = fitz.Pixmap(doc, xref)
@@ -69,8 +69,6 @@ def convert_pdf_to_cmyk(input_data):
 
     if gs_process.returncode != 0:
         raise Exception(
-            "ghostscript cmyk transformation failed with return code: {}\nstdout: {}\nstderr:{}".format(
-                gs_process.returncode, stdout, stderr
-            )
+            f"ghostscript cmyk transformation failed with return code: {gs_process.returncode}\nstdout: {stdout}\nstderr:{stderr}"
         )
     return BytesIO(stdout)

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,5 @@
 #app requirements
-boto3==1.28.5
-celery[sqs]==5.2.7
+celery[sqs]==5.4.0
 jsonschema==4.15.0
 Flask==3.0.0
 Flask-WeasyPrint==1.0.0
@@ -19,6 +18,6 @@ pdf2image==1.12.1
 PyMuPDF==1.24.4
 WeasyPrint==59
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
 
 gunicorn==21.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,55 +4,53 @@
 #
 #    pip-compile requirements.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
-async-timeout==4.0.2
-    # via redis
-attrs==21.4.0
+attrs==23.2.0
     # via jsonschema
-billiard==3.6.4.0
+billiard==4.2.0
     # via celery
-blinker==1.6.2
+blinker==1.8.2
     # via
     #   flask
     #   sentry-sdk
-boto3==1.28.5
+boto3==1.34.129
     # via
-    #   -r requirements.in
+    #   celery
     #   kombu
     #   notifications-utils
-botocore==1.31.5
+botocore==1.34.129
     # via
     #   boto3
     #   s3transfer
 brotli==1.0.9
     # via fonttools
-cachetools==5.2.0
+cachetools==5.3.3
     # via notifications-utils
-celery[sqs]==5.2.7
+celery[sqs]==5.4.0
     # via
     #   -r requirements.in
     #   sentry-sdk
-certifi==2023.7.22
+certifi==2024.6.2
     # via
     #   requests
     #   sentry-sdk
-cffi==1.15.0
+cffi==1.16.0
     # via weasyprint
-charset-normalizer==2.0.12
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   celery
     #   click-didyoumean
     #   click-plugins
     #   click-repl
     #   flask
-click-didyoumean==0.3.0
+click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1
     # via celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via celery
 cssselect2==0.6.0
     # via weasyprint
@@ -72,7 +70,7 @@ flask-weasyprint==1.0.0
     # via -r requirements.in
 fonttools[woff]==4.41.0
     # via weasyprint
-govuk-bank-holidays==0.11
+govuk-bank-holidays==0.14
     # via notifications-utils
 gunicorn==21.2.0
     # via
@@ -82,36 +80,36 @@ html5lib==1.1
     # via
     #   -r requirements.in
     #   weasyprint
-idna==3.3
+idna==3.7
     # via requests
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   flask
     #   notifications-utils
-jmespath==1.0.0
+jmespath==1.0.1
     # via
     #   boto3
     #   botocore
 jsonschema==4.15.0
     # via -r requirements.in
-kombu[sqs]==5.2.4
+kombu[sqs]==5.3.7
     # via celery
-markupsafe==2.1.1
+markupsafe==2.1.5
     # via
     #   jinja2
     #   sentry-sdk
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@78.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
-packaging==23.1
+packaging==24.1
     # via gunicorn
 pdf2image==1.12.1
     # via -r requirements.in
@@ -122,12 +120,14 @@ pillow==9.3.0
     #   pdf2image
     #   reportlab
     #   weasyprint
-prompt-toolkit==3.0.29
+prompt-toolkit==3.0.47
     # via click-repl
 pycparser==2.21
     # via cffi
 pycurl==7.44.1
-    # via kombu
+    # via
+    #   celery
+    #   kombu
 pydyf==0.7.0
     # via weasyprint
 pymupdf==1.24.4
@@ -142,50 +142,52 @@ pyphen==0.12.0
     # via weasyprint
 pyrsistent==0.18.1
     # via jsonschema
-python-dateutil==2.8.2
-    # via botocore
-python-json-logger==2.0.2
-    # via notifications-utils
-pytz==2022.1
+python-dateutil==2.9.0.post0
     # via
+    #   botocore
     #   celery
-    #   notifications-utils
+python-json-logger==2.0.7
+    # via notifications-utils
+pytz==2024.1
+    # via notifications-utils
 pyyaml==6.0.1
     # via notifications-utils
-redis==4.5.4
+redis==5.0.6
     # via flask-redis
 reportlab==3.6.13
     # via -r requirements.in
-requests==2.31.0
+requests==2.32.2
     # via
     #   govuk-bank-holidays
     #   notifications-utils
-s3transfer==0.6.1
+s3transfer==0.10.1
     # via boto3
 segno==1.5.2
     # via notifications-utils
-sentry-sdk[celery,flask]==1.35.0
+sentry-sdk[celery,flask]==1.45.0
     # via -r requirements.in
 six==1.16.0
     # via
-    #   click-repl
     #   html5lib
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils
-statsd==3.3.0
+statsd==4.0.1
     # via notifications-utils
 tinycss2==1.1.1
     # via
     #   cssselect2
     #   weasyprint
-urllib3==1.26.18
+tzdata==2024.1
+    # via celery
+urllib3==2.2.2
     # via
     #   botocore
+    #   celery
     #   kombu
     #   requests
     #   sentry-sdk
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -473,7 +473,7 @@ def test_recreate_pdf_for_precompiled_letter_that_fails_validation(client, caplo
 
     # the original file has not been copied or moved
     assert [o.key for o in backup_bucket.objects.all()] == ["1234-abcd.pdf"]
-    assert len([x for x in final_letters_bucket.objects.all()]) == 0
+    assert len(list(final_letters_bucket.objects.all())) == 0
 
     assert "Notification failed resanitisation: 1234-abcd" in caplog.messages
 

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -430,7 +430,7 @@ def test_precompiled_sanitise_pdf_without_notify_tag(client, auth_header):
 
     pdf = BytesIO(base64.b64decode(response.json["file"].encode()))
     assert is_notify_tag_present(pdf)
-    assert extract_address_block(pdf).normalised == ("Queen Elizabeth\n" "Buckingham Palace\n" "London\n" "SW1 1AA")
+    assert extract_address_block(pdf).normalised == ("Queen Elizabeth\nBuckingham Palace\nLondon\nSW1 1AA")
 
 
 def test_precompiled_sanitise_pdf_for_an_attachment(client, auth_header, mocker):

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -120,7 +120,7 @@ def test_convert_pdf_to_cmyk_does_not_strip_images():
 
     image_refs = first_page["/Resources"]["/XObject"].values()
     images = [image_ref.get_object() for image_ref in image_refs]
-    assert not any(["/Matte" in image for image in images])
+    assert not any("/Matte" in image for image in images)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -25,7 +25,7 @@ from tests.pdf_consts import (
 
 @pytest.mark.parametrize(
     "pdf",
-    [HTML(string=str("<html></html>")).write_pdf(), multi_page_pdf],
+    [HTML(string="<html></html>").write_pdf(), multi_page_pdf],
     ids=["templated", "precompiled"],
 )
 def test_convert_pdf_to_cmyk_outputs_valid_pdf(pdf):
@@ -39,7 +39,7 @@ def test_subprocess_fails(client, mocker):
     mock_popen.return_value.communicate.return_value = ("Failed", "There was an error")
 
     with pytest.raises(Exception) as excinfo:
-        html = HTML(string=str("<html></html>"))
+        html = HTML(string="<html></html>")
         pdf = BytesIO(html.write_pdf())
         convert_pdf_to_cmyk(pdf)
         assert "ghostscript process failed with return code: 1" in str(excinfo.value)
@@ -57,7 +57,7 @@ def test_subprocess_includes_output_error(client, mocker):
     )
 
     with pytest.raises(Exception) as excinfo:
-        html = HTML(string=str("<html></html>"))
+        html = HTML(string="<html></html>")
         pdf = BytesIO(html.write_pdf())
         convert_pdf_to_cmyk(pdf)
         assert "ghostscript cmyk transformation failed to read all content streams" in str(excinfo.value)


### PR DESCRIPTION
 ## 79.0.0

* Switches on Pyupgrade and a bunch of other more opinionated linting rules

 ## 78.2.0

* Bumped minimum versions of select subdependencies

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/78.1.0...79.0.0