### PR TITLE
Bump `imagemagick` to `8:7.1.1.43+dfsg1-1+deb13u8`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install binary app dependencies" \
         libcurl4 \
         curl \
         libpango1.0-dev=1.56.3-1 \
-        imagemagick=8:7.1.1.43+dfsg1-1+deb13u7 \
+        imagemagick=8:7.1.1.43+dfsg1-1+deb13u8 \
         ghostscript=10.05.1~dfsg-1+deb13u1 \
         poppler-utils=25.03.0-5+deb13u2 \
         fonts-urw-base35=20200910-8 \


### PR DESCRIPTION
The old version is no longer in the Debian repo

https://packages.debian.org/search?keywords=imagemagick