### PR TITLE
Wrap S3 with an in-memory cache

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -150,7 +150,7 @@ def create_pdf_for_templated_letter(self: Task, encoded_letter_data):
 
     cmyk_pdf = _prepare_pdf(letter_details, self)
 
-    page_count = get_page_count_for_pdf(cmyk_pdf.read())
+    page_count = get_page_count_for_pdf(cmyk_pdf)
     cmyk_pdf.seek(0)
     try:
         # If the file already exists in S3, it will be overwritten

--- a/app/templated.py
+++ b/app/templated.py
@@ -23,6 +23,7 @@ def generate_templated_pdf(
 
     if purpose == PDFPurpose.PRINT:
         pdf = convert_pdf_to_cmyk(pdf)
+        pdf.seek(0)
 
     # Letter attachments are passed through `/precompiled/sanitise` endpoint, so already in CMYK.
     if letter_attachment := letter_details["template"].get("letter_attachment"):

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -290,7 +290,7 @@ def test_create_pdf_for_templated_letter_errors_if_attachment_pushes_over_page_c
     data_for_create_pdf_for_templated_letter_task,
 ):
     # try stitching a 10 page attachment to a 1 page template
-    mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=multi_page_pdf)
+    mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=BytesIO(multi_page_pdf))
     mock_upload = mocker.patch("app.celery.tasks.s3upload")
     mock_celery = mocker.patch("app.celery.tasks.notify_celery.send_task")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def auth_header():
 
 @pytest.fixture(autouse=True)
 def mocked_cache_get(mocker):
-    return mocker.patch("app.s3download", side_effect=S3ObjectNotFound({}, ""))
+    return mocker.patch("app.caching_s3download", side_effect=S3ObjectNotFound({}, ""))
 
 
 @pytest.fixture(autouse=True)
@@ -134,3 +134,7 @@ def set_config(app, name, value):
 
 def s3_response_body(data: bytes = b"\x00"):
     return StreamingBody(BytesIO(data), len(data))
+
+
+def cache_response_body(data: bytes = b"\x00"):
+    return BytesIO(s3_response_body(data).read())

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,77 @@
+from unittest.mock import call
+
+import pytest
+from notifications_utils.s3 import S3ObjectNotFound
+
+from app.utils import caching_s3download
+from tests.conftest import s3_response_body
+
+
+def test_cache_only_makes_1_call_to_s3(mocker):
+    mock_s3download = mocker.patch("app.utils.s3download", return_value=s3_response_body())
+
+    for _ in range(3):
+        assert caching_s3download("foo", "bar").read() == b"\x00"  # Same bytes exactly
+
+    assert mock_s3download.call_args_list == [
+        call("foo", "bar"),
+    ]
+
+
+def test_cache_respects_different_keys(mocker):
+    mock_s3download = mocker.patch(
+        "app.utils.s3download",
+        side_effect=[
+            s3_response_body(b"a"),
+            s3_response_body(b"b"),
+            s3_response_body(b"c"),
+        ],
+    )
+
+    for i, a in enumerate((b"a", b"b", b"c")):
+        assert caching_s3download("foo", i).read() == a
+
+    assert mock_s3download.call_args_list == [
+        call("foo", 0),
+        call("foo", 1),
+        call("foo", 2),
+    ]
+
+
+def test_cache_respects_different_buckets(mocker):
+    mock_s3download = mocker.patch(
+        "app.utils.s3download",
+        side_effect=[
+            s3_response_body(b"foo"),
+            s3_response_body(b"bar"),
+            s3_response_body(b"baz"),
+        ],
+    )
+
+    for bucket in ("foo", "bar", "baz"):
+        assert caching_s3download(bucket, "same").read().decode() == bucket
+
+    assert mock_s3download.call_args_list == [
+        call("foo", "same"),
+        call("bar", "same"),
+        call("baz", "same"),
+    ]
+
+
+def test_cache_doesnt_cache_exceptions(mocker):
+    mock_s3download = mocker.patch(
+        "app.utils.s3download",
+        side_effect=[
+            S3ObjectNotFound({}, ""),
+            S3ObjectNotFound({}, ""),
+        ],
+    )
+
+    for _ in range(2):
+        with pytest.raises(S3ObjectNotFound):
+            caching_s3download("nope", "nope")
+
+    assert mock_s3download.call_args_list == [
+        call("nope", "nope"),
+        call("nope", "nope"),
+    ]

--- a/tests/test_letter_attachments.py
+++ b/tests/test_letter_attachments.py
@@ -1,13 +1,14 @@
+from io import BytesIO
+
 from app.letter_attachments import add_attachment_to_letter
 from app.preview import get_page_count_for_pdf
-from tests.conftest import s3_response_body
 from tests.pdf_consts import blank_page, valid_letter
 
 
 def test_add_attachment_to_letter(mocker):
-    mock_get_attachment = mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=blank_page)
-    response = add_attachment_to_letter("1234", (s3_response_body(valid_letter)), {"page_count": 1, "id": "5678"})
+    mock_get_attachment = mocker.patch("app.letter_attachments.get_attachment_pdf", return_value=BytesIO(blank_page))
+    response = add_attachment_to_letter("1234", BytesIO(valid_letter), {"page_count": 1, "id": "5678"})
 
     mock_get_attachment.assert_called_once_with("1234", "5678")
 
-    assert get_page_count_for_pdf(response.read()) == 2
+    assert get_page_count_for_pdf(BytesIO(response.read())) == 2


### PR DESCRIPTION
Once we put an attachment or cached PDF in S3 we never modify it. A new attachment or changes to a letter always results in a new cache object with a new key.

Each call to S3 takes ~50ms in production.

For viewing a 10 page letter in the admin app we need to:
- get the PDF to count the pages (1)
- get the PDF to extract each page to turn into a PNG (10)

That’s a total of 11 calls to S3 for the exact same PDF data.

Another case would be filling out the personalisation for a letter with an attachment. For each piece of personalisation we need to fetch the attachment PDF to merge it with the newly-generated templated letter before we cache the whole lot. So for a letter with 5 pieces of personalisation, that’s 5 repeated calls to S3 in fairly quick succession.

This commit puts an in-memory cache around calls to S3. So calls for the same object have a better chance of not going out to the network. 

***

It’s hard to know how effective this is without instrumentation.

Given 3 ECS tasks and 4 processes per task on production we think that means 12 separate caches.

With some simple modelling my guess is if you make 10 requests for the same thing in fairly quick succession you’ll have, on average, a 20% hit rate on the in-memory cache, with no performance penalty for a cache miss.

***

I’ve put the size of the cache at 500 items. Given a maximum PDF size of 2Mb (the most we allow for an attachment) this gives a worst-case cache size of 1Gb. I don’t know how much memory each worker has but they are only using about 10% of it at the moment:

<img width="703" alt="image" src="https://github.com/user-attachments/assets/4119120e-6264-40c7-8f9c-0ce3eff5e733" />

***

Some typical request times from the browser console for loading a single PNG running locally. This exaggerates the improvement because my laptop isn’t very close to the S3 server. 

With memory cache (this branch) | Without memory cache (`main`)
---|---
61ms | 965ms
42ms | 743ms
71ms | 955ms
23ms | 935ms
55ms | 772ms