### PR TITLE
Bump utils to 92.0.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@91.1.2
+# This file was automatically copied from notifications-utils@92.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@91.1.2
+# This file was automatically copied from notifications-utils@92.0.1
 
 [tool.black]
 line-length = 120

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ PyMuPDF==1.24.4
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@91.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@92.0.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ awscrt==0.20.11
     # via botocore
 billiard==4.2.0
     # via celery
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   flask
     #   gds-metrics
@@ -24,7 +24,7 @@ botocore==1.34.129
     #   s3transfer
 brotli==1.0.9
     # via fonttools
-cachetools==5.3.3
+cachetools==5.5.0
     # via notifications-utils
 celery==5.4.0
     # via
@@ -57,7 +57,7 @@ dnspython==2.6.1
     # via eventlet
 eventlet==0.36.1
     # via gunicorn
-flask==3.0.0
+flask==3.1.0
     # via
     #   flask-httpauth
     #   flask-redis
@@ -75,7 +75,7 @@ fonttools==4.41.0
     # via weasyprint
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
@@ -110,7 +110,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3bd28f8696247004f8553ba84596d55d764680d8
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -157,21 +157,21 @@ python-dateutil==2.9.0.post0
     #   celery
 python-json-logger==2.0.7
     # via notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via notifications-utils
 redis==5.0.6
     # via flask-redis
 reportlab==3.6.13
     # via -r requirements.in
-requests==2.32.2
+requests==2.32.3
     # via
     #   govuk-bank-holidays
     #   notifications-utils
 s3transfer==0.10.1
     # via boto3
-segno==1.5.2
+segno==1.6.1
     # via notifications-utils
 sentry-sdk==1.45.0
     # via -r requirements.in
@@ -214,7 +214,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via flask
 zopfli==0.2.2
     # via fonttools

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -20,7 +20,7 @@ billiard==4.2.0
     #   celery
 black==24.10.0
     # via -r requirements_for_test_common.in
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -r requirements.txt
     #   flask
@@ -40,7 +40,7 @@ brotli==1.0.9
     # via
     #   -r requirements.txt
     #   fonttools
-cachetools==5.3.3
+cachetools==5.5.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -99,7 +99,7 @@ eventlet==0.36.1
     #   gunicorn
 execnet==2.1.1
     # via pytest-xdist
-flask==3.0.0
+flask==3.1.0
     # via
     #   -r requirements.txt
     #   flask-httpauth
@@ -123,7 +123,7 @@ freezegun==1.5.1
     # via -r requirements_for_test_common.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.txt
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -180,7 +180,7 @@ moto==4.1.5
     # via -r requirements_for_test.in
 mypy-extensions==1.0.0
     # via black
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@3bd28f8696247004f8553ba84596d55d764680d8
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@9d8b26f172643484612c4572c9ae72a41e262916
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -272,11 +272,11 @@ python-json-logger==2.0.7
     # via
     #   -r requirements.txt
     #   notifications-utils
-pytz==2024.1
+pytz==2024.2
     # via
     #   -r requirements.txt
     #   notifications-utils
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.txt
     #   moto
@@ -288,7 +288,7 @@ redis==5.0.6
     #   flask-redis
 reportlab==3.6.13
     # via -r requirements.txt
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements.txt
     #   govuk-bank-holidays
@@ -306,7 +306,7 @@ s3transfer==0.10.1
     # via
     #   -r requirements.txt
     #   boto3
-segno==1.5.2
+segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -365,7 +365,7 @@ webencodings==0.5.1
     #   cssselect2
     #   html5lib
     #   tinycss2
-werkzeug==3.0.6
+werkzeug==3.1.3
     # via
     #   -r requirements.txt
     #   flask

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@91.1.2
+# This file was automatically copied from notifications-utils@92.0.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4


### PR DESCRIPTION
 ## 92.0.1

* Bumps core dependencies to latest versions

 ## 92.0.0

* Restores old validation code so later utils changes can be added to api, admin etc.

 ## 91.1.2

* Adds rule N804 (invalid-first-argument-name-for-class-method) to linter config

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/91.1.2...92.0.1