### PR TITLE
Bump Gunicorn to 23.0.0 and eventlet to 0.39.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ cssselect2==0.6.0
     # via weasyprint
 dnspython==2.6.1
     # via eventlet
-eventlet==0.36.1
+eventlet==0.39.1
     # via gunicorn
 flask==3.1.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ govuk-bank-holidays==0.15
     # via notifications-utils
 greenlet==3.0.3
     # via eventlet
-gunicorn==21.2.0
+gunicorn==23.0.0
     # via notifications-utils
 html5lib==1.1
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -90,7 +90,7 @@ dnspython==2.6.1
     # via
     #   -r requirements.txt
     #   eventlet
-eventlet==0.36.1
+eventlet==0.39.1
     # via
     #   -r requirements.txt
     #   gunicorn

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -128,7 +128,7 @@ greenlet==3.0.3
     # via
     #   -r requirements.txt
     #   eventlet
-gunicorn==21.2.0
+gunicorn==23.0.0
     # via
     #   -r requirements.txt
     #   notifications-utils


### PR DESCRIPTION
Fixes CVE-2024-6827

Matches what we are running in the API:
https://github.com/alphagov/notifications-api/blob/4f2cec89f216af57dd92d070fa07788df71b6131/requirements.in#L10-L11