### PR TITLE
Add `show-outdated-requirements` make command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.3.0
+# This file was automatically copied from notifications-utils@113.6.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ freeze-requirements: ## create static requirements.txt
 	uv pip compile requirements_for_test.in -o requirements_for_test.txt
 	uv pip sync requirements_for_test.txt
 
+.PHONY: show-outdated-requirements
+show-outdated-requirements: ## Audit requirements.in
+	python -c "from notifications_utils.version_tools import show_outdated_requirements; show_outdated_requirements()"
+
 .PHONY: bump-utils
 bump-utils:  # Bump notifications-utils package to latest version
 	python -c "from notifications_utils.version_tools import upgrade_version; upgrade_version()"

--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ PyMuPDF==1.24.11
 WeasyPrint==59
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@113.6.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as 0.7.1 brings significant performance gains
 prometheus-client==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,10 @@ certifi==2024.7.4
     # via
     #   requests
     #   sentry-sdk
-cffi==1.17.1
-    # via weasyprint
+cffi==2.0.0
+    # via
+    #   cryptography
+    #   weasyprint
 charset-normalizer==3.3.2
     # via
     #   reportlab
@@ -55,6 +57,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
+cryptography==46.0.7
+    # via notifications-utils
 cssselect2==0.6.0
     # via weasyprint
 dnspython==2.6.1
@@ -129,7 +133,7 @@ markupsafe==2.1.5
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
     # via -r requirements.in
 opentelemetry-api==1.40.0
     # via
@@ -272,6 +276,7 @@ packaging==24.1
     #   kombu
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-flask
+    #   requirements-parser
 pdf2image==1.17.0
     # via -r requirements.in
 phonenumbers==9.0.10
@@ -330,6 +335,8 @@ requests==2.32.5
     #   govuk-bank-holidays
     #   notifications-utils
     #   opentelemetry-exporter-otlp-proto-http
+requirements-parser==0.13.0
+    # via notifications-utils
 rpds-py==0.30.0
     # via
     #   jsonschema
@@ -354,14 +361,12 @@ tinycss2==1.1.1
     #   weasyprint
 typing-extensions==4.15.0
     # via
-    #   exceptiongroup
     #   grpcio
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-    #   referencing
 tzdata==2025.3
     # via kombu
 tzlocal==5.3.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -50,7 +50,7 @@ certifi==2024.7.4
     #   -r requirements.txt
     #   requests
     #   sentry-sdk
-cffi==1.17.1
+cffi==2.0.0
     # via
     #   -r requirements.txt
     #   cryptography
@@ -82,8 +82,11 @@ click-repl==0.3.0
     #   celery
 coverage==7.13.1
     # via pytest-testmon
-cryptography==45.0.7
-    # via moto
+cryptography==46.0.7
+    # via
+    #   -r requirements.txt
+    #   moto
+    #   notifications-utils
 cssselect2==0.6.0
     # via
     #   -r requirements.txt
@@ -199,7 +202,7 @@ mistune==0.8.4
     #   notifications-utils
 moto==5.1.18
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@58855282da48d522d0639e3f7732027f6ac73ab3
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@c720a3fc2cf724dd6f4c3a0f45dabd87012491b3
     # via -r requirements.txt
 opentelemetry-api==1.40.0
     # via
@@ -359,6 +362,7 @@ packaging==24.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-flask
     #   pytest
+    #   requirements-parser
 pdf2image==1.17.0
     # via -r requirements.txt
 phonenumbers==9.0.10
@@ -463,6 +467,10 @@ requests==2.32.5
     #   responses
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
+requirements-parser==0.13.0
+    # via
+    #   -r requirements.txt
+    #   notifications-utils
 responses==0.25.8
     # via moto
 rpds-py==0.30.0
@@ -505,14 +513,12 @@ tinycss2==1.1.1
 typing-extensions==4.15.0
     # via
     #   -r requirements.txt
-    #   exceptiongroup
     #   grpcio
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-    #   referencing
 tzdata==2025.3
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.3.0
+# This file was automatically copied from notifications-utils@113.6.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@113.3.0
+# This file was automatically copied from notifications-utils@113.6.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Implements https://github.com/alphagov/notifications-utils/pull/1342

***

Example output from this repo:

<img width="855" height="829" alt="image" src="https://github.com/user-attachments/assets/27bbd1d8-9beb-4e1e-8557-42bbbc3de8e9" />
