### PR TITLE
Store an original copy of all precompiled letters

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -48,13 +48,14 @@ def sanitise_and_upload_letter(self: Task, notification_id, filename, allow_inte
                 bucket_name=current_app.config["SANITISED_LETTER_BUCKET_NAME"],
                 file_location=filename,
             )
-            # upload a backup copy of the original PDF that will be held in the bucket for a week
-            copy_s3_object(
-                current_app.config["LETTERS_SCAN_BUCKET_NAME"],
-                filename,
-                current_app.config["PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME"],
-                f"{notification_id}.pdf",
-            )
+
+        # upload a backup copy of the original PDF that will be held in the bucket for a week
+        copy_s3_object(
+            current_app.config["LETTERS_SCAN_BUCKET_NAME"],
+            filename,
+            current_app.config["PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME"],
+            f"{notification_id}.pdf",
+        )
 
         extra = {"notification_id": notification_id, "validation_status": validation_status}
         current_app.logger.info(

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -24,7 +24,9 @@ from app.weasyprint_hack import WeasyprintError
 
 @notify_celery.task(name="sanitise-and-upload-letter", bind=True)
 def sanitise_and_upload_letter(self: Task, notification_id, filename, allow_international_letters=False):
-    current_app.logger.info("Sanitising notification with id %s", notification_id)
+    current_app.logger.info(
+        "Sanitising notification with id %s", notification_id, extra={"notification_id": notification_id}
+    )
 
     try:
         pdf_content = s3download(current_app.config["LETTERS_SCAN_BUCKET_NAME"], filename).read()

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -88,6 +88,7 @@ def test_sanitise_invalid_letter(mocker, client):
     mocker.patch("app.celery.tasks.s3download", return_value=file_with_content_in_margins)
     mock_upload = mocker.patch("app.celery.tasks.s3upload")
     mock_celery = mocker.patch("app.celery.tasks.notify_celery.send_task")
+    mock_backup_original = mocker.patch("app.celery.tasks.copy_s3_object")
 
     with _with_message_group_id("test-message-group-id"):
         sanitise_and_upload_letter("abc-123", "filename.pdf")
@@ -111,6 +112,12 @@ def test_sanitise_invalid_letter(mocker, client):
         queue="letter-tasks",
         MessageGroupId="test-message-group-id",
     )
+    mock_backup_original.assert_called_once_with(
+        current_app.config["LETTERS_SCAN_BUCKET_NAME"],
+        "filename.pdf",
+        current_app.config["PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME"],
+        "abc-123.pdf",
+    )
 
 
 @pytest.mark.parametrize(
@@ -130,6 +137,7 @@ def test_sanitise_international_letters(
     mocker.patch("app.celery.tasks.s3download", return_value=BytesIO(bad_postcode))
     mock_upload = mocker.patch("app.celery.tasks.s3upload")
     mock_celery = mocker.patch("app.celery.tasks.notify_celery.send_task")
+    mock_backup_original = mocker.patch("app.celery.tasks.copy_s3_object")
 
     with _with_message_group_id("test-message-group-id"):
         sanitise_and_upload_letter("abc-123", "filename.pdf", **extra_args)
@@ -152,6 +160,13 @@ def test_sanitise_international_letters(
         name="process-sanitised-letter",
         queue="letter-tasks",
         MessageGroupId="test-message-group-id",
+    )
+
+    mock_backup_original.assert_called_once_with(
+        current_app.config["LETTERS_SCAN_BUCKET_NAME"],
+        "filename.pdf",
+        current_app.config["PRECOMPILED_ORIGINALS_BACKUP_LETTER_BUCKET_NAME"],
+        "abc-123.pdf",
     )
 
 


### PR DESCRIPTION
We had been making a copy of the original letter files for letters
which pass sanitisation to the
`<env>-letters-precompiled-originals-backup` bucket. This changes things
to also copy letters which failed sanitisation to the bucket too.

We have tasks that can be run in the case of an incident to let us
resanitise a PDF, which recreates the PDF file. These are currently only
set up to deal with letters which previously passed sanitisation, but we
want to be able to run them with letters which failed too.

Later PRs will update the tasks themselves, but this change just
makes sure we have the data available for the tasks.

[Trello card](https://trello.com/c/h2UeCDvz/1800-allow-letters-which-failed-validation-to-be-reprocessed-in-the-event-of-an-incident)