### PR TITLE
Change port mapping to use the loopback address

### DIFF
--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 DOCKER_IMAGE_NAME=notifications-template-preview
+PORT=6013
 
 source environment.sh
 
 if [[ "${@}" == "web" || "${@}" == "web-local" ]]; then
-  EXPOSED_PORTS="-e PORT=6013 -p 6013:6013"
+  EXPOSED_PORTS="-e PORT=${PORT} -p 127.0.0.1:${PORT}:${PORT}"
 else
   EXPOSED_PORTS=""
 fi


### PR DESCRIPTION
Docker defaults to using `0.0.0.0`, the default route listening on all network interfaces, as opposed to the loopback address (`127.0.0.1`). This has security implications and we have been asked to change it.