### PR TITLE
Upgrade `WeaseyPrint` and add tests for CMYK prints with multiple languages

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,15 +11,15 @@ reportlab==4.4.9
 pdf2image==1.17.0
 PyMuPDF==1.24.11
 Flask-WeasyPrint==1.1.0
-WeasyPrint==59
+WeasyPrint==68.1
 
 # Weasyprint subdependencies which are probably safe to bump but we can’t be sure
 pillow==12.2.0
-pydyf==0.7.0
+pydyf==0.11.0
 pyphen==0.12.0
-tinycss2==1.1.1
+tinycss2==1.5.0
 fonttools==4.61.0
-cssselect2==0.6.0
+cssselect2==0.8.0
 
 # Other miscellaneous dependencies
 jsonschema~=4.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -487,9 +487,9 @@ cryptography==46.0.7 \
     --hash=sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298 \
     --hash=sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce
     # via notifications-utils
-cssselect2==0.6.0 \
-    --hash=sha256:3a83b2a68370c69c9cd3fcb88bbfaebe9d22edeef2c22d1ff3e1ed9c7fa45ed8 \
-    --hash=sha256:5b5d6dea81a5eb0c9ca39f116c8578dd413778060c94c1f51196371618909325
+cssselect2==0.8.0 \
+    --hash=sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e \
+    --hash=sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a
     # via
     #   -r requirements.in
     #   weasyprint
@@ -721,10 +721,6 @@ gunicorn==25.3.0 \
     --hash=sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660 \
     --hash=sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889
     # via notifications-utils
-html5lib==1.1 \
-    --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
-    --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
-    # via weasyprint
 idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
@@ -1247,9 +1243,9 @@ pycurl==7.45.7 \
     #   -r requirements.in
     #   celery
     #   kombu
-pydyf==0.7.0 \
-    --hash=sha256:23a753daa75adba387606c54eab4d5c9bca83f076be697e59f719d238753fb05 \
-    --hash=sha256:a5a88cb06e5beb64a1ef2147ee879b0e5139f5fdb827fda2fcf14a018c7b11e6
+pydyf==0.11.0 \
+    --hash=sha256:0aaf9e2ebbe786ec7a78ec3fbffa4cdcecde53fd6f563221d53c6bc1328848a3 \
+    --hash=sha256:394dddf619cca9d0c55715e3c55ea121a9bf9cbc780cdc1201a2427917b86b64
     # via
     #   -r requirements.in
     #   weasyprint
@@ -1520,9 +1516,7 @@ sentry-sdk==1.45.1 \
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-    # via
-    #   html5lib
-    #   python-dateutil
+    # via python-dateutil
 smartypants==2.0.2 \
     --hash=sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6 \
     --hash=sha256:9471578606e8ee0740065bf8771f55fec8c83313cb98c5d1c1864ddd389d0f3a
@@ -1531,13 +1525,17 @@ statsd==4.0.1 \
     --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
     --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
     # via notifications-utils
-tinycss2==1.1.1 \
-    --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
-    --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
+tinycss2==1.5.0 \
+    --hash=sha256:6645326e562ea497d6d11cfa608ce3ad30c1e96576b0e43d678dcf6275df6761 \
+    --hash=sha256:6a7be7a654f38a2a55b61d2d97b1f65a7eb40d1cb4057ac37145f675f16efdf9
     # via
     #   -r requirements.in
     #   cssselect2
     #   weasyprint
+tinyhtml5==2.1.0 \
+    --hash=sha256:60a50ec3d938a37e491efa01af895853060943dcebb5627de5b10d188b338a67 \
+    --hash=sha256:6e11cfff38515834268daf89d5f85bbde0b6dd02e8d9e212d1385c2289b89f0a
+    # via weasyprint
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
@@ -1580,9 +1578,9 @@ wcwidth==0.6.0 \
     --hash=sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad \
     --hash=sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159
     # via prompt-toolkit
-weasyprint==59.0 \
-    --hash=sha256:223a76636b3744eaa4ab8a2885f50cf46cf8ebb1acb99b5276d02feccf507492 \
-    --hash=sha256:a308d67c5e99f536b15527baaad4e91be0cf307317e0f66e8d934a0bc99bfb38
+weasyprint==68.1 \
+    --hash=sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be \
+    --hash=sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e
     # via
     #   -r requirements.in
     #   flask-weasyprint
@@ -1591,8 +1589,8 @@ webencodings==0.5.1 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via
     #   cssselect2
