### PR TITLE
Dockerfile: pre-compile bytecode for app in production image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,6 +71,8 @@ COPY --chown=notify:notify app app
 COPY --chown=notify:notify entrypoint.sh wsgi.py gunicorn_config.py Makefile run_celery.py ./
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 
+RUN python -m compileall .
+
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################


### PR DESCRIPTION
This should produce a small improvement in startup time. Bytecode for the libraries in the venv is already generated during pip install.