### PR TITLE
Bump utils to 99.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ PyMuPDF==1.24.4
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@97.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.1.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   flask
     #   notifications-utils
@@ -110,7 +110,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a82c8541b709a735ed11b49fea92d99216d98c1d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -147,7 +147,7 @@ itsdangerous==2.2.0
     #   -r requirements.txt
     #   flask
     #   notifications-utils
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements.txt
     #   flask
@@ -175,7 +175,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==4.1.5
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a82c8541b709a735ed11b49fea92d99216d98c1d
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@97.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,8 @@
-# This file was automatically copied from notifications-utils@97.0.0
+# This file was automatically copied from notifications-utils@99.1.0
 
-exclude = [
+extend-exclude = [
     "migrations/versions/",
-    "venv*",
     "__pycache__",
-    "node_modules",
     "cache",
     "migrations",
     "build",


### PR DESCRIPTION
Fixes CVE-2025-27516

***

 ## 99.1.0

* Adds support for economy mail in get_min_and_max_days_in_transit, with delivery estimated between 2 and 6 days

 ## 99.0.0

* NOTABLE CHANGE: Celery tasks emit an "early" log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument `early_log_level=logging.DEBUG` to the task decorator of your most heavily-called tasks to reduce the effect on log volume
* Annotates automatic celery task log messages with `celery_task_id`

 ## 98.0.1

* Moves from `setup.py` to `pyproject.toml` for package configuation
* Changes ruff config from `exclude` to `extend-exclude`

 ## 98.0.0

* Update rate multipliers for international SMS to have values for 1 April 2025 onwards. When used in notifications-api and notifications-admin this change will affect the billing of text messages the pricing shown.

 ## 97.0.5

* Fix mailto: URLs in Markdown links

 ## 97.0.4

* Fix inset text block styling

 ## 97.0.3

* Bump minimum jinja2 version to 3.1.6

 ## 97.0.2

* Fix external link redirect

 ## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/97.0.0...99.1.0