### PR TITLE
log when filesize grows during sanitising

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -89,6 +89,9 @@ LOGO_BOTTOM_FROM_TOP_OF_PAGE = 30.00
 
 A4_HEIGHT_IN_PTS = A4_HEIGHT * mm
 
+MAX_FILESIZE = 2 * 1024 * 1024  # 2MB
+ALLOWED_FILESIZE_INFLATION_PERCENTAGE = 50  # warn if filesize after sanitising has grown by more than 50%
+
 precompiled_blueprint = Blueprint("precompiled_blueprint", __name__)
 
 
@@ -182,6 +185,27 @@ def sanitise_precompiled_letter():
     return jsonify(sanitise_json), status_code
 
 
+def _warn_if_filesize_has_grown(*, orig_filesize: int, new_filesize: int) -> None:
+    orig_kb = orig_filesize / 1024
+    new_kb = new_filesize / 1024
+
+    if new_filesize > MAX_FILESIZE:
+        current_app.logger.error(
+            "template-preview post-sanitise filesize too big: orig_size=%iKb; new_size=%iKb, over max_filesize=%iMb",
+            orig_kb,
+            new_kb,
+            MAX_FILESIZE / 1024 / 1024,
+        )
+
+    elif orig_filesize * (1 + (ALLOWED_FILESIZE_INFLATION_PERCENTAGE / 100)) < new_filesize:
+        current_app.logger.warning(
+            "template-preview post-sanitise filesize too big: orig_size=%iKb; new_size=%iKb, pct_bigger=%i%%",
+            orig_kb,
+            new_kb,
+            (new_filesize / orig_filesize - 1) * 100,
+        )
+
+
 def sanitise_file_contents(encoded_string, *, allow_international_letters, filename, is_an_attachment=False):
     """
     Given a PDF, returns a new PDF that has been sanitised and dvla approved 👍
@@ -213,12 +237,16 @@ def sanitise_file_contents(encoded_string, *, allow_international_letters, filen
                 filename=filename,
             )
 
+        raw_file = file_data.read()
+
+        _warn_if_filesize_has_grown(orig_filesize=len(encoded_string), new_filesize=len(raw_file))
+
         return {
             "recipient_address": recipient_address,
             "page_count": page_count,
             "message": None,
             "invalid_pages": None,
-            "file": base64.b64encode(file_data.read()).decode("utf-8"),
+            "file": base64.b64encode(raw_file).decode("utf-8"),
         }
     # PdfReadError usually happens at pdf_page_count, when we first try to read the PDF.
     except (ValidationFailed, PdfReadError) as error:

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -185,13 +185,17 @@ def sanitise_precompiled_letter():
     return jsonify(sanitise_json), status_code
 
 
-def _warn_if_filesize_has_grown(*, orig_filesize: int, new_filesize: int) -> None:
+def _warn_if_filesize_has_grown(*, orig_filesize: int, new_filesize: int, filename: str) -> None:
     orig_kb = orig_filesize / 1024
     new_kb = new_filesize / 1024
 
     if new_filesize > MAX_FILESIZE:
         current_app.logger.error(
-            "template-preview post-sanitise filesize too big: orig_size=%iKb; new_size=%iKb, over max_filesize=%iMb",
+            (
+                "template-preview post-sanitise filesize too big: "
+                "filename=%s, orig_size=%iKb, new_size=%iKb, over max_filesize=%iMb"
+            ),
+            filename,
             orig_kb,
             new_kb,
             MAX_FILESIZE / 1024 / 1024,
@@ -199,7 +203,11 @@ def _warn_if_filesize_has_grown(*, orig_filesize: int, new_filesize: int) -> Non
 
     elif orig_filesize * (1 + (ALLOWED_FILESIZE_INFLATION_PERCENTAGE / 100)) < new_filesize:
         current_app.logger.warning(
-            "template-preview post-sanitise filesize too big: orig_size=%iKb; new_size=%iKb, pct_bigger=%i%%",
+            (
+                "template-preview post-sanitise filesize too big: "
+                "filename=%s, orig_size=%iKb, new_size=%iKb, pct_bigger=%i%%"
+            ),
+            filename,
             orig_kb,
             new_kb,
             (new_filesize / orig_filesize - 1) * 100,
@@ -239,7 +247,7 @@ def sanitise_file_contents(encoded_string, *, allow_international_letters, filen
 
         raw_file = file_data.read()
 
-        _warn_if_filesize_has_grown(orig_filesize=len(encoded_string), new_filesize=len(raw_file))
+        _warn_if_filesize_has_grown(orig_filesize=len(encoded_string), new_filesize=len(raw_file), filename=filename)
 
         return {
             "recipient_address": recipient_address,

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -847,25 +847,34 @@ def test_sanitise_file_contents_on_pdf_with_no_resources_on_one_of_the_pages_con
             1_024_000,
             1_638_400,
             logging.WARNING,
-            "template-preview post-sanitise filesize too big: orig_size=1000Kb; new_size=1600Kb, pct_bigger=60%",
+            (
+                "template-preview post-sanitise filesize too big: filename=foo.pdf, "
+                "orig_size=1000Kb, new_size=1600Kb, pct_bigger=60%"
+            ),
         ),
         (
             1_024_000,
             2_150_400,
             logging.ERROR,
-            "template-preview post-sanitise filesize too big: orig_size=1000Kb; new_size=2100Kb, over max_filesize=2Mb",
+            (
+                "template-preview post-sanitise filesize too big: filename=foo.pdf, "
+                "orig_size=1000Kb, new_size=2100Kb, over max_filesize=2Mb"
+            ),
         ),
         (
             1_843_200,
             2_150_400,
             logging.ERROR,
-            "template-preview post-sanitise filesize too big: orig_size=1800Kb; new_size=2100Kb, over max_filesize=2Mb",
+            (
+                "template-preview post-sanitise filesize too big: filename=foo.pdf, "
+                "orig_size=1800Kb, new_size=2100Kb, over max_filesize=2Mb"
+            ),
         ),
     ],
 )
 def test_warn_if_filesize_has_grown(client, caplog, orig_filesize, new_filesize, expected_lvl, expected_msg):
     with caplog.at_level(logging.INFO):
-        _warn_if_filesize_has_grown(orig_filesize=orig_filesize, new_filesize=new_filesize)
+        _warn_if_filesize_has_grown(orig_filesize=orig_filesize, new_filesize=new_filesize, filename="foo.pdf")
 
     if not expected_msg:
         assert caplog.records == []


### PR DESCRIPTION
we sometimes see issues where our system inflates the size of precompiled letters and attachments. the api checks that the filesize is below 2mb, but then we sometimes take a good pdf and make it too big at this point, causing technical failures and issues at DVLA which are hard to unpick.

while we work on fixing the underlying issues, here's some logging so we can at least be aware of how much it's happening.

i've set these to error logs if it's over 2mb or warning if it's still in size but did inflate. we might want to tweak these levels later if the logs are either not noisy enough or too noisy