### PR TITLE
Fix Gunicorn import

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,6 +1,6 @@
 import os
 
-from notifications_utils.gunicorn_defaults import set_gunicorn_defaults
+from notifications_utils.gunicorn.defaults import set_gunicorn_defaults
 
 set_gunicorn_defaults(globals())
 


### PR DESCRIPTION
Version 96.0.0 of notifications utils changed its location from `notifications_utils.gunicorn_defaults` to
`notifications_utils.gunicorn.defaults`.