### PR TITLE
add gds-metrics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 from flask import Flask, jsonify
 from flask_httpauth import HTTPTokenAuth
+from gds_metrics import GDSMetrics
 from notifications_utils import logging as utils_logging
 from notifications_utils import request_helper
 from notifications_utils.celery import NotifyCelery
@@ -16,6 +17,7 @@ from notifications_utils.s3 import S3ObjectNotFound, s3download, s3upload
 from app import weasyprint_hack
 
 notify_celery = NotifyCelery()
+metrics = GDSMetrics()
 
 
 def create_app():
@@ -30,6 +32,9 @@ def create_app():
         application.config.from_object(Config)
 
     init_app(application)
+
+    # Metrics intentionally high up to give the most accurate timing and reliability that the metric is recorded
+    metrics.init_app(application)
 
     from app.precompiled import precompiled_blueprint
     from app.preview import preview_blueprint

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,7 @@ WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@82.0.0
+
+# gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
+prometheus-client==0.14.1
+git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ billiard==4.2.0
 blinker==1.8.2
     # via
     #   flask
+    #   gds-metrics
     #   sentry-sdk
 boto3[crt]==1.34.129
     # via
@@ -65,6 +66,7 @@ flask==3.0.0
     #   flask-httpauth
     #   flask-redis
     #   flask-weasyprint
+    #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
 flask-httpauth==4.8.0
@@ -75,6 +77,8 @@ flask-weasyprint==1.0.0
     # via -r requirements.in
 fonttools[woff]==4.41.0
     # via weasyprint
+gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
+    # via -r requirements.in
 govuk-bank-holidays==0.14
     # via notifications-utils
 greenlet==3.0.3
@@ -125,6 +129,10 @@ pillow==9.3.0
     #   pdf2image
     #   reportlab
     #   weasyprint
+prometheus-client==0.14.1
+    # via
+    #   -r requirements.in
+    #   gds-metrics
 prompt-toolkit==3.0.47
     # via click-repl
 pycparser==2.21


### PR DESCRIPTION
As absurd as it may be to add yet another way of reporting metrics, this allows us to gather flask metrics via the prometheus protocol like other apps.

Has been tested by deploying with https://github.com/alphagov/notifications-aws/pull/2347 to a dev environment where the cluster's internal prometheus was queried via an ecs-exec session.