### PR TITLE
Set up OpenTelemetry auto-instrumentation for Celery workers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@109.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -9,7 +9,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.11.4'
+  rev: 'v0.15.2'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ PyMuPDF==1.24.11
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@109.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.3.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.in
+++ b/requirements.in
@@ -25,3 +25,22 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@11
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
+
+opentelemetry-distro[otlp]
+opentelemetry-instrumentation-asyncio
+opentelemetry-instrumentation-dbapi
+opentelemetry-instrumentation-logging
+opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-threading
+opentelemetry-instrumentation-urllib
+opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-boto3sqs
+opentelemetry-instrumentation-botocore
+opentelemetry-instrumentation-celery
+opentelemetry-instrumentation-click
+opentelemetry-instrumentation-flask
+opentelemetry-instrumentation-grpc
+opentelemetry-instrumentation-jinja2
+opentelemetry-instrumentation-redis
+opentelemetry-instrumentation-requests
+opentelemetry-instrumentation-urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,10 +81,16 @@ fonttools==4.61.0
     # via weasyprint
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.in
+googleapis-common-protos==1.74.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 govuk-bank-holidays==0.17
     # via notifications-utils
 greenlet==3.2.2
     # via eventlet
+grpcio==1.80.0
+    # via opentelemetry-exporter-otlp-proto-grpc
 gunicorn==25.1.0
     # via notifications-utils
 html5lib==1.1
@@ -126,13 +132,146 @@ mistune==0.8.4
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.in
 opentelemetry-api==1.40.0
-    # via notifications-utils
+    # via
+    #   notifications-utils
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.61b0
+    # via -r requirements.in
+opentelemetry-exporter-otlp==1.40.0
+    # via opentelemetry-distro
+opentelemetry-exporter-otlp-proto-common==1.40.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.40.0
+    # via opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.61b0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-asyncio==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-boto3sqs==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-botocore==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-celery==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-click==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-dbapi==0.61b0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-flask==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-grpc==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-jinja2==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-logging==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-redis==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-requests==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-sqlite3==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-threading==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-urllib==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-urllib3==0.61b0
+    # via -r requirements.in
+opentelemetry-instrumentation-wsgi==0.61b0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-instrumentation-flask
+opentelemetry-propagator-aws-xray==1.0.2
+    # via opentelemetry-instrumentation-botocore
+opentelemetry-proto==1.40.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.40.0
+    # via
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.61b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.61b0
+    # via
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
 ordered-set==4.1.0
     # via notifications-utils
 packaging==24.1
     # via
     #   gunicorn
     #   kombu
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-flask
 pdf2image==1.17.0
     # via -r requirements.in
 phonenumbers==9.0.10
@@ -148,6 +287,10 @@ prometheus-client==0.14.1
     #   gds-metrics
 prompt-toolkit==3.0.47
     # via click-repl
+protobuf==6.33.6
+    # via
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 pycparser==2.21
     # via cffi
 pycurl==7.45.7
@@ -186,6 +329,7 @@ requests==2.32.5
     # via
     #   govuk-bank-holidays
     #   notifications-utils
+    #   opentelemetry-exporter-otlp-proto-http
 rpds-py==0.30.0
     # via
     #   jsonschema
@@ -211,7 +355,12 @@ tinycss2==1.1.1
 typing-extensions==4.15.0
     # via
     #   exceptiongroup
+    #   grpcio
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   referencing
 tzdata==2025.3
     # via kombu
@@ -244,6 +393,18 @@ webencodings==0.5.1
     #   tinycss2
 werkzeug==3.1.6
     # via flask
+wrapt==1.17.3
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
 zipp==3.23.0
     # via importlib-metadata
 zopfli==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,6 +93,8 @@ html5lib==1.1
     #   weasyprint
 idna==3.7
     # via requests
+importlib-metadata==8.7.1
+    # via opentelemetry-api
 itsdangerous==2.2.0
     # via
     #   flask
@@ -121,8 +123,10 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0fc47126305fa1930b427b21d413b363cb3b702b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.in
+opentelemetry-api==1.40.0
+    # via notifications-utils
 ordered-set==4.1.0
     # via notifications-utils
 packaging==24.1
@@ -204,6 +208,11 @@ tinycss2==1.1.1
     # via
     #   cssselect2
     #   weasyprint
+typing-extensions==4.15.0
+    # via
+    #   exceptiongroup
+    #   opentelemetry-api
+    #   referencing
 tzdata==2025.3
     # via kombu
 tzlocal==5.3.1
@@ -235,5 +244,7 @@ webencodings==0.5.1
     #   tinycss2
 werkzeug==3.1.6
     # via flask
