### PR TITLE
Updates the `imagemagick` package to the most stable version `8:6.9.11.60+dfsg-1.3+deb11u6`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install binary app dependencies" \
         libcurl4 \
         curl \
         libpango1.0-dev=1.46.2-3 \
-        imagemagick=8:6.9.11.60+dfsg-1.3+deb11u5 \
+        imagemagick=8:6.9.11.60+dfsg-1.3+deb11u6 \
         libgs9-common=9.53.3~dfsg-7+deb11u7 \
         libgs9=9.53.3~dfsg-7+deb11u7 \
         ghostscript=9.53.3~dfsg-7+deb11u7 \


### PR DESCRIPTION
Updates the `imagemagick` package to the most stable version `8:6.9.11.60+dfsg-1.3+deb11u6`

The current version of `imagemagick` is no longer stable and has security issues. This has been moved to `oldstable-security` on 2025-04-26. Please see: https://tracker.debian.org/news/1641983/accepted-imagemagick-8691160dfsg-13deb11u5-source-into-oldstable-security/

This version (`8:6.9.11.60+dfsg-1.3+deb11u5`) is no longer available in the list of sources: https://qa.debian.org/madison.php?package=imagemagick

The most stable version in the `oldoldstable` versions is `8:6.9.11.60+dfsg-1.3+deb11u6`. See: https://tracker.debian.org/pkg/imagemagick

Suggestion:
Move to the latest stable version (currently: `8:7.1.1.43+dfsg1-1+deb13u1`) as this will provide a longer support window.

Note:
A similar update was done 6 months ago, however, it did not use a stable version: https://github.com/alphagov/notifications-template-preview/commit/65c50ae81a3e6d11f1b1d8416a0f0d5b10b6fcdb