### PR TITLE
Add cmyk pdf notify tag

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -15,7 +15,7 @@ from notifications_utils.template import LetterPrintTemplate
 
 from app import notify_celery
 from app.config import QueueNames, TaskNames
-from app.precompiled import sanitise_file_contents
+from app.precompiled import add_notify_tag_to_letter, is_notify_tag_present, sanitise_file_contents
 from app.preview import get_page_count_for_pdf
 from app.templated import generate_templated_pdf
 from app.utils import PDFPurpose, get_datetime_from_json, get_transient_letter_file_location
@@ -169,6 +169,13 @@ def create_pdf_for_templated_letter(self: Task, encoded_letter_data):
     metadata = None
     task_name = TaskNames.UPDATE_BILLABLE_UNITS_FOR_LETTER
     filename = letter_details["letter_filename"]
+
+    if not is_notify_tag_present(cmyk_pdf):
+        current_app.logger.info("CMYK PDF does not contain Notify tag, adding one.", extra={"file_name": filename})
+        cmyk_pdf = add_notify_tag_to_letter(cmyk_pdf, is_cmyk_pdf=True)
+    else:
+        current_app.logger.info("CMYK PDF already contains Notify tag (%s).", filename, extra={"file_name": filename})
+
     if page_count > LETTER_MAX_PAGE_COUNT:
         bucket_name = current_app.config["INVALID_PDF_BUCKET_NAME"]
         task_name = TaskNames.UPDATE_VALIDATION_FAILED_FOR_TEMPLATED_LETTER

--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -13,7 +13,7 @@ from notifications_utils.recipient_validation.postal_address import PostalAddres
 from pdf2image import convert_from_bytes
 from pypdf import PdfReader, PdfWriter
 from pypdf.errors import PdfReadError
-from reportlab.lib.colors import Color, black, white
+from reportlab.lib.colors import CMYKColor, Color, black, white
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.units import mm
 from reportlab.pdfbase import pdfmetrics
@@ -436,7 +436,7 @@ def log_metadata_for_letter(src_pdf, filename):
         )
 
 