+zipp==3.23.0
+    # via importlib-metadata
 zopfli==0.2.2
     # via fonttools

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -126,6 +126,11 @@ freezegun==1.5.1
     # via -r requirements_for_test_common.in
 gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
     # via -r requirements.txt
+googleapis-common-protos==1.74.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
 govuk-bank-holidays==0.17
     # via
     #   -r requirements.txt
@@ -134,6 +139,10 @@ greenlet==3.2.2
     # via
     #   -r requirements.txt
     #   eventlet
+grpcio==1.80.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
 gunicorn==25.1.0
     # via
     #   -r requirements.txt
@@ -196,6 +205,148 @@ opentelemetry-api==1.40.0
     # via
     #   -r requirements.txt
     #   notifications-utils
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-propagator-aws-xray
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-distro==0.61b0
+    # via -r requirements.txt
+opentelemetry-exporter-otlp==1.40.0
+    # via -r requirements.txt
+opentelemetry-exporter-otlp-proto-common==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-grpc==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp
+opentelemetry-instrumentation==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-distro
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-sqlite3
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-asyncio==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-boto3sqs==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-botocore==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-celery==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-click==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-dbapi==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-sqlite3
+opentelemetry-instrumentation-flask==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-grpc==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-jinja2==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-logging==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-redis==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-requests==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-sqlite3==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-threading==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-urllib==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-urllib3==0.61b0
+    # via -r requirements.txt
+opentelemetry-instrumentation-wsgi==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-flask
+opentelemetry-propagator-aws-xray==1.0.2
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-botocore
+opentelemetry-proto==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.40.0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-distro
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-botocore
+    #   opentelemetry-instrumentation-celery
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.61b0
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation-flask
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-urllib
+    #   opentelemetry-instrumentation-urllib3
+    #   opentelemetry-instrumentation-wsgi
 ordered-set==4.1.0
     # via
     #   -r requirements.txt
@@ -205,6 +356,8 @@ packaging==24.1
     #   -r requirements.txt
     #   gunicorn
     #   kombu
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-flask
     #   pytest
 pdf2image==1.17.0
     # via -r requirements.txt
@@ -228,6 +381,11 @@ prompt-toolkit==3.0.47
     # via
     #   -r requirements.txt
     #   click-repl
+protobuf==6.33.6
+    # via
+    #   -r requirements.txt
+    #   googleapis-common-protos
+    #   opentelemetry-proto
 py-partiql-parser==0.6.3
     # via moto
 pycparser==2.21
@@ -300,6 +458,7 @@ requests==2.32.5
     #   govuk-bank-holidays
     #   moto
     #   notifications-utils
+    #   opentelemetry-exporter-otlp-proto-http
     #   requests-mock
     #   responses
 requests-mock==1.12.1
@@ -347,7 +506,12 @@ typing-extensions==4.15.0
     # via
     #   -r requirements.txt
     #   exceptiongroup
+    #   grpcio
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-grpc
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   referencing
 tzdata==2025.3
     # via
@@ -391,6 +555,19 @@ werkzeug==3.1.6
     #   -r requirements.txt
     #   flask
     #   moto
+wrapt==1.17.3
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-asyncio
+    #   opentelemetry-instrumentation-boto3sqs
+    #   opentelemetry-instrumentation-click
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-jinja2
+    #   opentelemetry-instrumentation-redis
+    #   opentelemetry-instrumentation-threading
+    #   opentelemetry-instrumentation-urllib3
 xmltodict==1.0.2
     # via moto
 zipp==3.23.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -146,6 +146,10 @@ idna==3.7
     # via
     #   -r requirements.txt
     #   requests
+importlib-metadata==8.7.1
+    # via
+    #   -r requirements.txt
+    #   opentelemetry-api
 iniconfig==2.3.0
     # via pytest
 itsdangerous==2.2.0
@@ -186,8 +190,12 @@ mistune==0.8.4
     #   notifications-utils
 moto==5.1.18
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@0fc47126305fa1930b427b21d413b363cb3b702b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
     # via -r requirements.txt
+opentelemetry-api==1.40.0
+    # via
+    #   -r requirements.txt
+    #   notifications-utils
 ordered-set==4.1.0
     # via
     #   -r requirements.txt
@@ -303,7 +311,7 @@ rpds-py==0.30.0
     #   -r requirements.txt
     #   jsonschema
     #   referencing
-ruff==0.11.4
+ruff==0.15.2
     # via -r requirements_for_test_common.in
 s3transfer==0.10.1
     # via
@@ -335,6 +343,12 @@ tinycss2==1.1.1
     #   -r requirements.txt
     #   cssselect2
     #   weasyprint
+typing-extensions==4.15.0
+    # via
+    #   -r requirements.txt
+    #   exceptiongroup
+    #   opentelemetry-api
+    #   referencing
 tzdata==2025.3
     # via
     #   -r requirements.txt
