### PR TITLE
Fix casing in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye as base
+FROM python:3.11-slim-bullseye AS base
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /uvx /bin/
 
@@ -61,7 +61,7 @@ COPY . .
 RUN make generate-version-file  # This file gets copied across
 
 ##### Production Image #######################################################
-FROM base as production
+FROM base AS production
 
 RUN groupadd -r notify && useradd -r -g notify notify && chown -R notify:notify /home/vcap
 USER notify
@@ -80,7 +80,7 @@ RUN python -m compileall .
 ENTRYPOINT [ "/home/vcap/app/entrypoint.sh" ]
 
 ##### Test Image ##############################################################
-FROM production as test
+FROM production AS test
 
 USER root
 RUN echo "Install OS dependencies for test build" && apt-get update && \


### PR DESCRIPTION
To fix this issue, seen when runing the container:

```bash
FromAsCasing: 'as' and 'FROM' keywords' casing do not match
```