### PR TITLE
only try new text algo in the address bounding box

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -722,7 +722,7 @@ def _extract_text_from_page(page, rect):
         extracted_text.append(" ".join(w[4] for w in gwords))
     extracted_text = "\n".join(extracted_text)
 
-    if _get_address_from_get_textwords() != extracted_text:
+    if rect != NOTIFY_TAG_BOUNDING_BOX and _get_address_from_get_textwords() != extracted_text:
         # grouping by paragraph ended up different to grouping by y2. lets just log for now. we might want to swap over
         # in the future but without knowing how much it changes we cant be sure
         current_app.logger.info("Address extraction different between y2 and get_text")


### PR DESCRIPTION
we extract two different bits of text: addresses and the magic first page notify tag

the new function and old function are subtly different: the old algo includes any _words_ where the word bounding box intersects the provided rectangle. the new algo only includes _characters_ that are entirely contained within the provided rectangle (see note 2 in the docs [^1]).

since words going outside arent of the address arent an issue for us since we validate that the address is surrounded by whitespace, lets just limit the logging for now. if we do implement this we'll need to carefully consider how this impacts our bounding boxes and if we need to add a small extra buffer to them

[^1]: https://pymupdf.readthedocs.io/en/latest/page.html#Page.get_text