### PR TITLE
Bump utils to 95.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ PyMuPDF==1.24.4
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@94.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -175,7 +175,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==4.1.5
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d6311c3ab83b8225265277f781157c48f9318ae9
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@361486ff4960b5d02c162118b1fd64b097f9cb96
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@94.0.1
+# This file was automatically copied from notifications-utils@95.1.1
 
 exclude = [
     "migrations/versions/",
@@ -31,5 +31,6 @@ select = [
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
     "N804",  # First argument of a class method should be named `cls`
+    "RUF100",  # Checks for noqa directives that are no longer applicable
 ]
 ignore = []

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -493,7 +493,7 @@ def test_remove_folder_from_filename(filename, expected_filename):
 @pytest.mark.parametrize("include_notify_tag", (True, False))
 def test_create_pdf_for_letter_notify_tagging(client, include_notify_tag):
     pdf = _create_pdf_for_letter(
-        task=None,  # noqa
+        task=None,
         letter_details={
             "template": {"template_type": "letter", "subject": "subject", "content": "content"},
             "values": {},


### PR DESCRIPTION
## 95.1.1

* Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)

 ## 95.1.0

* Adds log message and statsd metric for retried celery tasks

 ## 95.0.0

* Reverts 92.0.0 to restore new validation code

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/94.0.1...95.1.1