### PR TITLE
Upgrade to Python 3.12

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye AS base
+FROM python:3.12-slim-bullseye AS base
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /uvx /bin/
 


### PR DESCRIPTION
 Python 3.11 will no longer receive security support in 2027.
 Although 3.13 is the latest Python stable version, Python 3.12 is being prefered because it doesn't necessitate
 an upgrade to the later versions of PyMuPDF which currently introduce unexpected behaviour.