-    #   html5lib
     #   tinycss2
+    #   tinyhtml5
 werkzeug==3.1.8 \
     --hash=sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50 \
     --hash=sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -623,9 +623,9 @@ cryptography==46.0.7 \
     #   -r requirements.txt
     #   moto
     #   notifications-utils
-cssselect2==0.6.0 \
-    --hash=sha256:3a83b2a68370c69c9cd3fcb88bbfaebe9d22edeef2c22d1ff3e1ed9c7fa45ed8 \
-    --hash=sha256:5b5d6dea81a5eb0c9ca39f116c8578dd413778060c94c1f51196371618909325
+cssselect2==0.8.0 \
+    --hash=sha256:46fc70ebc41ced7a32cd42d58b1884d72ade23d21e5a4eaaf022401c13f0e76e \
+    --hash=sha256:7674ffb954a3b46162392aee2a3a0aedb2e14ecf99fcc28644900f4e6e3e9d3a
     # via
     #   -r requirements.txt
     #   weasyprint
@@ -882,12 +882,6 @@ gunicorn==25.3.0 \
     # via
     #   -r requirements.txt
     #   notifications-utils
-html5lib==1.1 \
-    --hash=sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d \
-    --hash=sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f
-    # via
-    #   -r requirements.txt
-    #   weasyprint
 idna==3.11 \
     --hash=sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea \
     --hash=sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902
@@ -1461,9 +1455,9 @@ pycurl==7.45.7 \
     --hash=sha256:fb97f8f3f7754a5a00da450248de79d83e34938db04486efd26db81526dc25b4 \
     --hash=sha256:ff50a3d787c3d059f330d7cb7325b40416bcb0f43f5006b396a6e61871df0ebf
     # via -r requirements.txt
-pydyf==0.7.0 \
-    --hash=sha256:23a753daa75adba387606c54eab4d5c9bca83f076be697e59f719d238753fb05 \
-    --hash=sha256:a5a88cb06e5beb64a1ef2147ee879b0e5139f5fdb827fda2fcf14a018c7b11e6
+pydyf==0.11.0 \
+    --hash=sha256:0aaf9e2ebbe786ec7a78ec3fbffa4cdcecde53fd6f563221d53c6bc1328848a3 \
+    --hash=sha256:394dddf619cca9d0c55715e3c55ea121a9bf9cbc780cdc1201a2427917b86b64
     # via
     #   -r requirements.txt
     #   weasyprint
@@ -1820,7 +1814,6 @@ six==1.17.0 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
     #   -r requirements.txt
-    #   html5lib
     #   python-dateutil
 smartypants==2.0.2 \
     --hash=sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6 \
@@ -1838,12 +1831,18 @@ statsd==4.0.1 \
     # via
     #   -r requirements.txt
     #   notifications-utils
-tinycss2==1.1.1 \
-    --hash=sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf \
-    --hash=sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8
+tinycss2==1.5.0 \
+    --hash=sha256:6645326e562ea497d6d11cfa608ce3ad30c1e96576b0e43d678dcf6275df6761 \
+    --hash=sha256:6a7be7a654f38a2a55b61d2d97b1f65a7eb40d1cb4057ac37145f675f16efdf9
     # via
     #   -r requirements.txt
     #   cssselect2
+    #   weasyprint
+tinyhtml5==2.1.0 \
+    --hash=sha256:60a50ec3d938a37e491efa01af895853060943dcebb5627de5b10d188b338a67 \
+    --hash=sha256:6e11cfff38515834268daf89d5f85bbde0b6dd02e8d9e212d1385c2289b89f0a
+    # via
+    #   -r requirements.txt
     #   weasyprint
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
@@ -1896,9 +1895,9 @@ wcwidth==0.6.0 \
     # via
     #   -r requirements.txt
     #   prompt-toolkit
-weasyprint==59.0 \
-    --hash=sha256:223a76636b3744eaa4ab8a2885f50cf46cf8ebb1acb99b5276d02feccf507492 \
-    --hash=sha256:a308d67c5e99f536b15527baaad4e91be0cf307317e0f66e8d934a0bc99bfb38
+weasyprint==68.1 \
+    --hash=sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be \
+    --hash=sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e
     # via
     #   -r requirements.txt
     #   flask-weasyprint
@@ -1908,8 +1907,8 @@ webencodings==0.5.1 \
     # via
     #   -r requirements.txt
     #   cssselect2
