### PR TITLE
[bug fix] Only show barcode on first page of letter preview

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -113,7 +113,7 @@ def copy_s3_object(source_bucket, source_filename, target_bucket, target_filenam
 
 
 def _create_pdf_for_letter(
-    task: Task, letter_details, language: Literal["english", "welsh"], include_notify_tag: bool = True
+    task: Task, letter_details, language: Literal["english", "welsh"], includes_first_page: bool = True
 ):
     logo_filename = f"{letter_details['logo_filename']}.svg" if letter_details["logo_filename"] else None
     template = LetterPrintTemplate(
@@ -124,7 +124,7 @@ def _create_pdf_for_letter(
         admin_base_url=current_app.config["LETTER_LOGO_URL"],
         logo_file_name=logo_filename,
         language=language,
-        include_notify_tag=include_notify_tag,
+        includes_first_page=includes_first_page,
     )
     with current_app.test_request_context(""):
         html = HTML(string=str(template))
@@ -206,8 +206,8 @@ def create_pdf_for_templated_letter(self: Task, encoded_letter_data):
 
 
 def _prepare_pdf(letter_details, self):
-    def create_pdf_for_letter(letter_details, language, include_tag) -> BytesIO:
-        return _create_pdf_for_letter(self, letter_details, language=language, include_notify_tag=include_tag)
+    def create_pdf_for_letter(letter_details, language, includes_first_page) -> BytesIO:
+        return _create_pdf_for_letter(self, letter_details, language=language, includes_first_page=includes_first_page)
 
     purpose = PDFPurpose.PRINT
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -134,8 +134,8 @@ def view_letter_template_pdf():
 
 
 def prepare_pdf(letter_details):
-    def create_pdf_for_letter(letter_details, language, include_tag=True) -> BytesIO:
-        return _get_pdf_from_letter_json(letter_details, language=language, includes_first_page=include_tag)
+    def create_pdf_for_letter(letter_details, language, includes_first_page=True) -> BytesIO:
+        return _get_pdf_from_letter_json(letter_details, language=language, includes_first_page=includes_first_page)
 
     purpose = PDFPurpose.PREVIEW
 

--- a/app/preview.py
+++ b/app/preview.py
@@ -134,8 +134,8 @@ def view_letter_template_pdf():
 
 
 def prepare_pdf(letter_details):
-    def create_pdf_for_letter(letter_details, language, include_tag) -> BytesIO:
-        return _get_pdf_from_letter_json(letter_details, language=language)
+    def create_pdf_for_letter(letter_details, language, include_tag=True) -> BytesIO:
+        return _get_pdf_from_letter_json(letter_details, language=language, includes_first_page=include_tag)
 
     purpose = PDFPurpose.PREVIEW
 
@@ -194,12 +194,12 @@ def view_letter_attachment_preview():
     )
 
 
-def _get_pdf_from_letter_json(letter_json, language="english") -> BytesIO:
-    html = get_html(letter_json, language=language)
+def _get_pdf_from_letter_json(letter_json, language="english", includes_first_page=True) -> BytesIO:
+    html = get_html(letter_json, language=language, includes_first_page=includes_first_page)
     return get_pdf(html)
 
 
-def get_html(json, language="english"):
+def get_html(json, language="english", includes_first_page=True):
     branding_filename = f"{json['filename']}.svg" if json["filename"] else None
 
     return str(
@@ -212,6 +212,7 @@ def get_html(json, language="english"):
             logo_file_name=branding_filename,
             date=dateutil.parser.parse(json["date"]) if json.get("date") else None,
             language=language,
+            includes_first_page=includes_first_page,
         )
     )
 

--- a/app/templated.py
+++ b/app/templated.py
@@ -11,15 +11,15 @@ def generate_templated_pdf(
 ):
     # todo: remove `.get()` when all celery tasks are sending this key
     if letter_details["template"].get("letter_languages") == "welsh_then_english":
-        welsh_pdf = create_pdf_lambda(letter_details, language="welsh", include_tag=True)
-        english_pdf = create_pdf_lambda(letter_details, language="english", include_tag=False)
+        welsh_pdf = create_pdf_lambda(letter_details, language="welsh", includes_first_page=True)
+        english_pdf = create_pdf_lambda(letter_details, language="english", includes_first_page=False)
 
         pdf = stitch_pdfs(
             first_pdf=welsh_pdf,
             second_pdf=english_pdf,
         )
     else:
