### PR TITLE
Add predefined queue names so celery will not try to create queues

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -8,6 +8,20 @@ class QueueNames:
     LETTERS = "letter-tasks"
     SANITISE_LETTERS = "sanitise-letter-tasks"
 
+    @staticmethod
+    def all_queues():
+        return [
+            QueueNames.LETTERS,
+            QueueNames.SANITISE_LETTERS,
+        ]
+
+    @staticmethod
+    def predefined_queues(prefix, aws_region, aws_account_id):
+        return {
+            f"{prefix}{queue}": {"url": f"https://sqs.{aws_region}.amazonaws.com/{aws_account_id}/{prefix}{queue}"}
+            for queue in QueueNames.all_queues()
+        }
+
 
 class TaskNames:
     PROCESS_SANITISED_LETTER = "process-sanitised-letter"
@@ -24,15 +38,16 @@ class Config:
 
     NOTIFICATION_QUEUE_PREFIX = os.environ.get("NOTIFICATION_QUEUE_PREFIX")
 
+    AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID", "123456789012")
     CELERY = {
         "broker_url": "https://sqs.eu-west-1.amazonaws.com",
         "broker_transport": "sqs",
         "broker_transport_options": {
             "region": AWS_REGION,
-            "visibility_timeout": 310,
             "wait_time_seconds": 20,  # enable long polling, with a wait time of 20 seconds
             "queue_name_prefix": NOTIFICATION_QUEUE_PREFIX,
             "is_secure": True,
+            "predefined_queues": QueueNames.predefined_queues(NOTIFICATION_QUEUE_PREFIX, AWS_REGION, AWS_ACCOUNT_ID),
         },
         "timezone": "Europe/London",
         "worker_max_memory_per_child": 50,
@@ -81,6 +96,13 @@ class Development(Config):
 
     LETTER_LOGO_URL = "https://static-logos.notify.tools/letters"
 
+    CELERY = {
+        **Config.CELERY,
+        "broker_transport_options": {
+            key: value for key, value in Config.CELERY["broker_transport_options"].items() if key != "predefined_queues"
+        },
+    }
+
 
 class Test(Development):
     NOTIFY_ENVIRONMENT = "test"
@@ -93,6 +115,12 @@ class Test(Development):
     SANITISED_LETTER_BUCKET_NAME = "test-letters-sanitise"
     PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME = "test-letters-precompiled-originals-backup"
     LETTER_ATTACHMENT_BUCKET_NAME = "test-letter-attachments"
+    CELERY = {
+        **Config.CELERY,
+        "broker_transport_options": {
+            key: value for key, value in Config.CELERY["broker_transport_options"].items() if key != "predefined_queues"
+        },
+    }
 
 
 configs = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import os
 import pytest
 
 from app import config
+from app.config import QueueNames
 
 
 @pytest.fixture
@@ -28,3 +29,24 @@ def test_load_config(reload_config):
 
     assert os.environ["SECRET_KEY"] == "env"
     assert config.Config.SECRET_KEY == "env"
+
+
+def test_predefined_queues():
+    prefix = "test-prefix-"
+    aws_region = "eu-west-1"
+    aws_account_id = "123456789012"
+
+    class_queues = [
+        value for key, value in vars(QueueNames).items() if not key.startswith("_") and isinstance(value, str)
+    ]
+    predefined_queues = QueueNames.predefined_queues(prefix, aws_region, aws_account_id)
+
+    assert len(predefined_queues) == len(class_queues)
+
+    for queue_name in class_queues:
+        full_queue_name = f"{prefix}{queue_name}"
+        assert full_queue_name in predefined_queues
+        assert (
+            predefined_queues[full_queue_name]["url"]
+            == f"https://sqs.{aws_region}.amazonaws.com/{aws_account_id}/{full_queue_name}"
+        )


### PR DESCRIPTION
https://trello.com/c/joBsPfMJ/955-move-sqs-queue-creation-into-terraform-and-clean-up-old-queues

What
----

Add predefined queue names so celery will not try to create queues

Why
----

We want all queues to be created and managed through terraform

Note
----

This change should not be merged before [this pr](https://github.com/alphagov/notifications-aws/pull/2564).