### PR TITLE
Bump Sentry SDK to 1.45.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ celery[sqs]==5.4.0
 jsonschema==4.15.0
 Flask-WeasyPrint==1.0.0
 Flask-HTTPAuth==4.8.0
-sentry-sdk[flask,celery]>=1.0.0,<2.0.0
+sentry-sdk[flask,celery]==1.45.1
 
 # pdf libraries
 html5lib==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -173,7 +173,7 @@ s3transfer==0.10.1
     # via boto3
 segno==1.6.1
     # via notifications-utils
-sentry-sdk==1.45.0
+sentry-sdk==1.45.1
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -300,7 +300,7 @@ segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
-sentry-sdk==1.45.0
+sentry-sdk==1.45.1
     # via -r requirements.txt
 six==1.16.0
     # via


### PR DESCRIPTION
Fixes GHSA-g92j-qhmh-64v2

Not something that likely affects us, but clears down another Dependabot warning.

This fix was released in sentry-sdk==2.8.0, then also backported to sentry-sdk==1.45.1.

I think we could probably upgrade to Sentry >= 2 without making any changes, but more testing would be needed to validate this. So just going with the backport for now.

Specifying an exact version because that’s our convention.

***

Matches what we’ve already done in https://github.com/alphagov/notifications-admin/pull/5391