### PR TITLE
Remove debugger from requirements

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,4 +2,3 @@
 -r requirements_for_test_common.txt
 
 moto[s3]==4.1.5
-pdbpp==0.10.3


### PR DESCRIPTION
If people want to install debuggers of their choice in their own environments that’s fine, but we don’t need to standardise on one and install it everywhere