-    #   html5lib
     #   tinycss2
+    #   tinyhtml5
 werkzeug==3.1.8 \
     --hash=sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50 \
     --hash=sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -18,6 +18,7 @@ from pypdf import PdfReader
 import app.celery.tasks
 from app.celery.tasks import (
     _create_pdf_for_letter,
+    _prepare_pdf,
     _remove_folder_from_filename,
     create_pdf_for_templated_letter,
     recreate_pdf_for_precompiled_letter,
@@ -582,6 +583,45 @@ def test_create_pdf_for_letter_notify_tagging(client, includes_first_page):
     )
 
     assert ("NOTIFY" in PdfReader(pdf).pages[0].extract_text()) is includes_first_page
+
+
+@pytest.mark.parametrize(
+    "letter_content",
+    [
+        {"language": "English", "content": "My favourite animal is a cat."},
+        {"language": "Urdu", "content": "میرا پسندیدہ جانور ایک بلی ہے۔"},
+        {"language": "Ukrainian", "content": "Моя улюблена тварина - кіт."},
+        {"language": "Polish", "content": "Moim ulubionym zwierzęciem jest kot."},
+        {"language": "Romanian", "content": "Animalul meu preferat este o pisică."},
+        {"language": "Latvian", "content": "Mans mīļākais dzīvnieks ir kaķis."},
+        {"language": "Chinese (Simplified)", "content": "我最喜欢的动物是猫。"},
+        {"language": "Arabic", "content": "حيواني المفضل هو القط."},
+        {"language": "Hindi", "content": "मेरा पसंदीदा जानवर एक बिल्ली है।"},
+        {"language": "Punjabi (Gurmukhi script)", "content": "ਮੇਰਾ ਮਨਪਸੰਦ ਜਾਨਵਰ ਇੱਕ ਬਿੱਲੀ ਹੈ।"},
+        {"language": "Bangla", "content": "আমার প্রিয় প্রাণী একটি বিড়াল।"},
+        {"language": "Tamil", "content": "எனது பிடித்த விலங்கு ஒரு பூனை."},
+        {"language": "Telugu", "content": "నా ఇష్టమైన జంతువు ఒక పిల్లి."},
+        {"language": "Gujarati", "content": "મારું મનપસંદ પ્રાણી એક બિલાડી છે."},
+        {"language": "Marathi", "content": "माझं आवडतं प्राणी एक मांजर आहे."},
+        {"language": "Kannada", "content": "ನನ್ನ ಪ್ರಿಯ ಪ್ರಾಣಿ ಒಂದು ಬೆಕ್ಕು."},
+        {"language": "Hebrew", "content": "החיה האהובה עלי היא חתול."},
+        {"language": "Greek", "content": "Το αγαπημένο μου ζώο είναι μια γάτα."},
+        {"language": "Russian", "content": "Мое любимое животное - кот."},
+    ],
+    ids=lambda x: x["language"],
+)
+def test_cmyk_pdf_with_multiple_languages_for_letter_notify_tagging(client, letter_content):
+    pdf = _prepare_pdf(
+        self=None,
+        letter_details={
+            "template": {"template_type": "letter", "subject": "subject", "content": letter_content["content"]},
+            "values": {},
+            "letter_contact_block": "",
+            "logo_filename": "",
+        },
+    )
+
+    assert "NOTIFY" in PdfReader(pdf).pages[0].extract_text()
 
 
 @mock_aws

--- a/tests/test_preview/test_preview_templated.py
+++ b/tests/test_preview/test_preview_templated.py
@@ -137,7 +137,7 @@ def test_get_png_caches_with_correct_keys(
     mocked_cache_get,
     mocked_cache_set,
 ):
-    expected_cache_key = "pngs/cefe8adc607265516f196f2647a5bb8a36e060d0.png"
+    expected_cache_key = "pngs/78406ae4c518a7a8893de063845e96b62ae491fc.png"
     resp = view_letter_template_png()
 
     assert resp.status_code == 200


### PR DESCRIPTION
## What

- Upgrade `WeaseyPrint` to version `68.1`
- Add tests for checking CMYK PDFs to sure they have the `NOTIFY` tag

## Why

Previous version of `WeaseyPrint` (59) were corrupting PDFs containing `Urdu` and `Hebrew`. The reason why this was pinned to 59 was because of an issue with `SVG` files in version 68 (which has been fixed in [v68.1](https://github.com/Kozea/WeasyPrint/releases/tag/v68.1)).