### PR TITLE
Fix empty test assertions

### DIFF
--- a/tests/test_letter_attachments.py
+++ b/tests/test_letter_attachments.py
@@ -8,6 +8,6 @@ def test_add_attachment_to_letter(mocker):
     mock_get_attachment = mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=blank_page)
     response = add_attachment_to_letter("1234", (s3_response_body(valid_letter)), {"page_count": 1, "id": "5678"})
 
-    assert mock_get_attachment.called_once_with("1234", {"page_count": 1, "id": "5678"})
+    mock_get_attachment.assert_called_once_with("1234", "5678")
 
     assert get_page_count_for_pdf(response) == 2


### PR DESCRIPTION
`called_once_with` and `called_once` are not methods of `unittest.Mock`.

Instead they are mocked functions which will:
- accept any arguments
- always return something `True`-ish

This means the assertions in these tests are doing nothing, and changing their arguments or the arguments of the methods they are mocking does not cause the tests to fail.

This commit switches to using methods which do exist, and updating the arguments to make the tests pass.