### PR TITLE
Bump utils to 117.0.0, remove StatsD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.2
+# This file was automatically copied from notifications-utils@117.0.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,6 @@ from gds_metrics import GDSMetrics
 from notifications_utils import request_helper
 from notifications_utils.celery import NotifyCelery
 from notifications_utils.clients.signing.signing_client import Signing
-from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.logging import flask as utils_logging
 from notifications_utils.s3 import S3ObjectNotFound, s3upload
 
@@ -45,11 +44,9 @@ def create_app():
     application.register_blueprint(preview_blueprint)
     application.register_blueprint(precompiled_blueprint)
 
-    application.statsd_client = StatsdClient()
-    application.statsd_client.init_app(application)
     application.signing_client = Signing()
     application.signing_client.init_app(application)
-    utils_logging.init_app(application, application.statsd_client)
+    utils_logging.init_app(application)
     weasyprint_hack.init_app(application)
     request_helper.init_app(application)
     notify_celery.init_app(application)

--- a/app/config.py
+++ b/app/config.py
@@ -72,10 +72,6 @@ class Config:
 
     NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
 
-    STATSD_ENABLED = True
-    STATSD_HOST = os.environ.get("STATSD_HOST")
-    STATSD_PORT = 8125
-
     NOTIFY_ENVIRONMENT = os.environ.get("NOTIFY_ENVIRONMENT")
     LETTERS_SCAN_BUCKET_NAME = os.environ.get("LETTERS_SCAN_BUCKET_NAME")
     LETTER_CACHE_BUCKET_NAME = os.environ.get("LETTER_CACHE_BUCKET_NAME")
@@ -93,8 +89,6 @@ class Development(Config):
     NOTIFY_ENVIRONMENT = "development"
 
     CELERY_WORKER_LOG_LEVEL = "INFO"
-
-    STATSD_ENABLED = False
 
     LETTERS_SCAN_BUCKET_NAME = "development-letters-scan"
     LETTER_CACHE_BUCKET_NAME = "development-template-preview-cache"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,6 @@
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
-    STATSD_ENABLED=0
     DANGEROUS_SALT='test-notify-salt'
     SECRET_KEY='test-notify-secret-key'
     TEMPLATE_PREVIEW_INTERNAL_SECRETS=["my-secret-key", "my-secret-key2"]

--- a/requirements.in
+++ b/requirements.in
@@ -27,7 +27,7 @@ Flask-HTTPAuth~=4.8
 sentry-sdk[flask,celery]~=1.45
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.0.2
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@117.0.0
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -858,7 +858,7 @@ mistune==0.8.4 \
     --hash=sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e \
     --hash=sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db7e31b2ee80cd93ebbf7ca708a143619d100a04
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@64112420c90149d844c9aeaa224ea3914e695fd7
     # via -r requirements.in
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \
@@ -1521,10 +1521,6 @@ smartypants==2.0.2 \
     --hash=sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6 \
     --hash=sha256:9471578606e8ee0740065bf8771f55fec8c83313cb98c5d1c1864ddd389d0f3a
     # via notifications-utils
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via notifications-utils
 tinycss2==1.5.0 \
     --hash=sha256:6645326e562ea497d6d11cfa608ce3ad30c1e96576b0e43d678dcf6275df6761 \
     --hash=sha256:6a7be7a654f38a2a55b61d2d97b1f65a7eb40d1cb4057ac37145f675f16efdf9
@@ -1540,12 +1536,14 @@ typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via
+    #   exceptiongroup
     #   grpcio
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   referencing
 tzdata==2026.1 \
     --hash=sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9 \
     --hash=sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1039,7 +1039,7 @@ moto==5.1.18 \
     --hash=sha256:45298ef7b88561b839f6fe3e9da2a6e2ecd10283c7bf3daf43a07a97465885f9 \
     --hash=sha256:b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf
     # via -r requirements_for_test.in
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@db7e31b2ee80cd93ebbf7ca708a143619d100a04
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@64112420c90149d844c9aeaa224ea3914e695fd7
     # via -r requirements.txt
 opentelemetry-api==1.41.0 \
     --hash=sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f \
@@ -1825,12 +1825,6 @@ soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via beautifulsoup4
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via
-    #   -r requirements.txt
-    #   notifications-utils
 tinycss2==1.5.0 \
     --hash=sha256:6645326e562ea497d6d11cfa608ce3ad30c1e96576b0e43d678dcf6275df6761 \
     --hash=sha256:6a7be7a654f38a2a55b61d2d97b1f65a7eb40d1cb4057ac37145f675f16efdf9
@@ -1850,12 +1844,14 @@ typing-extensions==4.15.0 \
     # via
     #   -r requirements.txt
     #   beautifulsoup4
+    #   exceptiongroup
     #   grpcio
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   referencing
 tzdata==2026.1 \
     --hash=sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9 \
     --hash=sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.2
+# This file was automatically copied from notifications-utils@117.0.0
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.2
+# This file was automatically copied from notifications-utils@117.0.0
 
 extend-exclude = [
     "migrations/versions/",

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -13,7 +13,6 @@ fi
 docker run -it --rm \
   -e NOTIFY_ENVIRONMENT=development \
   -e FLASK_DEBUG=1 \
-  -e STATSD_ENABLED= \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$(aws configure get aws_access_key_id)} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$(aws configure get aws_secret_access_key)} \
   -e TEMPLATE_PREVIEW_INTERNAL_SECRETS='["my-secret-key"]' \

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.2
+# This file was automatically copied from notifications-utils@117.0.0
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Currently live in dev-b (along with the corresponding changes in api and antivirus), FTs are passing.