-def add_notify_tag_to_letter(src_pdf):
+def add_notify_tag_to_letter(src_pdf, is_cmyk_pdf=False):
     """
     Adds the word 'NOTIFY' to the first page of the PDF
 
@@ -445,7 +445,7 @@ def add_notify_tag_to_letter(src_pdf):
 
     pdf = PdfReader(src_pdf)
     page = pdf.pages[0]
-    can = NotifyCanvas(white)
+    can = NotifyCanvas(white) if not is_cmyk_pdf else NotifyCanvas(CMYKColor(0, 0, 0, 0))
     pdfmetrics.registerFont(TTFont(FONT, TRUE_TYPE_FONT_FILE))
     can.setFont(FONT, NOTIFY_TAG_FONT_SIZE)
 

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ Flask-HTTPAuth~=4.8
 sentry-sdk[flask,celery]~=1.45
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b71f3fbdfce59b8c14da2182251f0b9493ed3466
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ Flask-HTTPAuth~=4.8
 sentry-sdk[flask,celery]~=1.45
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -862,7 +862,7 @@ mistune==0.8.4 \
     --hash=sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e \
     --hash=sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db7e31b2ee80cd93ebbf7ca708a143619d100a04
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
     # via -r requirements.in
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \

--- a/requirements.txt
+++ b/requirements.txt
@@ -862,7 +862,7 @@ mistune==0.8.4 \
     --hash=sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e \
     --hash=sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b71f3fbdfce59b8c14da2182251f0b9493ed3466
     # via -r requirements.in
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1045,7 +1045,7 @@ moto==5.1.18 \
     --hash=sha256:45298ef7b88561b839f6fe3e9da2a6e2ecd10283c7bf3daf43a07a97465885f9 \
     --hash=sha256:b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db7e31b2ee80cd93ebbf7ca708a143619d100a04
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
     # via -r requirements.txt
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1045,7 +1045,7 @@ moto==5.1.18 \
     --hash=sha256:45298ef7b88561b839f6fe3e9da2a6e2ecd10283c7bf3daf43a07a97465885f9 \
     --hash=sha256:b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@ea9569e6fd7c9cd6e6a68ed4bdec9b013c529191
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b71f3fbdfce59b8c14da2182251f0b9493ed3466
     # via -r requirements.txt
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -615,7 +615,7 @@ def test_create_pdf_for_letter_does_not_contain_notify_tag(client, includes_firs
     ids=lambda x: x["language"],
 )
 def test_cmyk_pdf_with_multiple_languages_for_letter_notify_tagging(client, letter_content):
-    pdf = _prepare_pdf(
+    cmyk_pdf = _prepare_pdf(
         self=None,
         letter_details={
             "template": {"template_type": "letter", "subject": "subject", "content": letter_content["content"]},
@@ -625,7 +625,9 @@ def test_cmyk_pdf_with_multiple_languages_for_letter_notify_tagging(client, lett
         },
     )
 
-    assert "NOTIFY" in PdfReader(pdf).pages[0].extract_text()
+    assert "NOTIFY" not in PdfReader(cmyk_pdf).pages[0].extract_text()
+    notify_tagged_pdf = add_notify_tag_to_letter(cmyk_pdf)
+    assert "NOTIFY" in PdfReader(notify_tagged_pdf).pages[0].extract_text()
 
 
 @mock_aws

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -25,6 +25,7 @@ from app.celery.tasks import (
     sanitise_and_upload_letter,
 )
 from app.config import QueueNames
+from app.precompiled import add_notify_tag_to_letter
 from app.utils import get_transient_letter_file_location
 from app.weasyprint_hack import WeasyprintError
 from tests.pdf_consts import bad_postcode, blank_with_address, multi_page_pdf, no_colour
@@ -336,6 +337,7 @@ def test_create_pdf_for_templated_letter_adds_letter_attachment_if_provided(
         "app.templated.add_attachment_to_letter",
         return_value=BytesIO(multi_page_pdf),
     )
+    mocker.patch("app.celery.tasks.is_notify_tag_present", return_value=True)
 
     data_for_create_pdf_for_templated_letter_task["template"]["letter_attachment"] = {"page_count": 1, "id": "5678"}
 
@@ -568,7 +570,7 @@ def test_remove_folder_from_filename(filename, expected_filename):
 
 
 @pytest.mark.parametrize("includes_first_page", (True, False))
-def test_create_pdf_for_letter_notify_tagging(client, includes_first_page):
+def test_create_pdf_for_letter_does_not_contain_notify_tag(client, includes_first_page):
     pdf = _create_pdf_for_letter(
         task=None,
         letter_details={
@@ -581,7 +583,9 @@ def test_create_pdf_for_letter_notify_tagging(client, includes_first_page):
         includes_first_page=includes_first_page,
     )
 
-    assert ("NOTIFY" in PdfReader(pdf).pages[0].extract_text()) is includes_first_page
+    assert "NOTIFY" not in PdfReader(pdf).pages[0].extract_text()
+    stamped_pdf = add_notify_tag_to_letter(pdf)
+    assert "NOTIFY" in PdfReader(stamped_pdf).pages[0].extract_text()
 
 
 @mock_aws

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -79,12 +79,19 @@ def test_endpoints_rejects_if_not_authenticated(client, headers, endpoint, kwarg
     assert resp.status_code == 401
 
 
-def test_add_notify_tag_to_letter(mocker):
+@pytest.mark.parametrize(
+    "is_cmyk_pdf",
+    [
+        False,
+        True,
+    ],
+)
+def test_add_notify_tag_to_letter(mocker, is_cmyk_pdf):
     pdf_original = pypdf.PdfReader(BytesIO(multi_page_pdf))
 
     assert "NOTIFY" not in pdf_original.pages[0].extract_text()
 
-    pdf_page = add_notify_tag_to_letter(BytesIO(multi_page_pdf))
+    pdf_page = add_notify_tag_to_letter(BytesIO(multi_page_pdf), is_cmyk_pdf=is_cmyk_pdf)
 
     pdf_new = pypdf.PdfReader(BytesIO(pdf_page.read()))
 
@@ -96,7 +103,14 @@ def test_add_notify_tag_to_letter(mocker):
     assert pdf_new.pages[3].extract_text() == pdf_original.pages[3].extract_text()
 
 
-def test_add_notify_tag_to_letter_correct_margins(mocker):
+@pytest.mark.parametrize(
+    "is_cmyk_pdf",
+    [
+        False,
+        True,
+    ],
+)
+def test_add_notify_tag_to_letter_correct_margins(mocker, is_cmyk_pdf):
     pdf_original = pypdf.PdfReader(BytesIO(multi_page_pdf))
 
     can = NotifyCanvas(white)
@@ -106,7 +120,7 @@ def test_add_notify_tag_to_letter_correct_margins(mocker):
 
     # It fails because we are mocking but by that time the drawString method has been called so just carry on
     try:
-        add_notify_tag_to_letter(BytesIO(multi_page_pdf))
+        add_notify_tag_to_letter(BytesIO(multi_page_pdf), is_cmyk_pdf=is_cmyk_pdf)
     except Exception:
         pass
 


### PR DESCRIPTION
Remove the `NOTIFY` tag from utils for template letters and add the tag after CMYK PDF conversion. This change is only for template letters to minimise the risk and then add tag for precompiled letters as well.