### PR TITLE
Bump cffi, greenlet and Pillow to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ certifi==2024.7.4
     # via
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via weasyprint
 charset-normalizer==3.3.2
     # via requests
@@ -77,7 +77,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-greenlet==3.0.3
+greenlet==3.2.2
     # via eventlet
 gunicorn==23.0.0
     # via notifications-utils
@@ -121,7 +121,7 @@ pdf2image==1.12.1
     # via -r requirements.in
 phonenumbers==8.13.51
     # via notifications-utils
-pillow==9.3.0
+pillow==11.2.1
     # via
     #   pdf2image
     #   reportlab

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -49,7 +49,7 @@ certifi==2024.7.4
     #   -r requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r requirements.txt
     #   cryptography
@@ -124,7 +124,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-greenlet==3.0.3
+greenlet==3.2.2
     # via
     #   -r requirements.txt
     #   eventlet
@@ -193,7 +193,7 @@ phonenumbers==8.13.51
     # via
     #   -r requirements.txt
     #   notifications-utils
-pillow==9.3.0
+pillow==11.2.1
     # via
     #   -r requirements.txt
     #   pdf2image


### PR DESCRIPTION
The versions we are using do not install on newer versions of Python because of the way they are packaged

Closes https://github.com/alphagov/notifications-template-preview/pull/822