### PR TITLE
update imagemagick

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install binary app dependencies" \
         libcurl4 \
         curl \
         libpango1.0-dev=1.56.3-1 \
-        imagemagick=8:7.1.1.43+dfsg1-1+deb13u7 \
+        imagemagick=8:7.1.1.43+dfsg1-1+deb13u8 \
         ghostscript=10.05.1~dfsg-1+deb13u1 \
         poppler-utils=25.03.0-5+deb13u2 \
         fonts-urw-base35=20200910-8 \


### PR DESCRIPTION
 This applies the new security update to address an integer Overflow or Wraparound cve https://www.cve.org/CVERecord?id=CVE-2026-34238 discovered in imagemagick