### PR TITLE
Stop Docker builds from being based on an 7mo old image by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bootstrap: generate-version-file
 
 .PHONY: bootstrap
 bootstrap-with-docker: generate-version-file ## Setup environment to run app commands
-	docker build --build-arg BASE_IMAGE=base -f docker/Dockerfile --target test -t notifications-template-preview .
+	docker build -f docker/Dockerfile --target test -t notifications-template-preview .
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask in Docker container
@@ -75,4 +75,4 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} --target=production .
+	docker buildx build --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} --target=production .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-template-preview:base
 FROM python:3.11-slim-bullseye as base
 
 ENV PYTHONUNBUFFERED=1
@@ -35,7 +34,7 @@ RUN rm /etc/ImageMagick-6/policy.xml && cp ./policy.xml /etc/ImageMagick-6/polic
 WORKDIR /home/vcap/app
 
 ##### Python Build Image #####################################################
-FROM ${BASE_IMAGE} AS python_build
+FROM base AS python_build
 
 RUN echo "Install OS dependencies for python app requirements" && apt-get update && \
     apt-get upgrade -y && \
@@ -57,7 +56,7 @@ COPY . .
 RUN make generate-version-file  # This file gets copied across
 
 ##### Production Image #######################################################
-FROM ${BASE_IMAGE} as production
+FROM base as production
 
 RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap
 USER notify


### PR DESCRIPTION
[Trello card](https://trello.com/c/jzNNwLbO/928-rationalise-the-weird-way-we-handle-base-images-in-our-dockerfiles)

There used to be a Concourse job to build & push the base image to GHCR, but it's long gone and the last push was a long time ago.

I appreciate that this weird setup was probably put in place to speed up image builds, but I don't think it's worth the extra complexity, nor the risk of people accidentally running an unpatched 7 month old image.