@@ -379,6 +393,10 @@ werkzeug==3.1.6
     #   moto
 xmltodict==1.0.2
     # via moto
+zipp==3.23.0
+    # via
+    #   -r requirements.txt
+    #   importlib-metadata
 zopfli==0.2.2
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,12 +1,12 @@
-# This file was automatically copied from notifications-utils@109.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
-beautifulsoup4==4.12.3
-pytest==8.3.4
-pytest-env==1.1.5
-pytest-mock==3.14.0
-pytest-xdist==3.6.1
-pytest-testmon==2.1.1
-requests-mock==1.12.1
-freezegun==1.5.1
+beautifulsoup4
+pytest
+pytest-env
+pytest-mock
+pytest-xdist
+pytest-testmon
+requests-mock
+freezegun
 
-ruff==0.11.4  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.15.2  # Also update `.pre-commit-config.yaml` if this changes

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@109.0.0
+# This file was automatically copied from notifications-utils@113.3.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/run_celery.py
+++ b/run_celery.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
+import os
+
 import notifications_utils.logging.celery as celery_logging
+from celery.signals import worker_process_init
+from notifications_utils.semconv import set_service_instance_id
+from opentelemetry.instrumentation import auto_instrumentation
 
 from app.performance import init_performance_monitoring
 
@@ -11,3 +16,10 @@ from app import notify_celery, create_app  # noqa
 
 application = create_app()
 celery_logging.set_up_logging(application.config)
+
+
+@worker_process_init.connect
+def init_worker(**_) -> None:
+    if os.environ.get("OTEL_SERVICE_NAME") is not None:
+        set_service_instance_id()
+        auto_instrumentation.initialize()

--- a/tests/test_preview/test_preview_templated.py
+++ b/tests/test_preview/test_preview_templated.py
@@ -24,12 +24,10 @@ def view_letter_template_pdf(client, auth_header, view_letter_template_request_d
     resp = view_letter_template_pdf(json={...})
     resp = view_letter_template_pdf(headers={...})
     """
-    return lambda data=view_letter_template_request_data, headers=auth_header: (
-        client.post(
-            url_for("preview_blueprint.view_letter_template_pdf", filetype="pdf"),
-            data=json.dumps(data),
-            headers={"Content-type": "application/json", **headers},
-        )
+    return lambda data=view_letter_template_request_data, headers=auth_header: client.post(
+        url_for("preview_blueprint.view_letter_template_pdf", filetype="pdf"),
+        data=json.dumps(data),
+        headers={"Content-type": "application/json", **headers},
     )
 
 
@@ -43,12 +41,10 @@ def view_letter_template_png(client, auth_header, view_letter_template_request_d
     resp = view_letter_template_png(json={...})
     resp = view_letter_template_png(headers={...})
     """
-    return lambda data=view_letter_template_request_data, headers=auth_header: (
-        client.post(
-            url_for("preview_blueprint.view_letter_template_png"),
-            data=json.dumps(data),
-            headers={"Content-type": "application/json", **headers},
-        )
+    return lambda data=view_letter_template_request_data, headers=auth_header: client.post(
+        url_for("preview_blueprint.view_letter_template_png"),
+        data=json.dumps(data),
+        headers={"Content-type": "application/json", **headers},
     )
 
 
@@ -62,12 +58,10 @@ def view_letter_attachment(client, auth_header, view_letter_template_request_dat
     resp = view_letter_attachment(json={...})
     resp = view_letter_attachment(headers={...})
     """
-    return lambda data=view_letter_template_request_data, headers=auth_header: (
-        client.post(
-            url_for("preview_blueprint.view_letter_attachment_preview"),
-            data=json.dumps(data),
-            headers={"Content-type": "application/json", **headers},
-        )
+    return lambda data=view_letter_template_request_data, headers=auth_header: client.post(
+        url_for("preview_blueprint.view_letter_attachment_preview"),
+        data=json.dumps(data),
+        headers={"Content-type": "application/json", **headers},
     )
 
 


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Sets up OTel auto-instrumentation for Celery workers. This gives us automatic context/baggage propagation as well as a handful of metrics (although the automatic propagation won't work properly until we set up auto-instrumentation for our web apps). By configuring the OTel SDK we also enable the new Celery histogram metrics added in alphagov/notifications-utils#1298.

The newly added metrics follow a different naming convention to the existing StatsD-based ones, and so do not conflict with them.

Tested in dev-b: the new Celery duration metrics are reported correctly, and more importantly the values we're getting for them match the values generated by the existing StatsD instrumentation (`sum(celery_task_duration_seconds_count{celery_task_status="retry"})` == `sum(notify_celery_retry_time_summary_count)` and `sum(celery_task_duration_seconds_count{celery_task_status="failure"})` == `notify_celery_failures_total`).