### PR TITLE
Import PyMuPDF using its new name - `pymupdf` not `fitz`

### DIFF
--- a/app/precompiled.py
+++ b/app/precompiled.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from itertools import groupby
 from operator import itemgetter
 
-import fitz
+import pymupdf
 import sentry_sdk
 from flask import Blueprint, current_app, jsonify, request, send_file
 from notifications_utils.pdf import is_letter_too_long, pdf_page_count
@@ -40,7 +40,7 @@ NOTIFY_TAG_BOUNDING_BOX_HEIGHT = 6.149
 NOTIFY_TAG_FONT_SIZE = 6
 NOTIFY_TAG_LINE_HEIGHT = NOTIFY_TAG_FONT_SIZE * PT_TO_MM
 NOTIFY_TAG_TEXT = "NOTIFY"
-NOTIFY_TAG_BOUNDING_BOX = fitz.Rect(
+NOTIFY_TAG_BOUNDING_BOX = pymupdf.Rect(
     # add on a margin to ensure we capture all text
     0,  # x1
     0,  # y1
@@ -74,7 +74,7 @@ ADDRESS_LEFT_FROM_LEFT_OF_PAGE = 24.60
 ADDRESS_RIGHT_FROM_LEFT_OF_PAGE = 120.0
 ADDRESS_TOP_FROM_TOP_OF_PAGE = 39.50
 ADDRESS_BOTTOM_FROM_TOP_OF_PAGE = 66.30
-ADDRESS_BOUNDING_BOX = fitz.Rect(
+ADDRESS_BOUNDING_BOX = pymupdf.Rect(
     # add on a margin to ensure we capture all text
     (ADDRESS_LEFT_FROM_LEFT_OF_PAGE - 3) * mm,  # x1
     (ADDRESS_TOP_FROM_TOP_OF_PAGE - 3) * mm,  # y1
@@ -763,7 +763,7 @@ def _extract_text_from_first_page_of_pdf(pdf, rect):
     :return: Any text found
     """
     pdf.seek(0)
-    doc = fitz.open("pdf", pdf)
+    doc = pymupdf.open("pdf", pdf)
     page = doc[0]
     ret = _extract_text_from_page(page, rect)
     pdf.seek(0)
@@ -781,12 +781,12 @@ def _extract_text_from_page(page, rect):
     and is structured as follows:
     (x1, y1, x2, y2, word value, paragraph number, line number, word position within the line)
 
-    :param fitz.Page page: fitz page object from which to extract
+    :param pymupdf.Page page: pymupdf page object from which to extract
     :param rect: rectangle describing the area to extract from
     :return: Any text found
     """
     words = page.get_text_words()
-    mywords = [w for w in words if fitz.Rect(w[:4]).intersects(rect)]
+    mywords = [w for w in words if pymupdf.Rect(w[:4]).intersects(rect)]
 
     def _get_address_from_get_textwords():
         return page.get_text(clip=rect).strip()
@@ -834,7 +834,7 @@ def _get_pages_with_notify_tag(src_pdf_bytes, is_an_attachment=False):
     sent via notify
     """
     src_pdf_bytes.seek(0)
-    doc = fitz.open("pdf", src_pdf_bytes)
+    doc = pymupdf.open("pdf", src_pdf_bytes)
     starting_page_index = 1
     if is_an_attachment:
         starting_page_index = 0
@@ -855,7 +855,7 @@ def _get_pages_with_notify_tag(src_pdf_bytes, is_an_attachment=False):
 
 def redact_precompiled_letter_address_block(pdf):
     pdf.seek(0)  # make sure we're at the beginning
-    doc = fitz.open("pdf", pdf)
+    doc = pymupdf.open("pdf", pdf)
     first_page = doc[0]
 
     first_page.add_redact_annot(ADDRESS_BOUNDING_BOX)

--- a/app/transformation.py
+++ b/app/transformation.py
@@ -2,7 +2,7 @@
 import subprocess
 from io import BytesIO
 
-import fitz
+import pymupdf
 import sentry_sdk
 from flask import current_app
 
@@ -10,16 +10,20 @@ from app import InvalidRequest
 
 
 def _does_pdf_contain_colorspace(colourspace, data):
-    doc = fitz.open(stream=data, filetype="pdf")
+    doc = pymupdf.open(stream=data, filetype="pdf")
     for i in range(len(doc)):
         try:
             page = doc.get_page_images(i)
         except RuntimeError as e:
-            current_app.logger.warning("Fitz couldn't read page info for page %s", i + 1, extra={"page_number": i + 1})
+            current_app.logger.warning(
+                "PyMuPDF couldn't read page info for page %s",
+                i + 1,
+                extra={"page_number": i + 1},
+            )
             raise InvalidRequest(f"Invalid PDF on page {i + 1}") from e
         for img in page:
             xref = img[0]
-            pix = fitz.Pixmap(doc, xref)
+            pix = pymupdf.Pixmap(doc, xref)
             if colourspace in pix.colorspace.__str__():
                 data.seek(0)
                 return True

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -4,7 +4,7 @@ import logging
 from io import BytesIO
 from unittest.mock import ANY, MagicMock, call
 
-import fitz
+import pymupdf
 import pypdf
 import pytest
 from flask import url_for
@@ -710,7 +710,7 @@ def test_is_notify_tag_calls_extract_with_wider_numbers(mocker):
 
     is_notify_tag_present(pdf)
 
-    mock_extract.assert_called_once_with(pdf, fitz.Rect(0.0, 0.0, 15.191 * mm, 6.149 * mm))
+    mock_extract.assert_called_once_with(pdf, pymupdf.Rect(0.0, 0.0, 15.191 * mm, 6.149 * mm))
 
 
 @pytest.mark.parametrize(
@@ -803,7 +803,7 @@ def test_redact_address_block_preserves_addresses_elsewhere_on_page():
     )
     assert extract_address_block(new_pdf).raw_address == ""
 
-    doc = fitz.open("pdf", new_pdf)
+    doc = pymupdf.open("pdf", new_pdf)
     new_page_text = doc[0].get_text()
     assert address.raw_address in new_page_text
 
@@ -812,7 +812,7 @@ def test_redact_precompiled_letter_address_block_only_touches_first_page():
     address = extract_address_block(BytesIO(address_block_repeated_on_second_page))
     assert address.raw_address != ""  # check something is there before we redact
 
-    doc = fitz.open("pdf", address_block_repeated_on_second_page)
+    doc = pymupdf.open("pdf", address_block_repeated_on_second_page)
     second_page_text = doc[1].get_text()
 
     new_pdf = redact_precompiled_letter_address_block(
@@ -820,7 +820,7 @@ def test_redact_precompiled_letter_address_block_only_touches_first_page():
     )
     assert extract_address_block(new_pdf).raw_address == ""
 
-    doc = fitz.open("pdf", new_pdf)
+    doc = pymupdf.open("pdf", new_pdf)
     new_second_page_text = doc[1].get_text()
 
     assert len(doc) == 2

--- a/tests/test_transformation.py
+++ b/tests/test_transformation.py
@@ -1,7 +1,7 @@
 import os
 from io import BytesIO
 
-import fitz
+import pymupdf
 import pytest
 from PIL import Image, ImageChops
 from pypdf import PdfReader
@@ -101,10 +101,10 @@ def test_convert_pdf_to_cmyk_preserves_black(client):
     assert not does_pdf_contain_cmyk(data)
 
     result = convert_pdf_to_cmyk(data)
-    doc = fitz.open(stream=result, filetype="pdf")
+    doc = pymupdf.open(stream=result, filetype="pdf")
     first_image = doc.get_page_images(pno=0)[0]
     image_object_number = first_image[0]
-    pixmap = fitz.Pixmap(doc, image_object_number)
+    pixmap = pymupdf.Pixmap(doc, image_object_number)
 
     assert "CMYK" in str(pixmap.colorspace)
     assert pixmap.pixel(100, 100) == (0, 0, 0, 255)  # (C,M,Y,K), where 'K' is black
@@ -181,8 +181,8 @@ def test_cmyk_pdf_transformation():
 
             test_output_pdf = convert_pdf_to_cmyk(BytesIO(input_pdf))
 
-            test_pdf_value = fitz.open("pdf", test_output_pdf.getvalue())
-            expected_pdf_value = fitz.open("pdf", BytesIO(expected_pdf).getvalue())
+            test_pdf_value = pymupdf.open("pdf", test_output_pdf.getvalue())
+            expected_pdf_value = pymupdf.open("pdf", BytesIO(expected_pdf).getvalue())
 
             # Write file for visual checks
             f = open(f"{test_output_files}{filename}", "wb")


### PR DESCRIPTION
The Changelog for PyMuPDF version 1.24.3 included this line (we're on version 1.24.11):
```
The Python module is now called pymupdf. fitz is still supported for backwards compatibility.
```

There are no changes to how the code works, but it was unclear what 'fitz' was or where PyMuPDF was used, so this aims to makes it clearer.