### PR TITLE
Cache individual pages better

### DIFF
--- a/app/preview.py
+++ b/app/preview.py
@@ -102,7 +102,15 @@ def view_letter_template_png():
     pdf = prepare_pdf(json)
     # get pdf that can be read multiple times - unlike StreamingBody from boto that can only be read once
     requested_page = int(request.args.get("page", 1))
-    return get_png_preview_for_pdf(pdf, page_number=requested_page)
+    pdf_persist = BytesIO(pdf) if isinstance(pdf, bytes) else BytesIO(pdf.read())
+    png_preview = get_png(
+        pdf_persist,
+        requested_page,
+    )
+    return send_file(
+        path_or_file=png_preview,
+        mimetype="image/png",
+    )
 
 
 @preview_blueprint.route("/preview.pdf", methods=["POST"])
@@ -141,18 +149,6 @@ def prepare_pdf(letter_details):
     purpose = PDFPurpose.PREVIEW
 
     return generate_templated_pdf(letter_details, create_pdf_for_letter, purpose)
-
-
-def get_png_preview_for_pdf(pdf, page_number):
-    pdf_persist = BytesIO(pdf) if isinstance(pdf, bytes) else BytesIO(pdf.read())
-    png_preview = get_png(
-        pdf_persist,
-        page_number,
-    )
-    return send_file(
-        path_or_file=png_preview,
-        mimetype="image/png",
-    )
 
 
 @preview_blueprint.route("/letter_attachment_preview.png", methods=["POST"])

--- a/tests/test_preview/test_preview_precompiled.py
+++ b/tests/test_preview/test_preview_precompiled.py
@@ -79,13 +79,13 @@ def test_precompiled_pdf_caches_png_to_s3(
     assert response.get_data().startswith(b"\x89PNG")
     mocked_cache_get.assert_called_once_with(
         "test-template-preview-cache",
-        "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png",
+        "pngs/6ea9d4e6a58736a3f16238ba8553e09bb87b79ed.png",
     )
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == response.get_data()
     assert mocked_cache_set.call_args[0][1] == "eu-west-1"
     assert mocked_cache_set.call_args[0][2] == "test-template-preview-cache"
-    assert mocked_cache_set.call_args[0][3] == "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png"
+    assert mocked_cache_set.call_args[0][3] == "pngs/6ea9d4e6a58736a3f16238ba8553e09bb87b79ed.png"
 
 
 def test_precompiled_pdf_returns_png_from_cache(
@@ -109,7 +109,7 @@ def test_precompiled_pdf_returns_png_from_cache(
     assert response.get_data() == b"\x00"
     mocked_cache_get.assert_called_once_with(
         "test-template-preview-cache",
-        "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png",
+        "pngs/6ea9d4e6a58736a3f16238ba8553e09bb87b79ed.png",
     )
     assert mocked_cache_set.call_args_list == []
 

--- a/tests/test_preview/test_preview_precompiled.py
+++ b/tests/test_preview/test_preview_precompiled.py
@@ -79,13 +79,13 @@ def test_precompiled_pdf_caches_png_to_s3(
     assert response.get_data().startswith(b"\x89PNG")
     mocked_cache_get.assert_called_once_with(
         "test-template-preview-cache",
-        "precompiled/f9094f49cd156f0a5fb5082820fa4f396e082d88.page01.png",
+        "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png",
     )
     mocked_cache_set.call_args[0][0].seek(0)
     assert mocked_cache_set.call_args[0][0].read() == response.get_data()
     assert mocked_cache_set.call_args[0][1] == "eu-west-1"
     assert mocked_cache_set.call_args[0][2] == "test-template-preview-cache"
-    assert mocked_cache_set.call_args[0][3] == "precompiled/f9094f49cd156f0a5fb5082820fa4f396e082d88.page01.png"
+    assert mocked_cache_set.call_args[0][3] == "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png"
 
 
 def test_precompiled_pdf_returns_png_from_cache(
@@ -109,7 +109,7 @@ def test_precompiled_pdf_returns_png_from_cache(
     assert response.get_data() == b"\x00"
     mocked_cache_get.assert_called_once_with(
         "test-template-preview-cache",
-        "precompiled/f9094f49cd156f0a5fb5082820fa4f396e082d88.page01.png",
+        "pngs/22cc37e85bc1180251cc725b31395c894ee3e908.page01.png",
     )
     assert mocked_cache_set.call_args_list == []
 

--- a/tests/test_preview/test_preview_templated.py
+++ b/tests/test_preview/test_preview_templated.py
@@ -143,7 +143,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "templated/cfa8aaad30c73e8c98fcf09a29ac6523a624fe00.page01.png"
+    expected_cache_key = "pngs/cfa8aaad30c73e8c98fcf09a29ac6523a624fe00.page01.png"
     resp = view_letter_template_png()
 
     assert resp.status_code == 200

--- a/tests/test_preview/test_preview_templated.py
+++ b/tests/test_preview/test_preview_templated.py
@@ -143,7 +143,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "pngs/cfa8aaad30c73e8c98fcf09a29ac6523a624fe00.page01.png"
+    expected_cache_key = "pngs/b5e1c6f69a3e9dcce0eba4aad26d4037dff076a3.png"
     resp = view_letter_template_png()
 
     assert resp.status_code == 200
@@ -186,7 +186,7 @@ def test_get_png_caches_with_correct_keys(
         ),
         # both pdf and png found in cache
         (
-            [s3_response_body(), s3_response_body()],
+            [s3_response_body(valid_letter), s3_response_body()],
             2,
             0,
         ),


### PR DESCRIPTION
This pull request changes how we cache images of letter pages.

# Before

The cache key looked like:

> hash([contents of pdf] + [page number n])

Even the smallest change to the contents of the PDF would invalidate the cache for all images. For example filling in the address on page 1 meant page 10 would need to be re-rendered.

# After 

> hash([contents of page n])

The cache is only invalidated for pages which have changed. If editing something on page 1 doesn’t cause a reflow, page 10 is still cached.

***

This is especially advantageous where we have letters with attachments. Attachments are static, but they often contain graphics which are slow to render to PNGs.

Extracting the page content is work we have to do anyway in the case of a cache miss. In the case of a cache hit I estimate extracting and hashing a page will add about 150ms. This performance decrease is offset by the increased likelihood of a page being cached. It should also mean the simultaneous load on template preview is reduced when someone is clicking through and filling out the personalisation in a letter.
 
