### PR TITLE
Don’t check page exists twice for PNG preview

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -144,15 +144,10 @@ def prepare_pdf(letter_details):
 
 def get_png_preview_for_pdf(pdf, page_number):
     pdf_persist = BytesIO(pdf) if isinstance(pdf, bytes) else BytesIO(pdf.read())
-    templated_letter_page_count = get_page_count_for_pdf(pdf_persist)
-    if page_number <= templated_letter_page_count:
-        pdf_persist.seek(0)  # pdf was read to get page count, so we have to rewind it
-        png_preview = get_png(
-            pdf_persist,
-            page_number,
-        )
-    else:
-        abort(400, f"Letter does not have a page {page_number}")
+    png_preview = get_png(
+        pdf_persist,
+        page_number,
+    )
     return send_file(
         path_or_file=png_preview,
         mimetype="image/png",


### PR DESCRIPTION
The `png_from_pdf` function checks that the requested page exists: https://github.com/alphagov/notifications-template-preview/blob/f3f3051071b8ef3d7ae11e39e044bf5c0e2aabb2/app/preview.py#L37-L40

We make the same check further up the stack here: https://github.com/alphagov/notifications-template-preview/blob/f3f3051071b8ef3d7ae11e39e044bf5c0e2aabb2/app/preview.py#L147-L155

`get_page_count_for_pdf` is slow as shit:
<img width="813" alt="image" src="https://github.com/user-attachments/assets/fb47c17b-0e54-44c4-97f2-e13088123574" />

So let’s not do that.