### PR TITLE
chore: bump utils to 100.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ PyMuPDF==1.24.4
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b6f3cf856d6114a296e2b59de603a213ad46220a
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -119,7 +119,7 @@ packaging==24.1
     # via gunicorn
 pdf2image==1.12.1
     # via -r requirements.in
-phonenumbers==8.13.51
+phonenumbers==9.0.10
     # via notifications-utils
 pillow==11.2.1
     # via
@@ -156,6 +156,7 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   celery
+    #   notifications-utils
 python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -176,7 +176,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==4.1.5
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b6f3cf856d6114a296e2b59de603a213ad46220a
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@bb31f41dd194802ced5ea814f84cc25855467234
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -189,7 +189,7 @@ packaging==24.1
     #   pytest
 pdf2image==1.12.1
     # via -r requirements.txt
-phonenumbers==8.13.51
+phonenumbers==9.0.10
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -259,6 +259,7 @@ python-dateutil==2.9.0.post0
     #   celery
     #   freezegun
     #   moto
+    #   notifications-utils
 python-json-logger==3.3.0
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@100.2.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Bump utils to 100.2.0

 ## 100.2.0

* add  fields to pre/post request flask logs

 ## 100.1.0

* Updated  to version 9.0.9 to keep phonenumber metadata uptodate

 ## 100.0.0

*  is now a required argument of  (apps have already been updated)

 ## 99.8.0

* Add new version of GOV.UK brand to email template, behind a flag

 ## 99.7.0

* Update economy letter transit dates to max 8 days

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.6.0...100.2.0