### PR TITLE
Update imagemagick version to deb13u11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN echo "Install binary app dependencies" \
         libcurl4 \
         curl \
         libpango1.0-dev=1.56.3-1 \
-        imagemagick=8:7.1.1.43+dfsg1-1+deb13u8 \
+        imagemagick=8:7.1.1.43+dfsg1-1+deb13u11 \
         ghostscript=10.05.1~dfsg-1+deb13u1 \
         poppler-utils=25.03.0-5+deb13u3 \
         fonts-urw-base35=20200910-8 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN echo "Install binary app dependencies" \
         libpango1.0-dev=1.56.3-1 \
         imagemagick=8:7.1.1.43+dfsg1-1+deb13u11 \
         ghostscript=10.05.1~dfsg-1+deb13u1 \
-        poppler-utils=25.03.0-5+deb13u3 \
+        poppler-utils=25.03.0-5+deb13u4 \
         fonts-urw-base35=20200910-8 \
         fonts-freefont-ttf=20211204+svn4273-2 \
         fonts-wqy-zenhei \


### PR DESCRIPTION
The current package used in production has been withdrawn and replaced with 8:7.1.1.43+dfsg1-1+deb13u11