### PR TITLE
Accept `date` field when creating letter for print

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -4,7 +4,6 @@ from io import BytesIO
 from typing import Literal
 
 import boto3
-import dateutil.parser
 import sentry_sdk
 from botocore.exceptions import ClientError as BotoClientError
 from celery import Task
@@ -19,7 +18,7 @@ from app.config import QueueNames, TaskNames
 from app.precompiled import sanitise_file_contents
 from app.preview import get_page_count_for_pdf
 from app.templated import generate_templated_pdf
-from app.utils import PDFPurpose, get_transient_letter_file_location
+from app.utils import PDFPurpose, get_datetime_from_json, get_transient_letter_file_location
 from app.weasyprint_hack import WeasyprintError
 
 
@@ -133,7 +132,7 @@ def _create_pdf_for_letter(
         logo_file_name=logo_filename,
         language=language,
         includes_first_page=includes_first_page,
-        date=dateutil.parser.parse(letter_details["date"]) if letter_details.get("date") else None,
+        date=get_datetime_from_json(letter_details),
     )
     with current_app.test_request_context(""):
         html = HTML(string=str(template))

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from typing import Literal
 
 import boto3
+import dateutil.parser
 import sentry_sdk
 from botocore.exceptions import ClientError as BotoClientError
 from celery import Task
@@ -132,6 +133,7 @@ def _create_pdf_for_letter(
         logo_file_name=logo_filename,
         language=language,
         includes_first_page=includes_first_page,
+        date=dateutil.parser.parse(letter_details["date"]) if letter_details.get("date") else None,
     )
     with current_app.test_request_context(""):
         html = HTML(string=str(template))

--- a/app/preview.py
+++ b/app/preview.py
@@ -2,7 +2,6 @@ import base64
 import pickle
 from io import BytesIO
 
-import dateutil.parser
 import sentry_sdk
 from flask import Blueprint, abort, current_app, jsonify, request, send_file
 from flask_weasyprint import HTML
@@ -19,7 +18,7 @@ from app import auth
 from app.letter_attachments import get_attachment_pdf
 from app.schemas import get_and_validate_json_from_request, letter_attachment_preview_schema, preview_schema
 from app.templated import generate_templated_pdf
-from app.utils import PDFPurpose
+from app.utils import PDFPurpose, get_datetime_from_json
 
 preview_blueprint = Blueprint("preview_blueprint", __name__)
 
@@ -204,7 +203,7 @@ def get_html(json, language="english", includes_first_page=True):
             # letter assets are hosted on s3
             admin_base_url=current_app.config["LETTER_LOGO_URL"],
             logo_file_name=branding_filename,
-            date=dateutil.parser.parse(json["date"]) if json.get("date") else None,
+            date=get_datetime_from_json(json),
             language=language,
             includes_first_page=includes_first_page,
         )

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,6 +3,7 @@ from enum import StrEnum, auto
 from functools import lru_cache
 from io import BytesIO
 
+import dateutil.parser
 import sentry_sdk
 from notifications_utils.s3 import s3download
 from pypdf import PdfReader, PdfWriter
@@ -37,3 +38,7 @@ def _cached_s3_download(bucket_name, filename):
 
 def get_transient_letter_file_location(service_id, upload_id):
     return f"service-{service_id}/{upload_id}.pdf"
+
+
+def get_datetime_from_json(request_json):
+    return dateutil.parser.parse(request_json["date"]) if request_json.get("date") else None

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import uuid
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from io import BytesIO
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ from botocore.exceptions import ClientError as BotoClientError
 from celery.exceptions import Retry
 from flask import current_app
 from moto import mock_aws
+from notifications_utils.template import LetterPrintTemplate
 from pypdf import PdfReader
 
 import app.celery.tasks
@@ -172,10 +174,27 @@ def test_sanitise_and_upload_letter_raises_a_boto_error(mocker, client, caplog):
     )
 
 
-@pytest.mark.parametrize("logo_filename", ["hm-government", None])
+@pytest.mark.parametrize(
+    "logo_filename, expected_logo_filename_value",
+    (
+        ("hm-government", "hm-government.svg"),
+        (None, None),
+    ),
+)
 @pytest.mark.parametrize(
     "key_type,bucket_name",
-    [("test", "TEST_LETTERS_BUCKET_NAME"), ("normal", "LETTERS_PDF_BUCKET_NAME")],
+    [
+        ("test", "TEST_LETTERS_BUCKET_NAME"),
+        ("normal", "LETTERS_PDF_BUCKET_NAME"),
+    ],
+)
+@pytest.mark.parametrize(
+    "date_argument, expected_date_value",
+    (
+        ({}, None),
+        ({"date": None}, None),
+        ({"date": "2026-02-06T01:02:03.000000+00:00"}, datetime(2026, 2, 6, 1, 2, 3, tzinfo=UTC)),
+    ),
 )
 def test_create_pdf_for_templated_letter_happy_path(
     mocker,
@@ -184,15 +203,20 @@ def test_create_pdf_for_templated_letter_happy_path(
     key_type,
     bucket_name,
     logo_filename,
+    expected_logo_filename_value,
+    date_argument,
+    expected_date_value,
     caplog,
 ):
     # create a pdf for templated letter using data from API, upload the pdf to the final S3 bucket,
     # and send data back to API so that it can update notification status and billable units.
     mock_upload = mocker.patch("app.celery.tasks.s3upload")
     mock_celery = mocker.patch("app.celery.tasks.notify_celery.send_task")
+    mock_utils_template = mocker.patch("app.celery.tasks.LetterPrintTemplate", wraps=LetterPrintTemplate)
 
     data_for_create_pdf_for_templated_letter_task["logo_filename"] = logo_filename
     data_for_create_pdf_for_templated_letter_task["key_type"] = key_type
+    data_for_create_pdf_for_templated_letter_task |= date_argument
 
     encoded_data = current_app.signing_client.encode(data_for_create_pdf_for_templated_letter_task)
 
@@ -201,6 +225,30 @@ def test_create_pdf_for_templated_letter_happy_path(
         _with_message_group_id("test-message-group-id"),
     ):
         create_pdf_for_templated_letter(encoded_data)
+
+    mock_utils_template.assert_called_once_with(
+        {
+            "id": 1,
+            "template_type": "letter",
+            "letter_languages": "english",
+            "subject": "letter subject",
+            "content": "letter content with ((placeholder))",
+            "letter_welsh_subject": None,
+            "letter_welsh_content": None,
+            "updated_at": "2017-08-01",
+            "version": 1,
+            "service": "1234",
+        },
+        values={
+            "placeholder": "abc",
+        },
+        contact_block="123",
+        admin_base_url="https://static-logos.notify.tools/letters",
+        logo_file_name=expected_logo_filename_value,
+        language="english",
+        includes_first_page=True,
+        date=expected_date_value,
+    )
 
     mock_upload.assert_called_once_with(
         filedata=mocker.ANY,


### PR DESCRIPTION
It’s better if the date on a templated letter is the date when the user pressed _Send_ rather than when it was processed by us.

This is because:
- it will reflect what they see in the preview at the time of pressing send
- it won’t change if we have to recreate the PDFs for any reason

In order to do this the API needs to be able to tell template preview when the letter was created when putting the task on the queue.