### PR TITLE
Bump popler-utils to 25.03.0-5+deb13u3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "Install binary app dependencies" \
         libpango1.0-dev=1.56.3-1 \
         imagemagick=8:7.1.1.43+dfsg1-1+deb13u8 \
         ghostscript=10.05.1~dfsg-1+deb13u1 \
-        poppler-utils=25.03.0-5+deb13u2 \
+        poppler-utils=25.03.0-5+deb13u3 \
         fonts-urw-base35=20200910-8 \
         fonts-freefont-ttf=20211204+svn4273-2 \
         fonts-wqy-zenhei \


### PR DESCRIPTION
https://packages.debian.org/trixie/poppler-utils

Resolves
```
poppler-utils : Depends: libpoppler147 (= 25.03.0-5+deb13u2) but 25.03.0-5+deb13u3 is to be installed
```