-        pdf = create_pdf_lambda(letter_details, language="english", include_tag=True)
+        pdf = create_pdf_lambda(letter_details, language="english", includes_first_page=True)
 
     if purpose == PDFPurpose.PRINT:
         pdf = convert_pdf_to_cmyk(pdf)

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ PyMuPDF==1.24.4
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@95.1.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -110,7 +110,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@1b1d0ef1a52f7298685719e705ba4671e5338bf3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a82c8541b709a735ed11b49fea92d99216d98c1d
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -175,7 +175,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==4.1.5
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@1b1d0ef1a52f7298685719e705ba4671e5338bf3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a82c8541b709a735ed11b49fea92d99216d98c1d
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@95.1.2
+# This file was automatically copied from notifications-utils@97.0.0
 
 exclude = [
     "migrations/versions/",

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -242,8 +242,8 @@ def test_create_pdf_for_templated_letter_includes_welsh_pages_if_provided(
     )
 
     assert mock_create_pdf.call_args_list == [
-        mocker.call(mocker.ANY, mocker.ANY, language="welsh", include_notify_tag=True),
-        mocker.call(mocker.ANY, mocker.ANY, language="english", include_notify_tag=False),
+        mocker.call(mocker.ANY, mocker.ANY, language="welsh", includes_first_page=True),
+        mocker.call(mocker.ANY, mocker.ANY, language="english", includes_first_page=False),
     ]
 
     assert not any(r.levelname == "ERROR" for r in caplog.records)
@@ -490,8 +490,8 @@ def test_remove_folder_from_filename(filename, expected_filename):
     assert actual_filename == expected_filename
 
 
-@pytest.mark.parametrize("include_notify_tag", (True, False))
-def test_create_pdf_for_letter_notify_tagging(client, include_notify_tag):
+@pytest.mark.parametrize("includes_first_page", (True, False))
+def test_create_pdf_for_letter_notify_tagging(client, includes_first_page):
     pdf = _create_pdf_for_letter(
         task=None,
         letter_details={
@@ -501,7 +501,7 @@ def test_create_pdf_for_letter_notify_tagging(client, include_notify_tag):
             "logo_filename": "",
         },
         language="english",
-        include_notify_tag=include_notify_tag,
+        includes_first_page=includes_first_page,
     )
 
-    assert ("NOTIFY" in PdfReader(pdf).pages[0].extract_text()) is include_notify_tag
+    assert ("NOTIFY" in PdfReader(pdf).pages[0].extract_text()) is includes_first_page

--- a/tests/test_preview/test_preview_templated.py
+++ b/tests/test_preview/test_preview_templated.py
@@ -120,7 +120,7 @@ def test_get_pdf_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/d0a9992bafc3669a8104aec93d89e4bc7dca4cb1.pdf"
+    expected_cache_key = "templated/2cc1a7bd86ac0ff804385f2517814f253904f096.pdf"
     resp = view_letter_template_pdf()
 
     assert resp.status_code == 200
@@ -557,6 +557,7 @@ def test_letter_template_constructed_properly_for_pdf(view_letter_template_reque
         logo_file_name="hm-government.svg",
         date=None,
         language="english",
+        includes_first_page=True,
     )
 
 
@@ -709,7 +710,7 @@ def test_page_count_from_cache(client, auth_header, mocker, mocked_cache_get):
         headers={"Content-type": "application/json", **auth_header},
     )
     assert mocked_cache_get.call_args[0][0] == "test-template-preview-cache"
-    assert mocked_cache_get.call_args[0][1] == "templated/03ba71054b80b0ffc758d3b228784d1bfb8c0ca3.pdf"
+    assert mocked_cache_get.call_args[0][1] == "templated/63587b04d0018ea9012dfb6a67d76d2d55c87ae1.pdf"
     assert response.status_code == 200
     assert json.loads(response.get_data(as_text=True)) == {
         "count": 10,


### PR DESCRIPTION
For bilingual letters, only show the barcodes on the Welsh first page, and not on the English first page - as this is how it will look when printed.

Review commit by commit.

Trello ticket: https://trello.com/c/Hr4MDKlM/152-barcodes-show-on-pages-after-the-1st-on-bilingual-letters

WARNING! Has to be tested with, and can only be merged after this utils PR goes in, and new patch is incorporated into this PR: https://github.com/alphagov/notifications-utils/pull/1203 (tests will fail until this is done, too, so no danger of accidental merge)

How the fix looks like:

|BEFORE|AFTER|
|:---|:---|
|![Screenshot 2025-03-04 at 14 42 34](https://github.com/user-attachments/assets/a11fc90f-2c15-4043-b95f-0e6ecbaf763f)|![Screenshot 2025-03-04 at 14 39 39](https://github.com/user-attachments/assets/784bf017-121c-480b-a898-d52bccb6a4b3)|
