### PR TITLE
Increase size of in-memory S3 cache

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -30,6 +30,6 @@ def caching_s3download(bucket_name, filename) -> BytesIO:
     return BytesIO(b64decode(cached))
 
 
-@lru_cache(maxsize=500)
+@lru_cache(maxsize=2_000)
 def _cached_s3_download(bucket_name, filename):
     return b64encode(s3download(bucket_name, filename).read())


### PR DESCRIPTION
The biggest objects we put in the cache are 2MB (size of letter attachment or precompiled PDF). In reality most objects are much smaller (for example 100kB for a single page of a templated letter as a PNG).

With 500 objects this results in a worst case cache size of 1GB.

Our instances of `template-preview-web` are configured with 8GB of memory:
https://github.com/alphagov/notifications-aws/blob/ab9716b67cbbb9c89756c60e257ec9a716f8d794/terraform/notify-infra/service_template_preview.tf#L12

The max utilistation we see in Grafana is 12%, or 960MB (most of that will be the app, not the cache):
<img width="705" alt="image" src="https://github.com/user-attachments/assets/50ff816d-2a67-40f2-ac31-fd6a3c23ef6d" />

Increasing the cache size by 4&times; to 2,000 objects gives us a worst case memory usage or 4GB, or not much over 50%. It should give us a much higher chance of a cache hit, thereby increasing performance.