### PR TITLE
Bump Flask-weasyprint to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 #app requirements
 celery[sqs]==5.4.0
 jsonschema==4.15.0
-Flask-WeasyPrint==1.0.0
+Flask-WeasyPrint==1.1.0
 Flask-HTTPAuth==4.8.0
 sentry-sdk[flask,celery]==1.45.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-flask-weasyprint==1.0.0
+flask-weasyprint==1.1.0
     # via -r requirements.in
 fonttools==4.41.0
     # via weasyprint

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -110,7 +110,7 @@ flask-redis==0.4.0
     # via
     #   -r requirements.txt
     #   notifications-utils
-flask-weasyprint==1.0.0
+flask-weasyprint==1.1.0
     # via -r requirements.txt
 fonttools==4.41.0
     # via


### PR DESCRIPTION
Supports newer versions of Python.

Requires Flask >= 2.3.0 and WeasyPrint >= 53.0 (which we already have).